### PR TITLE
stub_env version 1.0.0 is broken

### DIFF
--- a/run_loop.gemspec
+++ b/run_loop.gemspec
@@ -31,7 +31,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency('guard-bundler', '~> 2.0')
   s.add_development_dependency('growl', '~> 1.0')
   s.add_development_dependency('rb-readline', '~> 0.5')
-  s.add_development_dependency('stub_env', '~> 0.2')
+  # stub_env release 1.0.0 is broken
+  s.add_development_dependency('stub_env', '0.2')
   s.add_development_dependency('pry')
   s.add_development_dependency('pry-nav')
 end


### PR DESCRIPTION
#### Motivation

* **version 1.0.0 `stub_env` is raising {} does not implement: stubbed?** [#1](https://github.com/littleowllabs/stub_env/issues/1)

