### PR TITLE
should call Xcode tools in the context of xcrun

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -361,7 +361,7 @@ module RunLoop
     end
 
     def self.instruments_command_prefix(udid, results_dir_trace)
-      instruments_path = 'instruments'
+      instruments_path = 'xcrun instruments'
       if udid
         instruments_path = "#{instruments_path} -w \"#{udid}\""
       end

--- a/lib/run_loop/version.rb
+++ b/lib/run_loop/version.rb
@@ -1,3 +1,3 @@
 module RunLoop
-  VERSION = '1.0.0.pre1'
+  VERSION = '1.0.0.pre2'
 end


### PR DESCRIPTION
## motivation

In order to respect the DEVELOPER_DIR env var we need to call instruments in the context of xcrun.
