### PR TITLE
update gemspec dependencies

### DIFF
--- a/run_loop.gemspec
+++ b/run_loop.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.homepage    = "http://calaba.sh"
   s.summary     = %q{Tools related to running Calabash iOS tests}
   s.description = %q{calabash-cucumber drives tests for native iOS apps. RunLoop provides a number of tools associated with running Calabash tests.}
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.files         = Dir.glob('{bin,lib}/**/*') + Dir.glob('scripts/*.js') + ['scripts/udidetect', 'LICENSE']
   s.executables   = "run-loop"
   s.require_paths = ["lib"]


### PR DESCRIPTION
## motivation

I want to relax dependencies so we don't have problems updating the gem later.

I would also like to make the following changes, but need guidance.
#### 1. should only include the files necessary for runtime

The current `git ls-files` strategy pulls too many files into gem; files that are not required at runtime.

```
+  s.files         = Dir.glob('{bin,lib}/**/*') + Dir.glob('scripts/*.js') + ['scripts/udidetect', 'LICENSE']
```
#### 2. update your email address

```
+  s.email       = ['karl.krukow@xamarin.com']
```

**IMPORTANT** Neither of the changes above are in the changeset!
## todo
- [ ] @krukow needs review
