### PR TITLE
Feature/lipo check should work when bundle path has spaces

### DIFF
--- a/lib/run_loop/lipo.rb
+++ b/lib/run_loop/lipo.rb
@@ -1,5 +1,4 @@
 require 'open3'
-require 'shellwords'
 
 module RunLoop
 
@@ -82,8 +81,7 @@ module RunLoop
     # @return [Array<String>] A list of architecture.
     # @raise [RuntimeError] If the output of lipo cannot be parsed.
     def info
-      escaped_binary_path = Shellwords.escape(binary_path)
-      execute_lipo("-info #{escaped_binary_path}") do |stdout, stderr, wait_thr|
+      execute_lipo("-info \"#{binary_path}\"") do |stdout, stderr, wait_thr|
         output = stdout.read.strip
         begin
           output.split(':')[-1].strip.split

--- a/spec/lib/lipo_spec.rb
+++ b/spec/lib/lipo_spec.rb
@@ -47,7 +47,9 @@ describe RunLoop::Lipo do
 
     context 'bundle path has spaces' do
       let(:app_bundle_path) {
-        working_dir = File.join(Dir.tmpdir, 'a path with spaces')
+        tmpdir = Dir.mktmpdir
+        working_dir = File.join(tmpdir, 'a path with spaces')
+        FileUtils.mkdir_p(working_dir)
         original = Resources.shared.app_bundle_path_i386
         FileUtils.cp_r(original, working_dir)
         File.join(working_dir, File.basename(original))

--- a/spec/lib/lipo_spec.rb
+++ b/spec/lib/lipo_spec.rb
@@ -1,3 +1,6 @@
+require 'tmpdir'
+require 'fileutils'
+
 describe RunLoop::Lipo do
 
   let(:app_bundle_path) { Resources.shared.app_bundle_path }
@@ -40,6 +43,17 @@ describe RunLoop::Lipo do
                                                        stream.call('stderr output'),
                                                        RunLoop::Lipo::ProcessStatus.new)
       expect { lipo.info }.to raise_error
+    end
+
+    context 'bundle path has spaces' do
+      let(:app_bundle_path) {
+        working_dir = File.join(Dir.tmpdir, 'a path with spaces')
+        original = Resources.shared.app_bundle_path_i386
+        FileUtils.cp_r(original, working_dir)
+        File.join(working_dir, File.basename(original))
+      }
+      it { is_expected.to be_a Array  }
+      it { is_expected.to match_array ['i386']  }
     end
   end
 


### PR DESCRIPTION
Builds on **Escape binary path in argument to lipo.** #101 submitted by @gredman.

Fixes:  **run-loop's lipo compatibility check is raising an error when it can't parse -info output without any helpful information** [#656](https://github.com/calabash/calabash-ios/issues/656).

