### PR TITLE
Build the chou binaries before every travis ci job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: bundle
 before_script:
   - gem uninstall -Vax --force --no-abort-on-dependent run_loop
   - scripts/ci/travis/instruments-auth.sh
+  - scripts/ci/travis/make-and-install-test-binaries.rb
 
 script:
   - scripts/ci/travis/install-gem-ci.rb

--- a/scripts/ci/travis/make-and-install-test-binaries.rb
+++ b/scripts/ci/travis/make-and-install-test-binaries.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+
+require 'tmpdir'
+require File.expand_path(File.join(File.dirname(__FILE__), 'ci-helpers'))
+
+
+spec_resources_dir = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'spec', 'resources'))
+
+Dir.chdir spec_resources_dir do
+  do_system('rm -rf chou-cal.app')
+  do_system('rm -rf chou-cal.ipa')
+  do_system('rm -rf chou.app')
+  do_system('rm -rf chou.ipa')
+
+  unless travis_ci?
+    do_system('rm -rf dylibs')
+  end
+end
+
+working_directory = Dir.mktmpdir
+
+Dir.chdir working_directory do
+
+  do_system('git clone --depth 1 --recursive https://github.com/calabash/calabash-ios-server')
+  server_dir = File.expand_path(File.join(working_directory, 'calabash-ios-server'))
+
+  Dir.chdir server_dir do
+    install_gem 'xcpretty'
+    do_system('make framework')
+    do_system('zip -y -q -r calabash.framework.zip calabash.framework')
+
+    unless travis_ci?
+      do_system('make dylibs')
+      do_system("mv calabash-dylibs #{spec_resources_dir}/dylibs")
+    end
+  end
+
+  framework_zip = File.expand_path(File.join(server_dir, 'calabash.framework.zip'))
+
+  do_system('git clone --depth 1 --recursive https://github.com/jmoody/animated-happiness')
+  Dir.chdir './animated-happiness/chou' do
+    do_system('rm -rf calabash.framework')
+    do_system("cp #{framework_zip} ./")
+    do_system('unzip calabash.framework.zip')
+    do_system('make all')
+    do_system("mv chou-cal.app #{spec_resources_dir}/")
+    do_system("mv chou-cal.ipa #{spec_resources_dir}/")
+    do_system("mv chou.app #{spec_resources_dir}/")
+    do_system("mv chou.ipa #{spec_resources_dir}/")
+  end
+
+end


### PR DESCRIPTION
**Experimental**

The test binaries are becoming out-of-date very quickly and they are a pain to keep synchronized.
- scripts/ci/travis/make-and-install-test-binaries.rb will make and install the test binaries using the latest calabash-ios-server on the develop branch.
