### PR TITLE
Device class can provide instruments ready simulator names

### DIFF
--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -28,5 +28,27 @@ module RunLoop
     def physical_device?
       (self.udid =~ /[a-f0-9]{40}/) == 0
     end
+
+    # Returns and instruments-ready device identifier that is a suitable value
+    # for DEVICE_TARGET environment variable.
+    #
+    # @return [String] An instruments-ready device identifier.
+    # @raise [RuntimeError] If trying to obtain a instruments-ready identifier
+    #  for a simulator when Xcode < 6.
+    def instruments_identifier(xcode_tools=RunLoop::XCTools.new)
+      if physical_device?
+        self.udid
+      else
+        unless xcode_tools.xcode_version_gte_6?
+          raise "Expected Xcode >= 6, but found version #{xcode_tools.version} - cannot create an identifier"
+        end
+        if self.version == RunLoop::Version.new('7.0.3')
+          version_part = self.version.to_s
+        else
+          version_part = "#{self.version.major}.#{self.version.minor}"
+        end
+        "#{self.name} (#{version_part} Simulator)"
+      end
+    end
   end
 end

--- a/spec/lib/device_spec.rb
+++ b/spec/lib/device_spec.rb
@@ -52,4 +52,33 @@ describe RunLoop::Device do
       it { is_expected.to be == false }
     end
   end
+
+  describe '#instruments_identifier' do
+    subject { device.instruments_identifier }
+    context 'physical device' do
+      let(:device) { RunLoop::Device.new('name', '8.1.1', 'e60ef9ae876ab4a218ee966d0525c9fb79e5606d') }
+      it { is_expected.to be == 'e60ef9ae876ab4a218ee966d0525c9fb79e5606d' }
+    end
+
+    describe 'simulator' do
+      context 'with Major.Minor SDK version' do
+        let(:device) { RunLoop::Device.new('Form Factor', '8.1.1', 'not a device udid') }
+        it { is_expected.to be == 'Form Factor (8.1 Simulator)' }
+      end
+
+      context 'with Major.Minor.Patch SDK version' do
+        let(:device) { RunLoop::Device.new('Form Factor', '7.0.3', 'not a device udid') }
+        it { is_expected.to be == 'Form Factor (7.0.3 Simulator)' }
+      end
+
+      describe 'Xcode < 6' do
+        let(:device) { RunLoop::Device.new('Form Factor', '7.0.3', 'not a device udid') }
+        let(:xcode_tools) { RunLoop::XCTools.new }
+        it 'raises an error' do
+          expect(xcode_tools).to receive(:xcode_version_gte_6?).and_return(false)
+          expect { device.instruments_identifier(xcode_tools) }.to raise_error
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
**RunLoop::Device needs a method to return 'instruments ready' names for simulators** #51

```
moody@stern:~/git/run-loop
|2.1.3| (feature/device-class-can-provide-instruments-ready-simulator-names-issue-51)
$ irb
Don't touch that button!
irb(main):001:0> sim_control = RunLoop::SimControl.new
#<RunLoop::SimControl:0x007fb85a386390>
> sim_control.simulators.map { |device| device.instruments_identifier }
[
    [ 0] "iPhone 4s (7.0 Simulator)",
    [ 1] "iPhone 5 (7.0 Simulator)",
    [ 2] "iPhone 5s (7.0 Simulator)",
    < snip >
    [19] "iPad Air (8.1 Simulator)",
    [20] "Resizable iPhone (8.1 Simulator)",
    [21] "Resizable iPad (8.1 Simulator)"
]
> xcode_tools = RunLoop::XCTools.new
#<RunLoop::XCTools:0x007fb85a41cf98>
> xcode_tools.instruments(:devices).map { |device| device.instruments_identifier }
[
    [0] "e60ef9ae876 < snip > b79e5606d",
    [1] "43be3f89d95 < snip > a1bd91124",
    [2] "44f1fdea2446< snip > 20633b0db"
]
```
