### PR TITLE
Enable Xcode 6 simulator keyboards by default

### DIFF
--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -290,6 +290,9 @@ module RunLoop
         details = sim_details :udid
         results = existing.map do |dir|
           enable_accessibility_in_sim_data_dir(dir, details, opts)
+          # This is done here so we don't have to make a public method
+          # to enable the keyboards for all devices.
+          enable_keyboard_in_sim_data_dir(dir, details, opts)
         end
       else
         possible = XCODE_5_SDKS.map do |sdk|
@@ -728,10 +731,81 @@ module RunLoop
             msgs << "could not set #{hash_key} => '#{settings[:key]}' to #{value}"
             puts "WARN: #{msgs.join("\n")}"
           end
-          end
+        end
         success
         end
       res.all?
+    end
+
+    # @!visibility private
+    # Enables the keyboard to be shown by default on the new Xcode 6 simulators.
+    #
+    # @note This will quit the simulator.
+    #
+    # @note This is for Xcode 6 only.  Will raise an error if called on Xcode 5.
+    #
+    # If the Library/Preferences/com.apple.Preferences.plist file doesn't exist
+    # this method will create one with the content to activate the keyboard
+    #
+    # @param [String] sim_data_dir The directory where the
+    #   Library/Preferences/com.apple.Accessibility.plist can be found.
+    # @param [Hash] sim_details_key_with_udid A hash table of simulator details
+    #   that can be obtained by calling `sim_details(:udid)`.
+    #
+    # @param [Hash] opts controls the behavior of the method
+    # @option opts [Boolean] :verbose controls logging output
+    # @return [Boolean] if the plist exists and the plist was successfully updated.
+    # @raise [RuntimeError] If called when Xcode 6 is _not_ the active Xcode version.
+    def enable_keyboard_in_sim_data_dir(sim_data_dir, sim_details_key_with_udid, opts={})
+      unless xcode_version_gte_6?
+        raise RuntimeError, 'it is illegal to call this method when the Xcode < 6 is the current Xcode version'
+      end
+
+      hash = {:key => 'AutomaticMinimizationEnabled',
+              :value => 0,
+              :type => 'integer'}
+
+      default_opts = {:verbose => false}
+      merged_opts = default_opts.merge(opts)
+
+      quit_sim
+
+      verbose = merged_opts[:verbose]
+      target_udid = sim_data_dir[XCODE_6_SIM_UDID_REGEX, 0]
+
+      # Directory contains simulators not reported by instruments -s devices
+      simulator_details = sim_details_key_with_udid[target_udid]
+      if simulator_details.nil?
+        if verbose
+          xcode_version = xctools.xcode_version
+          puts ["INFO: Skipping '#{target_udid}' directory because",
+                "there is no corresponding simulator for active Xcode (version '#{xcode_version}')"].join("\n")
+        end
+        return true
+      end
+
+      launch_name = simulator_details.fetch(:launch_name, nil)
+
+      msgs = ["cannot enable keyboard for '#{target_udid}' - '#{launch_name}'"]
+      plist_path = File.expand_path("#{sim_data_dir}/Library/Preferences/com.apple.Preferences.plist")
+
+      unless File.exist? plist_path
+        FileUtils.mkdir_p("#{sim_data_dir}/Library/Preferences")
+        plist = CFPropertyList::List.new
+        data = {}
+        plist.value = CFPropertyList.guess(data)
+        plist.save(plist_path, CFPropertyList::List::FORMAT_BINARY)
+      end
+
+      success = pbuddy.plist_set(hash[:key], hash[:type], hash[:value], plist_path)
+      unless success
+        if verbose
+          msgs << "could not set #{hash_key} => '#{settings[:key]}' to #{value}"
+          puts "WARN: #{msgs.join("\n")}"
+        end
+      end
+
+      success
     end
 
     # @!visibility private

--- a/spec/sim_control_spec.rb
+++ b/spec/sim_control_spec.rb
@@ -268,6 +268,39 @@ describe RunLoop::SimControl do
     end
   end
 
+  describe '#enable_keyboard_in_sim_data_dir' do
+    describe 'raises an error' do
+      it 'on Xcode < 6' do
+        local_sim_control = RunLoop::SimControl.new
+        expect(local_sim_control).to receive(:xcode_version_gte_6?).and_return(false)
+        expect { local_sim_control.instance_eval { enable_keyboard_in_sim_data_dir(nil, nil, nil) } }.to raise_error RuntimeError
+      end
+    end
+
+    if RunLoop::XCTools.new.xcode_version_gte_6?
+      describe "with Xcode #{Resources.shared.current_xcode_version}" do
+        local_sim_control = RunLoop::SimControl.new
+        sim_details = local_sim_control.instance_eval { sim_details(:udid) }
+        simulator_udid = nil
+        sim_details.each do |key, value|
+          simulator_udid = key
+          break if simulator_udid
+        end
+        it 'sets the keyboard preferences' do
+          sdk_dir = File.expand_path(File.join(Dir.mktmpdir, "#{simulator_udid}/data"))
+          plist_path = File.expand_path("#{sdk_dir}/Library/Preferences/com.apple.Preferences.plist")
+          expect(local_sim_control.instance_eval { enable_keyboard_in_sim_data_dir(sdk_dir, sim_details) }).to be == true
+          expect(File.exist?(plist_path)).to be == true
+        end
+
+        it 'can skip directories not reported by instruments' do
+          sdk_dir = "~/Library/Developer/CoreSimulator/Devices/AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA"
+          expect(local_sim_control.instance_eval { enable_keyboard_in_sim_data_dir(sdk_dir, sim_details) }).to be == true
+        end
+      end
+    end
+  end
+
   describe '#sims_details' do
     describe 'raises an error when called' do
       it 'on XCode < 6' do


### PR DESCRIPTION
## Description
- This is related to https://github.com/calabash/calabash-ios/issues/511

> Xcode 6 simulator has a new option "Connect Hardware Keyboard". It seems to be on by default. The native keyboard will not appear in the simulator if this option is active.
> wait_for_keyboard will wait forever if the native keyboard does no appear.
- This should hopefully allow us to test using calabash-ios on Travis.
## What this fix entails

Simply by adding the below to `com.apple.Preferences.plist` under `CoreSimulator/Devices/{udid}/data/Library/Preferences/` makes the native keyboard appear without toggling the `Connect Hardware Keyboard` button manually.

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>AutomaticMinimizationEnabled</key>
    <integer>0</integer>
</dict>
</plist>
```
