### PR TITLE
Source gems from https vs. http

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in calabash-ios-cucumber.gemspec
 gemspec


### PR DESCRIPTION
Bundler 1.7 has some changes that enforce rules about multiple sources. 

I don't think the intent was to block mixed http and https sources, but I ran into trouble earlier this week when testing w/ bundler 1.7.  Since this change is good regardless (it is recommend by RubyGems), it makes
sense to remove one possible compatibility issue.

Is https actually more secure? o_O
