### PR TITLE
updates the readme with versioning info [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 [![Build Status](https://travis-ci.org/calabash/run_loop.svg?branch=master)](https://travis-ci.org/calabash/run_loop) [![License](https://go-shields.herokuapp.com/license-MIT-blue.png)](http://opensource.org/licenses/MIT)
 
-## run-loop
+## run_loop
 
 ### License
 
-run-loop is available under the MIT license. See the LICENSE file for more info.
+run_loop is available under the MIT license. See the LICENSE file for more info.
+
+### Versioning
+
+run_loop follows the spirit of Semantic Versioning. [1]  However, the semantic versioning spec is incompatible with RubyGem's patterns for pre-release gems. [2]
+
+- [1] http://semver.org/
+- [2] http://gravitext.com/2012/07/22/versioning.html _"But returning to the practical: No release version of SemVer is compatible with Rubygems."_ - David Kellum


### PR DESCRIPTION
## motivation

Clarifying the relationship between semantic versioning and rubygems beta release versioning pattern.
