### PR TITLE
Feature/enable host strategy caching for console attach

### DIFF
--- a/lib/run_loop.rb
+++ b/lib/run_loop.rb
@@ -6,4 +6,4 @@ require 'run_loop/sim_control'
 require 'run_loop/device'
 require 'run_loop/instruments'
 require 'run_loop/lipo'
-
+require 'run_loop/host_cache'

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -170,6 +170,7 @@ module RunLoop
       uia_strategy = options[:uia_strategy]
       if uia_strategy == :host
         create_uia_pipe(repl_path)
+        RunLoop::HostCache.default.clear
       end
 
       cal_script = File.join(SCRIPTS_PATH, 'calabash_script_uia.js')
@@ -511,7 +512,7 @@ module RunLoop
         raise RunLoop::WriteFailedError.new("Trying write of command #{cmd_str} at index #{index}")
       end
       run_loop[:index] = index + 1
-
+      RunLoop::HostCache.default.write(run_loop)
       index
     end
 
@@ -534,7 +535,6 @@ module RunLoop
     end
 
     def self.read_response(run_loop, expected_index, empty_file_timeout=10, search_for_property='index')
-
       log_file = run_loop[:log_file]
       initial_offset = run_loop[:initial_offset] || 0
       offset = initial_offset
@@ -606,9 +606,8 @@ module RunLoop
       end
 
       run_loop[:initial_offset] = offset
-
+      RunLoop::HostCache.default.write(run_loop)
       result
-
     end
 
     # @deprecated 1.0.5

--- a/lib/run_loop/host_cache.rb
+++ b/lib/run_loop/host_cache.rb
@@ -1,0 +1,103 @@
+require 'fileutils'
+
+module RunLoop
+
+  # A class for managing an on-disk hash table that represents the current
+  # state of the :host strategy run-loop.  It is used by Calabash iOS
+  # `console_attach` method.
+  # @see http://calabashapi.xamarin.com/ios/Calabash/Cucumber/Core.html#console_attach-instance_method
+  #
+  # Marshal is safe to use here because:
+  # 1. This code is not executed on the XTC.
+  # 2. Users who muck about with this cache can only hurt themselves.
+  class HostCache
+
+    # The path to the cache file.
+    #
+    # @!attribute [r] path
+    # @return [String] An expanded path to the cache file.
+    attr_reader :path
+
+    # The directory where the cache is stored.
+    # @return [String] Expanded path to the default cache directory.
+    def self.default_directory
+      File.expand_path('./.calabash')
+    end
+
+    # The default cache.
+    def self.default
+      RunLoop::HostCache.new(self.default_directory)
+    end
+
+    # Creates a new HostCache that is ready for IO.
+    #
+    # @param [String] directory The directory where the cache file is located.
+    #  If the directory does not exist, it will be created.
+    # @options [Hash] options Options to control the state of the new object.
+    # @option [String] filename (host_run_loop.hash) The cache filename.
+    # @option [Boolean] clear (false) If true, the current cache will be cleared.
+    # @return [RunLoop::HostCache] A cache that is ready for IO.
+    def initialize(directory, options = {})
+      default_opts = {:filename => 'host_run_loop.hash',
+                      :clear => false}
+      merged_opts = default_opts.merge(options)
+
+      dir_expanded = File.expand_path(directory)
+      unless Dir.exist?(dir_expanded)
+        FileUtils.mkdir_p(dir_expanded)
+      end
+
+      @path = File.join(dir_expanded, merged_opts[:filename])
+
+      if merged_opts[:clear] && File.exist?(@path)
+        FileUtils.rm_rf @path
+      end
+    end
+
+    # Reads the current cache.
+    # @return [Hash] A hash representation of the current state of the run-loop.
+    def read
+      if File.exist? @path
+        File.open(@path) do |file|
+          Marshal.load(file)
+        end
+      else
+        self.write({})
+        self.read
+      end
+    end
+
+    # @!visibility private
+    #
+    # Writes `hash` as a serial object.  The existing data is overwritten.
+    #
+    # @param [Hash] hash The hash to write.
+    # @raise [ArgumentError] The `hash` parameter must not be nil and it must
+    #  be a Hash.
+    # @raise [TypeError] If the hash contains objects that cannot be written
+    #  by Marshal.dump.
+    #
+    # @return [Boolean] Returns true if `hash` was successfully Marshal.dump'ed.
+    def write(hash)
+      if hash.nil?
+        raise ArgumentError, 'Expected the hash parameter to be non-nil'
+      end
+
+      unless hash.is_a?(Hash)
+        raise ArgumentError, "Expected #{hash} to a Hash, but it is a #{hash.class}"
+      end
+
+      File.open(@path, 'w+') do |file|
+        Marshal.dump(hash, file)
+      end
+      true
+    end
+
+    # @!visibility private
+    # Clears the current cache.
+    # @return [Boolean] Returns true if the hash was cleared.
+    def clear
+      self.write({})
+    end
+  end
+end

--- a/lib/run_loop/host_cache.rb
+++ b/lib/run_loop/host_cache.rb
@@ -3,6 +3,7 @@ require 'digest/sha1'
 
 module RunLoop
 
+  # @!visibility private
   # A class for managing an on-disk hash table that represents the current
   # state of the :host strategy run-loop.  It is used by Calabash iOS
   # `console_attach` method.

--- a/lib/run_loop/host_cache.rb
+++ b/lib/run_loop/host_cache.rb
@@ -21,7 +21,7 @@ module RunLoop
     # The directory where the cache is stored.
     # @return [String] Expanded path to the default cache directory.
     def self.default_directory
-      File.expand_path('./.calabash')
+      File.expand_path('/tmp/run-loop-host-cache')
     end
 
     # The default cache.

--- a/lib/run_loop/host_cache.rb
+++ b/lib/run_loop/host_cache.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'digest/sha1'
 
 module RunLoop
 
@@ -38,7 +39,8 @@ module RunLoop
     # @option [Boolean] clear (false) If true, the current cache will be cleared.
     # @return [RunLoop::HostCache] A cache that is ready for IO.
     def initialize(directory, options = {})
-      default_opts = {:filename => 'host_run_loop.hash',
+      sha1 = Digest::SHA1.hexdigest 'host_run_loop.hash'
+      default_opts = {:filename => sha1,
                       :clear => false}
       merged_opts = default_opts.merge(options)
 

--- a/spec/lib/host_cache_spec.rb
+++ b/spec/lib/host_cache_spec.rb
@@ -36,7 +36,7 @@ describe RunLoop::HostCache do
 
   context '.default_directory' do
     subject { RunLoop::HostCache.default_directory }
-    it { is_expected.to be == File.expand_path('./.calabash') }
+    it { is_expected.to be == File.expand_path('/tmp/run-loop-host-cache') }
   end
 
   context '.default' do

--- a/spec/lib/host_cache_spec.rb
+++ b/spec/lib/host_cache_spec.rb
@@ -1,0 +1,100 @@
+describe RunLoop::HostCache do
+
+  let(:directory) { Dir.mktmpdir }
+
+  describe '.new' do
+
+    after(:each) { FileUtils.rm_rf(File.expand_path('./host_cache.db')) }
+
+    it 'when directory exists' do
+      cache = RunLoop::HostCache.new(directory)
+      expect(cache.path).to be == File.join(directory, 'host_run_loop.hash')
+    end
+
+    it 'when directory does not exist' do
+      new_dir = File.join(directory, '.calabash')
+      cache = RunLoop::HostCache.new(new_dir)
+      expect(cache.path).to be == File.join(new_dir, 'host_run_loop.hash')
+      expect(Dir.exist?(new_dir))
+    end
+
+    it 'respects :filename option' do
+      filename = 'host_cache.db'
+      cache = RunLoop::HostCache.new(directory, {filename:filename})
+      expect(cache.path).to be == File.join(directory, filename)
+    end
+
+    it 'respects :clear option' do
+      filename = 'host_cache.db'
+      expected_path = File.join(directory, filename)
+      FileUtils.touch(filename)
+      cache = RunLoop::HostCache.new(directory, {filename:filename, clear:true})
+      expect(cache.path).to be == expected_path
+      expect(File.exist?(expected_path)).to be == false
+    end
+  end
+
+  context '.default_directory' do
+    subject { RunLoop::HostCache.default_directory }
+    it { is_expected.to be == File.expand_path('./.calabash') }
+  end
+
+  context '.default' do
+    subject { RunLoop::HostCache.default }
+    it {
+      is_expected.not_to be nil
+      is_expected.to be_a RunLoop::HostCache
+    }
+  end
+
+  describe 'io' do
+    let(:hash) { { :number => 1, :word => 'word', :symbol => :symbol } }
+    describe '#read' do
+      it 'returns an empty array if cache file does not exist' do
+        cache = RunLoop::HostCache.new(directory)
+        result = cache.read
+        expect(result).to be_a Hash
+        expect(result).to be == {}
+      end
+    end
+
+    describe '#write' do
+      let(:cache) { RunLoop::HostCache.new(directory) }
+      describe 'raises error when' do
+        it 'argument is nil' do
+          expect { cache.write(nil) }.to raise_error ArgumentError
+        end
+
+        it 'argument is not a Hash' do
+          expect { cache.write([]) }.to raise_error ArgumentError
+        end
+
+        it "argument cannot be Marshal.dump'ed" do
+          hash = {:dir => StringIO.new('fifo') }
+          expect { cache.write( hash ) }.to raise_error TypeError
+        end
+      end
+
+      it "what it writes can be Marshal.load'ed" do
+        expect(cache.write(hash)).to be == true
+
+        actual = nil
+        File.open(cache.path) do |file|
+          actual = Marshal.load(file)
+        end
+
+        expect(actual).to be == hash
+      end
+    end
+
+    describe '#clear' do
+      it 'can clear the cache' do
+        cache = RunLoop::HostCache.new(directory)
+        expect(cache.write(hash)).to be == true
+        expect(cache.read).to be == hash
+        expect(cache.clear).to be == true
+        expect(cache.read).to be == {}
+      end
+    end
+  end
+end

--- a/spec/lib/host_cache_spec.rb
+++ b/spec/lib/host_cache_spec.rb
@@ -1,6 +1,7 @@
 describe RunLoop::HostCache do
 
   let(:directory) { Dir.mktmpdir }
+  let(:cache_filename) { '2780e6479cc2bfcd0a007bd08bdf36de11b397bd' }
 
   describe '.new' do
 
@@ -8,13 +9,13 @@ describe RunLoop::HostCache do
 
     it 'when directory exists' do
       cache = RunLoop::HostCache.new(directory)
-      expect(cache.path).to be == File.join(directory, 'host_run_loop.hash')
+      expect(cache.path).to be == File.join(directory, cache_filename)
     end
 
     it 'when directory does not exist' do
       new_dir = File.join(directory, '.calabash')
       cache = RunLoop::HostCache.new(new_dir)
-      expect(cache.path).to be == File.join(new_dir, 'host_run_loop.hash')
+      expect(cache.path).to be == File.join(new_dir, cache_filename)
       expect(Dir.exist?(new_dir))
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'awesome_print'
 require 'resources'
 require 'stub_env'
 require 'pry'
+require 'tmpdir'
+require 'fileutils'
 
 # monkey patch for AwesomePrint + objects that implement '=='
 module AwesomePrint


### PR DESCRIPTION
#### Motivation

`console_attach` for the :host strategy is broken.

* **"TypeError: no implicit conversion of nil into String" for write_request when user needs to establish/re-establish a valid run_loop is not user-friendly** #102
* **When :uia_strategy => :host, `console_attach` attaches, but throws exception when performing gestures.** [#638](https://github.com/calabash/calabash-ios/issues/638)

#### Method

See #102 for discussion.

When :host strategy performs IO, it serializes `run_loop` (a Hash) to a local file in `/tmp`

In the `Calabash::Cucumber::Launcher#attach` method, this Hash is read and the launcher's run_loop Hash is populated with the current state of the run loop.

#### Notes

I thought about putting the cache in the run-loop temporary :results_dir, but decided against it.  It would have required parsing (yet again) the output of `ps`.  I am also seeing multiple `instruments` processes, so we cannot guarantee that  we will choose the correct :results_dir.

I am a little concerned about using Marshal.  It is possible that a malicious user could abuse this in an environment like Travis.  However, since this code is not executed on the XTC, I don't think there is too much of a risk.  The alternative is to use a JSON format.  YAML was ruled out because the parsing is very slow.

**UPDATE:** Voted - 2 of 3 voted for Marshal; security is not a problem.

* https://code.google.com/p/ruby-security/wiki/Guide#Serialization/Marshaling

#### Tests

The round-trip tests are in an unpublished branch of calabash-ios.

- [ ] @krukow needs review

