### PR TITLE
calabash-ios depends on Core.above_or_eql_version?

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -25,6 +25,23 @@ module RunLoop
       SCRIPTS_PATH
     end
 
+    # @deprecated since 1.0.0
+    # still used extensively in calabash-ios launcher
+    def self.above_or_eql_version?(target_version, xcode_version)
+      if target_version.is_a?(RunLoop::Version)
+        target = target_version
+      else
+        target = RunLoop::Version.new(target_version)
+      end
+
+      if xcode_version.is_a?(RunLoop::Version)
+        xcode = xcode_version
+      else
+        xcode = RunLoop::Version.new(xcode_version)
+      end
+      target >= xcode
+    end
+
     def self.script_for_key(key)
       if SCRIPTS[key].nil?
         return nil

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -7,8 +7,6 @@ describe RunLoop::Core do
     ENV.delete('TRACE_TEMPLATE')
   }
 
-
-
   describe '.automation_template' do
 
     after(:each) { ENV.delete('TRACE_TEMPLATE') }
@@ -97,4 +95,19 @@ describe RunLoop::Core do
     end
   end
 
+  describe '.above_or_eql_version?' do
+    subject(:a) { RunLoop::Version.new('5.1.1') }
+    subject(:b) { RunLoop::Version.new('6.0') }
+    describe 'returns correct value when' do
+      it 'both args are RunLoop::Version' do
+        expect(RunLoop::Core.above_or_eql_version? a, b).to be == false
+        expect(RunLoop::Core.above_or_eql_version? b, a).to be == true
+      end
+
+      it 'both args are Strings' do
+        expect(RunLoop::Core.above_or_eql_version? a.to_s, b.to_s).to be == false
+        expect(RunLoop::Core.above_or_eql_version? b.to_s, a.to_s).to be == true
+      end
+    end
+  end
 end


### PR DESCRIPTION
## motivation

I jumped the gun and removed this method without checking for calls in calabash-ios.
