### PR TITLE
Introduce a delay which causes instruments to flush log output

### DIFF
--- a/lib/run_loop/version.rb
+++ b/lib/run_loop/version.rb
@@ -1,5 +1,5 @@
 module RunLoop
-  VERSION = '1.2.3'
+  VERSION = '1.2.4'
 
   # A model of a software release version that can be used to compare two versions.
   #

--- a/scripts/run_loop_host.js
+++ b/scripts/run_loop_host.js
@@ -324,5 +324,6 @@ while (true) {
 
         _expectedIndex = Math.max(_actualIndex+1, _expectedIndex+1);
         Log.result("success", _result);
+        target.delay(0.1);
     }
 }


### PR DESCRIPTION
Fix https://github.com/calabash/calabash-ios/issues/670 by using a small delay causing instrument to flush log buffer