### PR TITLE
Fix stable and pre-release comparison

### DIFF
--- a/lib/run_loop/version.rb
+++ b/lib/run_loop/version.rb
@@ -148,11 +148,14 @@ module RunLoop
         return a.patch.to_i > b.patch.to_i ? 1 : -1
       end
 
-      return 1 if a.pre and (not b.pre)
-      return -1 if (not a.pre) and b.pre
+      return -1 if a.pre and (not a.pre_version) and b.pre_version
+      return 1 if a.pre_version and b.pre and (not b.pre_version)
 
-      return 1 if a.pre_version and (not b.pre_version)
-      return -1 if (not a.pre_version) and b.pre_version
+      return -1 if a.pre and (not b.pre)
+      return 1 if (not a.pre) and b.pre
+
+      return -1 if a.pre_version and (not b.pre_version)
+      return 1 if (not a.pre_version) and b.pre_version
 
       if a.pre_version != b.pre_version
         return a.pre_version.to_i > b.pre_version.to_i ? 1 : -1

--- a/spec/lib/version_spec.rb
+++ b/spec/lib/version_spec.rb
@@ -48,6 +48,10 @@ describe RunLoop::Version do
       b = RunLoop::Version.new('0.9.5.pre1')
       expect(a == b).to be false
 
+      a = RunLoop::Version.new('0.9.5')
+      b = RunLoop::Version.new('0.9.5.pre1')
+      expect(a == b).to be false
+
     end
   end
 
@@ -59,6 +63,10 @@ describe RunLoop::Version do
 
       a = RunLoop::Version.new('0.9.5')
       b = RunLoop::Version.new('0.9.5.pre')
+      expect(a != b).to be true
+
+      a = RunLoop::Version.new('0.9.5')
+      b = RunLoop::Version.new('0.9.5.pre1')
       expect(a != b).to be true
 
       a = RunLoop::Version.new('0.9.5.pre')
@@ -81,6 +89,10 @@ describe RunLoop::Version do
       b = RunLoop::Version.new('0.9.5.pre')
       expect(a > b).to be true
 
+      a = RunLoop::Version.new('0.9.5')
+      b = RunLoop::Version.new('0.9.5.pre1')
+      expect(a > b).to be true
+
       a = RunLoop::Version.new('0.9.5.pre')
       b = RunLoop::Version.new('0.9.5.pre1')
       expect(a < b).to be true
@@ -99,6 +111,10 @@ describe RunLoop::Version do
 
       a = RunLoop::Version.new('0.9.5')
       b = RunLoop::Version.new('0.9.5.pre')
+      expect(b < a).to be true
+
+      a = RunLoop::Version.new('0.9.5')
+      b = RunLoop::Version.new('0.9.5.pre1')
       expect(b < a).to be true
 
       a = RunLoop::Version.new('0.9.5.pre')

--- a/spec/lib/version_spec.rb
+++ b/spec/lib/version_spec.rb
@@ -79,7 +79,7 @@ describe RunLoop::Version do
 
       a = RunLoop::Version.new('0.9.5')
       b = RunLoop::Version.new('0.9.5.pre')
-      expect(a < b).to be true
+      expect(a > b).to be true
 
       a = RunLoop::Version.new('0.9.5.pre')
       b = RunLoop::Version.new('0.9.5.pre1')
@@ -99,7 +99,7 @@ describe RunLoop::Version do
 
       a = RunLoop::Version.new('0.9.5')
       b = RunLoop::Version.new('0.9.5.pre')
-      expect(b > a).to be true
+      expect(b < a).to be true
 
       a = RunLoop::Version.new('0.9.5.pre')
       b = RunLoop::Version.new('0.9.5.pre1')


### PR DESCRIPTION
Issue #110 
0.12.0 should be bigger (>) than 0.12.0.pre2