### PR TITLE
Relax json dependency to ~> 1.8

### DIFF
--- a/run_loop.gemspec
+++ b/run_loop.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9'
 
   s.add_dependency('thor', '>= 0.18')
-  s.add_dependency('json', '1.8.1')
+  s.add_dependency('json', '~> 1.8')
   # Matches XTC requirement; would like to use ~> 1.4.0.
   s.add_dependency 'retriable', '~> 1.3.3.1'
   s.add_dependency('awesome_print', '~> 1.6')


### PR DESCRIPTION
### Motivation

We temporarily had to pin version to 1.8.1.