### PR TITLE
Retriable dependency should match xamarin-test-cloud's dependency.

### DIFF
--- a/run_loop.gemspec
+++ b/run_loop.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency('thor', '>= 0.18')
   s.add_dependency('json', '~> 1.8')
-  # downgrade because of xtc gem '~> 1.4'
-  s.add_dependency 'retriable', '~> 1.3'
+  # matches XTC requirement; would like to use ~> 1.4.0
+  s.add_dependency 'retriable', '~> 1.3.3.1'
 
   s.add_dependency('CFPropertyList','~> 2.2')
 


### PR DESCRIPTION
This is an attempt to reduce the chance of XTC validation problems.
