### PR TITLE
Namespace the run-loop cache dir - Fix for

### DIFF
--- a/lib/run_loop.rb
+++ b/lib/run_loop.rb
@@ -1,3 +1,4 @@
+require 'run_loop/environment'
 require 'run_loop/core'
 require 'run_loop/version'
 require 'run_loop/xctools'

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -1,0 +1,11 @@
+module RunLoop
+  class Environment
+
+    # Returns the user's Unix uid.
+    # @return [Integer] The user's Unix uid as an integer.
+    def self.uid
+      `id -u`.strip.to_i
+    end
+
+  end
+end

--- a/lib/run_loop/host_cache.rb
+++ b/lib/run_loop/host_cache.rb
@@ -23,7 +23,8 @@ module RunLoop
     # The directory where the cache is stored.
     # @return [String] Expanded path to the default cache directory.
     def self.default_directory
-      File.expand_path('/tmp/run-loop-host-cache')
+      uid = RunLoop::Environment.uid
+      File.expand_path("/tmp/run-loop-host-cache/#{uid}")
     end
 
     # The default cache.

--- a/lib/run_loop/host_cache.rb
+++ b/lib/run_loop/host_cache.rb
@@ -24,7 +24,7 @@ module RunLoop
     # @return [String] Expanded path to the default cache directory.
     def self.default_directory
       uid = RunLoop::Environment.uid
-      File.expand_path("/tmp/run-loop-host-cache/#{uid}")
+      File.expand_path("/tmp/com.xamarin.calabash.run-loop/host-cache/#{uid}")
     end
 
     # The default cache.

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -1,0 +1,13 @@
+describe RunLoop::Environment do
+
+  let(:environment) { RunLoop::Environment.new }
+
+  context '.user_id' do
+  subject { RunLoop::Environment.uid }
+    it {
+      is_expected.not_to be nil
+      is_expected.to be_a_kind_of(Integer)
+    }
+
+  end
+end

--- a/spec/lib/host_cache_spec.rb
+++ b/spec/lib/host_cache_spec.rb
@@ -35,9 +35,13 @@ describe RunLoop::HostCache do
     end
   end
 
-  context '.default_directory' do
-    subject { RunLoop::HostCache.default_directory }
-    it { is_expected.to be == File.expand_path('/tmp/run-loop-host-cache') }
+  describe '.default_directory' do
+    it 'returns a user-specific directory when possible' do
+      uid = 501
+      expect(RunLoop::Environment).to receive(:uid).and_return(uid)
+      expected = File.expand_path("/tmp/run-loop-host-cache/#{uid}")
+      expect(RunLoop::HostCache.default_directory).to be == expected
+    end
   end
 
   context '.default' do

--- a/spec/lib/host_cache_spec.rb
+++ b/spec/lib/host_cache_spec.rb
@@ -39,7 +39,7 @@ describe RunLoop::HostCache do
     it 'returns a user-specific directory when possible' do
       uid = 501
       expect(RunLoop::Environment).to receive(:uid).and_return(uid)
-      expected = File.expand_path("/tmp/run-loop-host-cache/#{uid}")
+      expected = File.expand_path("/tmp/com.xamarin.calabash.run-loop/host-cache/#{uid}")
       expect(RunLoop::HostCache.default_directory).to be == expected
     end
   end


### PR DESCRIPTION
#### Motivation

* **In multi-user environments, /tmp/run_loop_host_cache causes permissions issues** #121

The cache file will be written to a user-specific directory.  I opted to use the `uid` of the user because:

* `ENV['USER']` could be empty
* `whoami` can return user names with spaces, invalid path characters, and UTF8 characters.