### PR TITLE
Feature/refactor onalert javascript

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -151,6 +151,8 @@ module RunLoop
 
       dependencies = options[:dependencies] || []
       dependencies << File.join(scripts_path, 'calabash_script_uia.js')
+      dependencies << File.join(scripts_path, 'detect_externally_generated_alerts.js')
+      dependencies << File.join(scripts_path, 'logger.js')
       dependencies.each do |dep|
         FileUtils.cp(dep, results_dir)
       end

--- a/scripts/detect_externally_generated_alerts.js
+++ b/scripts/detect_externally_generated_alerts.js
@@ -1,0 +1,51 @@
+#import "./logger.js";
+
+function findAlertViewText(alert) {
+  if (!alert) {
+    return false;
+  }
+  var txt = alert.name(),
+        txts;
+  if (txt == null) {
+    txts = alert.staticTexts();
+    if (txts != null && txts.length > 0) {
+      txt = txts[0].name();
+    }
+  }
+  return txt;
+}
+
+function isExternallyGeneratedAlert(alert) {
+  var exps =
+              [
+                // Location Alerts
+                ["OK", /vil bruge din aktuelle placering/],
+                ["OK", /Would Like to Use Your Current Location/],
+                ["Allow", /access your location/],
+                ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
+                ["OK", /Location Accuracy/],
+                ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/],
+
+                // Notifications
+                ["OK", /Would Like to Send You Notifications/],
+
+                // Photos
+                ["OK", /Would Like to Access Your Photos/],
+
+                // Contacts
+                ["OK", /Would Like to Access Your Contacts/]
+              ],
+        ans, exp,
+        txt;
+
+  txt = findAlertViewText(alert);
+  Log.output({"output":"alert: "+txt}, true);
+  for (var i = 0; i < exps.length; i++) {
+    ans = exps[i][0];
+    exp = exps[i][1];
+    if (exp.test(txt)) {
+      return ans;
+    }
+  }
+  return false;
+}

--- a/scripts/logger.js
+++ b/scripts/logger.js
@@ -1,0 +1,26 @@
+var Log = (function () {
+  var forceFlush = [],
+        N = 16384,
+        i = N;
+  while (i--) {
+    forceFlush[i] = "*";
+  }
+  forceFlush = forceFlush.join('');
+
+  function log_json(object, flush)
+  {
+    UIALogger.logMessage("OUTPUT_JSON:\n"+JSON.stringify(object)+"\nEND_OUTPUT");
+    if (flush) {
+      UIALogger.logMessage(forceFlush);
+    }
+  }
+
+  return {
+    result: function (status, data, flush) {
+      log_json({"status": status, "value": data, "index":_actualIndex}, flush)
+    },
+    output: function (msg, flush) {
+      log_json({"output": msg,"last_index":_actualIndex}, flush);
+    }
+  };
+})();

--- a/scripts/run_loop_basic.js
+++ b/scripts/run_loop_basic.js
@@ -148,61 +148,11 @@ if (typeof JSON !== 'object') {
     }
 }());
 
-function findAlertViewText(alert) {
-    if (!alert) {
-        return false;
-    }
-    var txt = alert.name(),
-        txts;
-    if (txt == null) {
-        txts = alert.staticTexts();
-        if (txts != null && txts.length > 0) {
-            txt = txts[0].name();
-        }
-    }
-    return txt;
-}
-
-function isExternallyGeneratedAlert(alert) {
-    var exps =
-                [
-                    // Location Alerts
-                    ["OK", /vil bruge din aktuelle placering/],
-                    ["OK", /Would Like to Use Your Current Location/],
-                    ["Allow", /access your location/],
-                    ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
-                    ["OK", /Location Accuracy/],
-                    ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/],
-
-                    // Notifications
-                    ["OK", /Would Like to Send You Notifications/],
-
-                    // Photos
-                    ["OK", /Would Like to Access Your Photos/],
-
-                    // Contacts
-                    ["OK", /Would Like to Access Your Contacts/]
-                ],
-          ans, exp,
-          txt;
-
-    txt = findAlertViewText(alert);
-    Log.output({"output":"alert: "+txt}, true);
-    for (var i = 0; i < exps.length; i++) {
-        ans = exps[i][0];
-        exp = exps[i][1];
-        if (exp.test(txt)) {
-            return ans;
-        }
-    }
-    return false;
-}
-
 UIATarget.onAlert = function (alert) {
     Log.output({"output":"on alert"}, true);
     var target = UIATarget.localTarget();
     target.pushTimeout(10);
-    function attemptTouchOKOnLocation(retry_count) {
+    function attemptTouchDefaultAlertButton(retry_count) {
         retry_count = retry_count || 0;
         if (retry_count >= 5) {
             Log.output("Maxed out retry (5) - unable to dismiss location dialog.");
@@ -220,11 +170,11 @@ UIATarget.onAlert = function (alert) {
                 Log.output(e.toString());
             }
             target.delay(1);
-            attemptTouchOKOnLocation(retry_count + 1);
+            attemptTouchDefaultAlertButton(retry_count + 1);
         }
     }
 
-    attemptTouchOKOnLocation(0);
+    attemptTouchDefaultAlertButton(0);
     target.popTimeout();
     return true;
 };

--- a/scripts/run_loop_basic.js
+++ b/scripts/run_loop_basic.js
@@ -189,20 +189,28 @@ function findAlertViewText(alert) {
     return txt;
 }
 
-function isLocationPrompt(alert) {
-    var exps = [
-            ["OK", /vil bruge din aktuelle placering/],
-            ["OK", /Would Like to Use Your Current Location/],
-            ["OK", /Would Like to Send You Notifications/],
-            ["Allow", /access your location/],
-            ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
-            ["OK", /Would Like to Access Your Photos/],
-            ["OK", /Would Like to Access Your Contacts/],
-            ["OK", /Location Accuracy/],
-            ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/]
-        ],
-        ans, exp,
-        txt;
+function isExternallyGeneratedAlert(alert) {
+    var exps =
+                [
+                    // Location Alerts
+                    ["OK", /vil bruge din aktuelle placering/],
+                    ["OK", /Would Like to Use Your Current Location/],
+                    ["Allow", /access your location/],
+                    ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
+                    ["OK", /Location Accuracy/],
+                    ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/],
+
+                    // Notifications
+                    ["OK", /Would Like to Send You Notifications/],
+
+                    // Photos
+                    ["OK", /Would Like to Access Your Photos/],
+
+                    // Contacts
+                    ["OK", /Would Like to Access Your Contacts/]
+                ],
+          ans, exp,
+          txt;
 
     txt = findAlertViewText(alert);
     Log.output({"output":"alert: "+txt}, true);
@@ -227,7 +235,7 @@ UIATarget.onAlert = function (alert) {
             return;
         }
         try {
-            var answer = isLocationPrompt(alert);
+            var answer = isExternallyGeneratedAlert(alert);
             if (answer) {
                 alert.buttons()[answer].tap();
             }

--- a/scripts/run_loop_basic.js
+++ b/scripts/run_loop_basic.js
@@ -1,3 +1,6 @@
+#import "./detect_externally_generated_alerts.js";
+#import "./logger.js";
+
 if (typeof JSON !== 'object') {
     JSON = {};
 }

--- a/scripts/run_loop_basic.js
+++ b/scripts/run_loop_basic.js
@@ -148,35 +148,6 @@ if (typeof JSON !== 'object') {
     }
 }());
 
-
-var Log = (function () {
-    var forceFlush = [],
-        N = 16384,
-        i = N;
-    while (i--) {
-        forceFlush[i] = "*";
-    }
-    forceFlush = forceFlush.join('');
-
-    function log_json(object, flush)
-    {
-        UIALogger.logMessage("OUTPUT_JSON:\n"+JSON.stringify(object)+"\nEND_OUTPUT");
-        if (flush) {
-            UIALogger.logMessage(forceFlush);
-        }
-    }
-
-    return {
-        result: function (status, data, flush) {
-            log_json({"status": status, "value": data, "index":_actualIndex}, flush)
-        },
-        output: function (msg, flush) {
-            log_json({"output": msg,"last_index":_actualIndex}, flush);
-        }
-    };
-})();
-
-
 function findAlertViewText(alert) {
     if (!alert) {
         return false;

--- a/scripts/run_loop_fast_uia.js
+++ b/scripts/run_loop_fast_uia.js
@@ -196,20 +196,28 @@ function findAlertViewText(alert) {
     return txt;
 }
 
-function isLocationPrompt(alert) {
-    var exps = [
-            ["OK", /vil bruge din aktuelle placering/],
-            ["OK", /Would Like to Use Your Current Location/],
-            ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
-            ["OK", /Would Like to Send You Notifications/],
-            ["Allow", /access your location/],
-            ["OK", /Would Like to Access Your Photos/],
-            ["OK", /Would Like to Access Your Contacts/],
-            ["OK", /Location Accuracy/],
-            ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/]
-        ],
-        ans, exp,
-        txt;
+function isExternallyGeneratedAlert(alert) {
+    var exps =
+                [
+                    // Location Alerts
+                    ["OK", /vil bruge din aktuelle placering/],
+                    ["OK", /Would Like to Use Your Current Location/],
+                    ["Allow", /access your location/],
+                    ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
+                    ["OK", /Location Accuracy/],
+                    ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/],
+
+                    // Notifications
+                    ["OK", /Would Like to Send You Notifications/],
+
+                    // Photos
+                    ["OK", /Would Like to Access Your Photos/],
+
+                    // Contacts
+                    ["OK", /Would Like to Access Your Contacts/]
+                ],
+          ans, exp,
+          txt;
 
     txt = findAlertViewText(alert);
     Log.output({"output":"alert: "+txt}, true);
@@ -237,7 +245,7 @@ UIATarget.onAlert = function (alert) {
             return;
         }
         try {
-            var answer = isLocationPrompt(alert);
+            var answer = isExternallyGeneratedAlert(alert);
             if (answer) {
                 alert.buttons()[answer].tap();
             }

--- a/scripts/run_loop_fast_uia.js
+++ b/scripts/run_loop_fast_uia.js
@@ -1,3 +1,6 @@
+#import "./detect_externally_generated_alerts.js";
+#import "./logger.js";
+
 if (typeof JSON !== 'object') {
     JSON = {};
 }

--- a/scripts/run_loop_fast_uia.js
+++ b/scripts/run_loop_fast_uia.js
@@ -156,58 +156,6 @@ var _expectedIndex = 0,//expected index of next command
     _result,
     _lastResponse=null;
 
-
-
-function findAlertViewText(alert) {
-    if (!alert) {
-        return false;
-    }
-    var txt = alert.name(),
-        txts;
-    if (txt == null) {
-        txts = alert.staticTexts();
-        if (txts != null && txts.length > 0) {
-            txt = txts[0].name();
-        }
-    }
-    return txt;
-}
-
-function isExternallyGeneratedAlert(alert) {
-    var exps =
-                [
-                    // Location Alerts
-                    ["OK", /vil bruge din aktuelle placering/],
-                    ["OK", /Would Like to Use Your Current Location/],
-                    ["Allow", /access your location/],
-                    ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
-                    ["OK", /Location Accuracy/],
-                    ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/],
-
-                    // Notifications
-                    ["OK", /Would Like to Send You Notifications/],
-
-                    // Photos
-                    ["OK", /Would Like to Access Your Photos/],
-
-                    // Contacts
-                    ["OK", /Would Like to Access Your Contacts/]
-                ],
-          ans, exp,
-          txt;
-
-    txt = findAlertViewText(alert);
-    Log.output({"output":"alert: "+txt}, true);
-    for (var i = 0; i < exps.length; i++) {
-        ans = exps[i][0];
-        exp = exps[i][1];
-        if (exp.test(txt)) {
-            return ans;
-        }
-    }
-    return false;
-}
-
 UIATarget.onAlert = function (alert) {
     var target = UIATarget.localTarget(),
         app = target.frontMostApp(),
@@ -215,7 +163,7 @@ UIATarget.onAlert = function (alert) {
         rsp = null,
         actualIndex = null;
     target.pushTimeout(10);
-    function attemptTouchOKOnLocation(retry_count) {
+    function attemptTouchDefaultAlertButton(retry_count) {
         retry_count = retry_count || 0;
         if (retry_count >= 5) {
             Log.output("Maxed out retry (5) - unable to dismiss location dialog.");
@@ -233,11 +181,11 @@ UIATarget.onAlert = function (alert) {
                 Log.output(e.toString());
             }
             target.delay(1);
-            attemptTouchOKOnLocation(retry_count + 1);
+            attemptTouchDefaultAlertButton(retry_count + 1);
         }
     }
 
-    attemptTouchOKOnLocation(0);
+    attemptTouchDefaultAlertButton(0);
     target.popTimeout();
     for (var i=0;i<_RUN_LOOP_MAX_RETRY_AFTER_HANDLER;i++) {
         req = app.preferencesValueForKey(__calabashRequest);

--- a/scripts/run_loop_fast_uia.js
+++ b/scripts/run_loop_fast_uia.js
@@ -156,32 +156,6 @@ var _expectedIndex = 0,//expected index of next command
     _result,
     _lastResponse=null;
 
-var Log = (function () {
-    var forceFlush = [],
-        N = 16384,
-        i = N;
-    while (i--) {
-        forceFlush[i] = "*";
-    }
-    forceFlush = forceFlush.join('');
-
-    function log_json(object, flush)
-    {
-        UIALogger.logMessage("OUTPUT_JSON:\n"+JSON.stringify(object)+"\nEND_OUTPUT");
-        if (flush) {
-            UIALogger.logMessage(forceFlush);
-        }
-    }
-
-    return {
-        result: function (status, data, flush) {
-            log_json({"status": status, "value": data, "index":_actualIndex}, flush)
-        },
-        output: function (msg, flush) {
-            log_json({"output": msg,"last_index":_actualIndex}, flush);
-        }
-    };
-})();
 
 
 function findAlertViewText(alert) {

--- a/scripts/run_loop_host.js
+++ b/scripts/run_loop_host.js
@@ -159,8 +159,6 @@ var timeoutScriptPath = "$TIMEOUT_SCRIPT_PATH",
 
 
 
-
-
 var _expectedIndex = 0,//expected index of next command
     _actualIndex,//actual index of next command by reading commandPath
     _index,//index of ':' char in command
@@ -168,58 +166,6 @@ var _expectedIndex = 0,//expected index of next command
     _result,//result of eval
     _input,//command
     _process;//host command process
-
-
-
-function findAlertViewText(alert) {
-    if (!alert) {
-        return false;
-    }
-    var txt = alert.name(),
-        txts;
-    if (txt == null) {
-        txts = alert.staticTexts();
-        if (txts != null && txts.length > 0) {
-            txt = txts[0].name();
-        }
-    }
-    return txt;
-}
-
-function isExternallyGeneratedAlert(alert) {
-    var exps =
-                [
-                    // Location Alerts
-                    ["OK", /vil bruge din aktuelle placering/],
-                    ["OK", /Would Like to Use Your Current Location/],
-                    ["Allow", /access your location/],
-                    ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
-                    ["OK", /Location Accuracy/],
-                    ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/],
-
-                    // Notifications
-                    ["OK", /Would Like to Send You Notifications/],
-
-                    // Photos
-                    ["OK", /Would Like to Access Your Photos/],
-
-                    // Contacts
-                    ["OK", /Would Like to Access Your Contacts/]
-        ],
-        ans, exp,
-        txt;
-
-    txt = findAlertViewText(alert);
-    Log.output({"output":"alert: "+txt}, true);
-    for (var i = 0; i < exps.length; i++) {
-        ans = exps[i][0];
-        exp = exps[i][1];
-        if (exp.test(txt)) {
-            return ans;
-        }
-    }
-    return false;
-}
 
 UIATarget.onAlert = function (alert) {
     Log.output({"output":"on alert"}, true);

--- a/scripts/run_loop_host.js
+++ b/scripts/run_loop_host.js
@@ -169,35 +169,6 @@ var _expectedIndex = 0,//expected index of next command
     _input,//command
     _process;//host command process
 
-var Log = (function () {
-    var forceFlush = [],
-        N = "$MODE" == "FLUSH" ? 16384 : 0,
-        i = N;
-    while (i--) {
-        forceFlush[i] = "*";
-    }
-    forceFlush = forceFlush.join('');
-
-    function log_json(object)
-    {
-        UIALogger.logMessage("OUTPUT_JSON:\n"+JSON.stringify(object)+"\nEND_OUTPUT");
-    }
-
-    return {
-        result: function (status, data) {
-            log_json({"status": status, "value": data, "index":_actualIndex})
-            if (forceFlush.length > 0) {
-                UIALogger.logMessage(forceFlush);
-            }
-        },
-        output: function (msg) {
-            log_json({"output": msg,"last_index":_actualIndex});
-            if (forceFlush.length > 0) {
-                UIALogger.logMessage(forceFlush);
-            }
-        }
-    };
-})();
 
 
 function findAlertViewText(alert) {

--- a/scripts/run_loop_host.js
+++ b/scripts/run_loop_host.js
@@ -214,17 +214,25 @@ function findAlertViewText(alert) {
     return txt;
 }
 
-function isLocationPrompt(alert) {
-    var exps = [
-            ["OK", /vil bruge din aktuelle placering/],
-            ["OK", /Would Like to Use Your Current Location/],
-            ["OK", /Would Like to Send You Notifications/],
-            ["Allow", /access your location/],
-            ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
-            ["OK", /Would Like to Access Your Photos/],
-            ["OK", /Would Like to Access Your Contacts/],
-            ["OK", /Location Accuracy/],
-            ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/]
+function isExternallyGeneratedAlert(alert) {
+    var exps =
+                [
+                    // Location Alerts
+                    ["OK", /vil bruge din aktuelle placering/],
+                    ["OK", /Would Like to Use Your Current Location/],
+                    ["Allow", /access your location/],
+                    ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
+                    ["OK", /Location Accuracy/],
+                    ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/],
+
+                    // Notifications
+                    ["OK", /Would Like to Send You Notifications/],
+
+                    // Photos
+                    ["OK", /Would Like to Access Your Photos/],
+
+                    // Contacts
+                    ["OK", /Would Like to Access Your Contacts/]
         ],
         ans, exp,
         txt;
@@ -245,14 +253,14 @@ UIATarget.onAlert = function (alert) {
     Log.output({"output":"on alert"}, true);
     var target = UIATarget.localTarget();
     target.pushTimeout(10);
-    function attemptTouchOKOnLocation(retry_count) {
+    function attemptTouchDefaultAlertButton(retry_count) {
         retry_count = retry_count || 0;
         if (retry_count >= 5) {
             Log.output("Maxed out retry (5) - unable to dismiss location dialog.");
             return;
         }
         try {
-            var answer = isLocationPrompt(alert);
+            var answer = isExternallyGeneratedAlert(alert);
             if (answer) {
                 alert.buttons()[answer].tap();
             }
@@ -263,11 +271,11 @@ UIATarget.onAlert = function (alert) {
                 Log.output(e.toString());
             }
             target.delay(1);
-            attemptTouchOKOnLocation(retry_count + 1);
+            attemptTouchDefaultAlertButton(retry_count + 1);
         }
     }
 
-    attemptTouchOKOnLocation(0);
+    attemptTouchDefaultAlertButton(0);
     target.popTimeout();
     return true;
 };

--- a/scripts/run_loop_host.js
+++ b/scripts/run_loop_host.js
@@ -1,4 +1,5 @@
-//#import "calabash_script_uia.js"
+#import "./detect_externally_generated_alerts.js";
+#import "./logger.js";
 
 if (typeof JSON !== 'object') {
     JSON = {};

--- a/scripts/run_loop_shared_element.js
+++ b/scripts/run_loop_shared_element.js
@@ -196,20 +196,28 @@ function findAlertViewText(alert) {
     return txt;
 }
 
-function isLocationPrompt(alert) {
-    var exps = [
-            ["OK", /vil bruge din aktuelle placering/],
-            ["OK", /Would Like to Use Your Current Location/],
-            ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
-            ["OK", /Would Like to Send You Notifications/],
-            ["Allow", /access your location/],
-            ["OK", /Would Like to Access Your Photos/],
-            ["OK", /Would Like to Access Your Contacts/],
-            ["OK", /Location Accuracy/],
-            ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/]
-        ],
-        ans, exp,
-        txt;
+function isExternallyGeneratedAlert(alert) {
+    var exps =
+                [
+                    // Location Alerts
+                    ["OK", /vil bruge din aktuelle placering/],
+                    ["OK", /Would Like to Use Your Current Location/],
+                    ["Allow", /access your location/],
+                    ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
+                    ["OK", /Location Accuracy/],
+                    ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/],
+
+                    // Notifications
+                    ["OK", /Would Like to Send You Notifications/],
+
+                    // Photos
+                    ["OK", /Would Like to Access Your Photos/],
+
+                    // Contacts
+                    ["OK", /Would Like to Access Your Contacts/]
+                ],
+          ans, exp,
+          txt;
 
     txt = findAlertViewText(alert);
     Log.output({"output":"alert: "+txt}, true);
@@ -237,7 +245,7 @@ UIATarget.onAlert = function (alert) {
             return;
         }
         try {
-            var answer = isLocationPrompt(alert);
+            var answer = isExternallyGeneratedAlert(alert);
             if (answer) {
                 alert.buttons()[answer].tap();
             }

--- a/scripts/run_loop_shared_element.js
+++ b/scripts/run_loop_shared_element.js
@@ -156,58 +156,6 @@ var _expectedIndex = 0,//expected index of next command
     _result,
     _lastResponse=null;
 
-
-
-function findAlertViewText(alert) {
-    if (!alert) {
-        return false;
-    }
-    var txt = alert.name(),
-        txts;
-    if (txt == null) {
-        txts = alert.staticTexts();
-        if (txts != null && txts.length > 0) {
-            txt = txts[0].name();
-        }
-    }
-    return txt;
-}
-
-function isExternallyGeneratedAlert(alert) {
-    var exps =
-                [
-                    // Location Alerts
-                    ["OK", /vil bruge din aktuelle placering/],
-                    ["OK", /Would Like to Use Your Current Location/],
-                    ["Allow", /access your location/],
-                    ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
-                    ["OK", /Location Accuracy/],
-                    ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/],
-
-                    // Notifications
-                    ["OK", /Would Like to Send You Notifications/],
-
-                    // Photos
-                    ["OK", /Would Like to Access Your Photos/],
-
-                    // Contacts
-                    ["OK", /Would Like to Access Your Contacts/]
-                ],
-          ans, exp,
-          txt;
-
-    txt = findAlertViewText(alert);
-    Log.output({"output":"alert: "+txt}, true);
-    for (var i = 0; i < exps.length; i++) {
-        ans = exps[i][0];
-        exp = exps[i][1];
-        if (exp.test(txt)) {
-            return ans;
-        }
-    }
-    return false;
-}
-
 UIATarget.onAlert = function (alert) {
     var target = UIATarget.localTarget(),
         app = target.frontMostApp(),
@@ -215,7 +163,7 @@ UIATarget.onAlert = function (alert) {
         rsp = null,
         actualIndex = null;
     target.pushTimeout(10);
-    function attemptTouchOKOnLocation(retry_count) {
+    function attemptTouchDefaultAlertButton(retry_count) {
         retry_count = retry_count || 0;
         if (retry_count >= 5) {
             Log.output("Maxed out retry (5) - unable to dismiss location dialog.");
@@ -233,11 +181,11 @@ UIATarget.onAlert = function (alert) {
                 Log.output(e.toString());
             }
             target.delay(1);
-            attemptTouchOKOnLocation(retry_count + 1);
+            attemptTouchDefaultAlertButton(retry_count + 1);
         }
     }
 
-    attemptTouchOKOnLocation(0);
+    attemptTouchDefaultAlertButton(0);
     target.popTimeout();
     return true;
 };

--- a/scripts/run_loop_shared_element.js
+++ b/scripts/run_loop_shared_element.js
@@ -1,3 +1,6 @@
+#import "./detect_externally_generated_alerts.js";
+#import "./logger.js";
+
 if (typeof JSON !== 'object') {
     JSON = {};
 }

--- a/scripts/run_loop_shared_element.js
+++ b/scripts/run_loop_shared_element.js
@@ -156,32 +156,6 @@ var _expectedIndex = 0,//expected index of next command
     _result,
     _lastResponse=null;
 
-var Log = (function () {
-    var forceFlush = [],
-        N = 16384,
-        i = N;
-    while (i--) {
-        forceFlush[i] = "*";
-    }
-    forceFlush = forceFlush.join('');
-
-    function log_json(object, flush)
-    {
-        UIALogger.logMessage("OUTPUT_JSON:\n"+JSON.stringify(object)+"\nEND_OUTPUT");
-        if (flush) {
-            UIALogger.logMessage(forceFlush);
-        }
-    }
-
-    return {
-        result: function (status, data, flush) {
-            log_json({"status": status, "value": data, "index":_actualIndex}, flush)
-        },
-        output: function (msg, flush) {
-            log_json({"output": msg,"last_index":_actualIndex}, flush);
-        }
-    };
-})();
 
 
 function findAlertViewText(alert) {


### PR DESCRIPTION
We want to expand the range of system-level UIAlerts we can automatically dismiss.

This commit refactors the current dismiss behaviors to a single file instead of having the same code duplicated in each strategy script.

### TODO

- [ ] @krukow need review
- [ ] @jmoody Needs tests

RE: testing - This is a pain to test locally on devices because it requires an uninstall and a manual update in the Settings.app for each "permission" we want to test.

