### PR TITLE
AXInspectorEnabled needs to be false b/c the inspector panel blocks UINavigationBar button touches

### DIFF
--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -326,7 +326,7 @@ module RunLoop
                 #
                 # I don't know what the behavior is on Xcode 5.0*.
                 :inspector_showing => {:key => 'AXInspectorEnabled',
-                                       :value => 'true',
+                                       :value => 'false',
                                        :type => 'bool'},
 
                 # Controls if the Accessibility Inspector is expanded or not


### PR DESCRIPTION
## Motivation

CI tests against the 'masters' toolchain are failing.

See for https://github.com/jmoody/briar-ios-example/pull/29 analysis.
# 
# ![2014-08-13_21-08-27](https://cloud.githubusercontent.com/assets/466104/3911320/257cb71e-2320-11e4-8c57-bd409e390d25.png)
## Testing
- [x] all green against Xcode 5.0 - Xcode 6.0b5
- [x] Travis CI flickering when running this gem's rspec.
- [x] Jenkins 'masters' toolchain passes previously flickering tests - http://ljs-jenkins.ngrok.com/job/briar-pr/25/
#### Travis

Fails about ~1/3 of the time.  Ruby version does not matter.

```
rspec ./spec/sim_control_spec.rb:59 # RunLoop::SimControl#quit_sim and #launch_sim with Xcode 5.1.1
rspec ./spec/run_sim_spec.rb:9 # RunLoop run on simulator Xcode 5.1.1
```

Travis CI simulators are run in a VM which makes testing unstable.
