### PR TITLE
rollback retriable dep. to match test-cloud gem

### DIFF
--- a/run_loop.gemspec
+++ b/run_loop.gemspec
@@ -20,7 +20,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency('thor', '>= 0.18')
   s.add_dependency('json', '~> 1.8')
-  s.add_dependency('retriable', '~> 1.4')
+  # downgrade because of xtc gem '~> 1.4'
+  s.add_dependency 'retriable', '~> 1.3'
+
   s.add_dependency('CFPropertyList','~> 2.2')
 
   s.add_development_dependency('bundler', '~> 1.6')


### PR DESCRIPTION
I have had some trouble in the past with XTC rejecting retriable > 1.3.

I am tracking gem dependencies with Gemnasium.
- https://gemnasium.com/calabash/run_loop
