### PR TITLE
Lipo compatibility check should raise an exception with a verbose message

### DIFF
--- a/lib/run_loop/lipo.rb
+++ b/lib/run_loop/lipo.rb
@@ -79,10 +79,21 @@ module RunLoop
 
     # Returns a list of architecture in the binary.
     # @return [Array<String>] A list of architecture.
+    # @raise [RuntimeError] If the output of lipo cannot be parsed.
     def info
-      execute_lipo("-info #{binary_path}") do |stdout, _, _|
+      execute_lipo("-info #{binary_path}") do |stdout, stderr, wait_thr|
         output = stdout.read.strip
-        output.split(':')[-1].strip.split
+        begin
+          output.split(':')[-1].strip.split
+        rescue Exception => e
+          msg = ['Expected to be able to parse the output of lipo.',
+                 "cmd:    'lipo -info #{binary_path}'",
+                 "stdout: '#{output}'",
+                 "stderr: '#{stderr.read.strip}'",
+                 "exit code: '#{wait_thr.value}'",
+                 e.message]
+          raise msg.join("\n")
+        end
       end
     end
 

--- a/spec/lib/lipo_spec.rb
+++ b/spec/lib/lipo_spec.rb
@@ -30,6 +30,17 @@ describe RunLoop::Lipo do
       let(:app_bundle_path) { Resources.shared.app_bundle_path_arm_FAT }
       it { is_expected.to match_array ['armv7', 'arm64']}
     end
+
+    it 'raises an error if lipo output cannot be parsed' do
+      stream = lambda { |string|  StringIO.new(string, 'r') }
+      class RunLoop::Lipo::RSpec::ProcessStatus
+        def value() 1 end
+      end
+      expect(lipo).to receive(:execute_lipo).and_yield(stream.call(''),
+                                                       stream.call('stderr output'),
+                                                       RunLoop::Lipo::RSpec::ProcessStatus.new)
+      expect { lipo.info }.to raise_error
+    end
   end
 
   describe '#expect_compatible_arch' do


### PR DESCRIPTION
#### Motivation

**run-loop's lipo compatibility check is raising an error when it can't parse -info output without any helpful information** [#656](https://github.com/calabash/calabash-ios/issues/656)

@krukow This compatibility check is new in 0.12.0.  I know you don't like raise exceptions, but if this condition occurs, we _will_ throw an exception downstream [lipo.rb:L71](https://github.com/calabash/run_loop/blob/develop/lib/run_loop/lipo.rb#L71).  If we raise here, at least we'll get more information about the output of `lipo -info`.

