### PR TITLE
Update core.rb with "# encoding: utf-8"

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'fileutils'
 require 'tmpdir'
 require 'timeout'


### PR DESCRIPTION
ArgumentError: invalid byte sequence in US-ASCII
    from /Users/eduardo/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/run_loop-1.0.9/lib/run_loop/core.rb:120:in `gsub'
    from /Users/eduardo/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/run_loop-1.0.9/lib/run_loop/core.rb:120:in`run_with_options'
    from /Users/eduardo/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/run_loop-1.0.9/lib/run_loop/core.rb:679:in `run'
    from /Users/eduardo/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/calabash-cucumber-0.11.3/lib/calabash-cucumber/launcher.rb:724:in`block in new_run_loop'
    from /Users/eduardo/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/calabash-cucumber-0.11.3/lib/calabash-cucumber/launcher.rb:722:in `times'
    from /Users/eduardo/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/calabash-cucumber-0.11.3/lib/calabash-cucumber/launcher.rb:722:in`new_run_loop'
    from /Users/eduardo/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/calabash-cucumber-0.11.3/lib/calabash-cucumber/launcher.rb:597:in `relaunch'
    from /Users/eduardo/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/calabash-cucumber-0.11.3/lib/calabash-cucumber/core.rb:838:in`start_test_server_in_background'
    from (irb):1
    from /Users/eduardo/.rbenv/versions/2.1.1/bin/irb:11:in `<main>'
