### PR TITLE
After killing instruments, try Process.wait

### DIFF
--- a/lib/run_loop/instruments.rb
+++ b/lib/run_loop/instruments.rb
@@ -45,6 +45,7 @@ module RunLoop
             puts "Sending '#{kill_signal}' to instruments process '#{pid}'"
           end
           Process.kill(kill_signal, pid.to_i)
+          Process.wait(pid, Process::WNOHANG)
         rescue Exception => e
           if ENV['DEBUG'] == '1'
             puts "Could not kill process '#{pid.to_i}' - ignoring #{e}"


### PR DESCRIPTION
Seeing cases where instruments process are hanging or become orphaned.

We will still wait using `wait_for_process_to_terminate`; this is an additional attempt to cleanly exit instruments.
