### PR TITLE
Use iPhone 5s as simulator default

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -409,11 +409,11 @@ module RunLoop
     #  version.
     def self.default_simulator(xcode_tools=RunLoop::XCTools.new)
       if xcode_tools.xcode_version_gte_62?
-        'iPhone 5 (8.2 Simulator)'
+        'iPhone 5s (8.2 Simulator)'
       elsif xcode_tools.xcode_version_gte_61?
-        'iPhone 5 (8.1 Simulator)'
+        'iPhone 5s (8.1 Simulator)'
       elsif xcode_tools.xcode_version_gte_6?
-        'iPhone 5 (8.0 Simulator)'
+        'iPhone 5s (8.0 Simulator)'
       else
         'iPhone Retina (4-inch) - Simulator - iOS 7.1'
       end

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -111,29 +111,29 @@ describe RunLoop::Core do
       expect(actual).to be == expected
     end
 
-    it "when Xcode 6.0* it returns 'iPhone 5 (8.0 Simulator)'" do
+    it "when Xcode 6.0* it returns 'iPhone 5s (8.0 Simulator)'" do
       version = RunLoop::Version.new('6.0')
       xctools = RunLoop::XCTools.new
       expect(xctools).to receive(:xcode_version).at_least(:once).and_return(version)
-      expected = 'iPhone 5 (8.0 Simulator)'
+      expected = 'iPhone 5s (8.0 Simulator)'
       actual = RunLoop::Core.default_simulator(xctools)
       expect(actual).to be == expected
     end
 
-    it "when Xcode 6.1* it returns 'iPhone 5 (8.1 Simulator)'" do
+    it "when Xcode 6.1* it returns 'iPhone 5s (8.1 Simulator)'" do
       version = RunLoop::Version.new('6.1')
       xctools = RunLoop::XCTools.new
       expect(xctools).to receive(:xcode_version).at_least(:once).and_return(version)
-      expected = 'iPhone 5 (8.1 Simulator)'
+      expected = 'iPhone 5s (8.1 Simulator)'
       actual = RunLoop::Core.default_simulator(xctools)
       expect(actual).to be == expected
     end
 
-    it "when Xcode 6.2* it returns 'iPhone 5 (8.2 Simulator)'" do
+    it "when Xcode 6.2* it returns 'iPhone 5s (8.2 Simulator)'" do
       version = RunLoop::Version.new('6.2')
       xctools = RunLoop::XCTools.new
       expect(xctools).to receive(:xcode_version).at_least(:once).and_return(version)
-      expected = 'iPhone 5 (8.2 Simulator)'
+      expected = 'iPhone 5s (8.2 Simulator)'
       actual = RunLoop::Core.default_simulator(xctools)
       expect(actual).to be == expected
     end
@@ -164,11 +164,11 @@ describe RunLoop::Core do
       valid_versions = ['6.0', '6.0.1'].map { |elm| RunLoop::Version.new(elm) }
       valid_targets.each do |target|
         valid_versions.each do |version|
-          it "returns 'iPhone 5 (8.0 Simulator)' for Xcode '#{version}' if simulator = '#{target.nil? ? 'nil' : target }'" do
+          it "returns 'iPhone 5s (8.0 Simulator)' for Xcode '#{version}' if simulator = '#{target.nil? ? 'nil' : target }'" do
             xctools = RunLoop::XCTools.new
             expect(xctools).to receive(:xcode_version).at_least(:once).and_return(version)
             udid, apb = RunLoop::Core.udid_and_bundle_for_launcher(target, options, xctools)
-            expect(udid).to be == 'iPhone 5 (8.0 Simulator)'
+            expect(udid).to be == 'iPhone 5s (8.0 Simulator)'
             expect(apb).to be == options[:app]
           end
         end
@@ -181,11 +181,11 @@ describe RunLoop::Core do
       valid_versions = ['6.1'].map { |elm| RunLoop::Version.new(elm) }
       valid_targets.each do |target|
         valid_versions.each do |version|
-          it "returns 'iPhone 5 (8.1 Simulator)' for Xcode '#{version}' if simulator = '#{target.nil? ? 'nil' : target }'" do
+          it "returns 'iPhone 5s (8.1 Simulator)' for Xcode '#{version}' if simulator = '#{target.nil? ? 'nil' : target }'" do
             xctools = RunLoop::XCTools.new
             expect(xctools).to receive(:xcode_version).at_least(:once).and_return(version)
             udid, apb = RunLoop::Core.udid_and_bundle_for_launcher(target, options, xctools)
-            expect(udid).to be == 'iPhone 5 (8.1 Simulator)'
+            expect(udid).to be == 'iPhone 5s (8.1 Simulator)'
             expect(apb).to be == options[:app]
           end
         end


### PR DESCRIPTION
#### Motivation

Was iPhone 5. Xcode 6's default simulator is iPhone 5s. This is an attempt to improve the first-run experience by avoiding the binary-is-incompatible-with-simulator problem.

* https://github.com/calabash/run_loop/blob/develop/lib/run_loop/lipo.rb#L25
* **Ensure compatible arch before launching on device** #80