### PR TITLE
Fix querying Symbols and bump run loop prerelease version

### DIFF
--- a/lib/run_loop/version.rb
+++ b/lib/run_loop/version.rb
@@ -1,5 +1,5 @@
 module RunLoop
-  VERSION = '1.1.1.pre4'
+  VERSION = '1.1.1.pre5'
 
   # A model of a software release version that can be used to compare two versions.
   #

--- a/scripts/calabash_script_uia.js
+++ b/scripts/calabash_script_uia.js
@@ -25537,6 +25537,11 @@ String.prototype.calabash_script$query$IQuery$_query$arity$3 = function(kw, coll
   var kw__$1 = this;
   return calabash_script.query.filter_by_type.call(null, cljs.core.keyword.call(null, kw__$1), calabash_script.query.dir_seq.call(null, dir, coll));
 };
+cljs.core.Symbol.prototype.calabash_script$query$IQuery$ = true;
+cljs.core.Symbol.prototype.calabash_script$query$IQuery$_query$arity$3 = function(s, coll, dir) {
+  var s__$1 = this;
+  return calabash_script.query._query.call(null, cljs.core.keyword.call(null, s__$1), coll, dir);
+};
 cljs.core.Keyword.prototype.calabash_script$query$IQuery$ = true;
 cljs.core.Keyword.prototype.calabash_script$query$IQuery$_query$arity$3 = function(kw, coll, dir) {
   var kw__$1 = this;


### PR DESCRIPTION
This is a compatibility fix for Xamarin.UITest which calls

```
uia.queryWindows('keyboard')
```

This is now supported for backwards compatibility with semantics `uia.queryWindows(':keyboard')`
