### PR TITLE
ProcessWaiter to wait for processes

### DIFF
--- a/lib/run_loop.rb
+++ b/lib/run_loop.rb
@@ -1,5 +1,6 @@
 require 'run_loop/environment'
 require 'run_loop/process_terminator'
+require 'run_loop/process_waiter'
 require 'run_loop/core'
 require 'run_loop/version'
 require 'run_loop/xctools'

--- a/lib/run_loop/process_waiter.rb
+++ b/lib/run_loop/process_waiter.rb
@@ -1,0 +1,85 @@
+module RunLoop
+
+  # A class for waiting on processes.
+  class ProcessWaiter
+
+    attr_reader :process_name
+
+    def initialize(process_name, options={})
+      @options = DEFAULT_OPTIONS.merge(options)
+      @process_name = process_name
+    end
+
+    # Collect a list of Integer pids.
+    # @return [Array<Integer>] An array of integer pids for the `process_name`
+    def pids
+      process_info = `ps x -o pid,comm | grep -v grep | grep #{process_name}`
+      process_array = process_info.split("\n")
+      process_array.map { |process| process.split(' ').first.strip.to_i }
+    end
+
+    # Is the `process_name` a running?
+    def running_process?
+      !pids.empty?
+    end
+
+    # Wait for `process_name` to start.
+    def wait_for_any
+      return true if running_process?
+
+      now = Time.now
+      poll_until = now + @options[:timeout]
+      delay = @options[:interval]
+      is_alive = false
+      while Time.now < poll_until
+        is_alive = running_process?
+        break if is_alive
+        sleep delay
+      end
+
+      if RunLoop::Environment.debug?
+        puts "Waited for #{Time.now - now} seconds for '#{process_name}' to start."
+      end
+
+      if @options[:raise_on_timeout] and !is_alive
+        raise "Waited #{@options[:timeout]} seconds for '#{process_name}' to start."
+      end
+      is_alive
+    end
+
+    # Wait for all `process_name` to finish.
+    def wait_for_none
+      return true if !running_process?
+
+      now = Time.now
+      poll_until = now + @options[:timeout]
+      delay = @options[:interval]
+      has_terminated = false
+      while Time.now < poll_until
+        has_terminated = !self.running_process?
+        break if has_terminated
+        sleep delay
+      end
+
+      if RunLoop::Environment.debug?
+        puts "Waited for #{Time.now - now} seconds for '#{process_name}' to die."
+      end
+
+      if @options[:raise_on_timeout] and !has_terminated
+        raise "Waited #{@options[:timeout]} seconds for '#{process_name}' to die."
+      end
+      has_terminated
+    end
+
+    private
+
+    # @!visibility private
+    DEFAULT_OPTIONS =
+          {
+                :timeout => 10.0,
+                :interval => 0.1,
+                :raise_on_timeout => false
+          }
+  end
+end
+

--- a/spec/integration/process_waiter_spec.rb
+++ b/spec/integration/process_waiter_spec.rb
@@ -1,0 +1,76 @@
+describe RunLoop::ProcessWaiter do
+
+  before(:each) { Resources.shared.kill_fake_instruments_process }
+
+  context '#wait_for_any' do
+    describe 'returns true' do
+      it 'fast if process is running' do
+        res = RunLoop::ProcessWaiter.new('ruby').wait_for_any
+        expect(res).to be == true
+      end
+
+      it 'after waiting for process' do
+        waiter = RunLoop::ProcessWaiter.new('ruby', {:timeout => 2})
+        vals = [false, false, false, true]
+        expect(waiter).to receive(:running_process?).exactly(4).times.and_return(*vals)
+        expect(waiter.wait_for_any).to be == true
+      end
+    end
+
+    it 'returns false' do
+      waiter = RunLoop::ProcessWaiter.new('ruby', {:timeout => 1})
+      expect(waiter).to receive(:running_process?).at_least(:twice).and_return(false)
+      expect(waiter.wait_for_any).to be == false
+    end
+
+    it 'raises an error' do
+      options = {:timeout => 1, :raise_on_timeout => true }
+      waiter = RunLoop::ProcessWaiter.new('ruby', options)
+      expect(waiter).to receive(:running_process?).at_least(:twice).and_return(false)
+      expect { waiter.wait_for_any }.to raise_error
+    end
+
+    it 'can log how long it waited' do
+      expect(RunLoop::Environment).to receive(:debug?).at_least(:once).and_return(true)
+      waiter = RunLoop::ProcessWaiter.new('ruby', {:timeout => 2})
+      vals = [false, false, false, true]
+      expect(waiter).to receive(:running_process?).exactly(4).times.and_return(*vals)
+      expect(waiter.wait_for_any).to be == true
+    end
+  end
+
+
+  context '#wait_for_none' do
+    describe 'returns true' do
+      it 'fast if no process is running' do
+        res = RunLoop::ProcessWaiter.new('no-such-process').wait_for_none
+        expect(res).to be == true
+      end
+
+      it 'after waiting for process to expire' do
+        waiter = RunLoop::ProcessWaiter.new('ruby', {:timeout => 1})
+        vals = [true, true, true, false]
+        expect(waiter).to receive(:running_process?).exactly(4).times.and_return(*vals)
+        expect(waiter.wait_for_none).to be == true
+      end
+    end
+
+    it 'returns false' do
+      waiter = RunLoop::ProcessWaiter.new('ruby', {:timeout => 1})
+      expect(waiter.wait_for_none).to be == false
+    end
+
+    it 'raises an error' do
+      options = {:timeout => 1, :raise_on_timeout => true }
+      waiter = RunLoop::ProcessWaiter.new('ruby', options)
+      expect { waiter.wait_for_none }.to raise_error
+    end
+
+    it 'can log how long it waited' do
+      expect(RunLoop::Environment).to receive(:debug?).at_least(:once).and_return(true)
+      waiter = RunLoop::ProcessWaiter.new('ruby', {:timeout => 2})
+      expect(waiter.wait_for_none).to be == false
+    end
+  end
+
+end

--- a/spec/lib/process_waiter_spec.rb
+++ b/spec/lib/process_waiter_spec.rb
@@ -1,0 +1,56 @@
+describe RunLoop::ProcessWaiter do
+
+  context '.new' do
+    describe 'sets the process name' do
+      subject { RunLoop::ProcessWaiter.new('process').process_name }
+      it { is_expected.to be ==  'process' }
+    end
+
+    describe '@options' do
+      subject {
+        RunLoop::ProcessWaiter.new('process', options).instance_variable_get(:@options)
+      }
+
+      describe 'defaults when no options are passed' do
+        let(:options) { {} }
+        it { is_expected.to be == RunLoop::ProcessWaiter::DEFAULT_OPTIONS }
+      end
+
+      describe 'merges when options are passed' do
+        let(:options) { {:timeout => 5} }
+        let(:expected) { RunLoop::ProcessWaiter::DEFAULT_OPTIONS.merge(options) }
+        it { is_expected.to be == expected }
+      end
+    end
+  end
+
+  context '#pids' do
+    subject { RunLoop::ProcessWaiter.new(name).pids }
+
+    describe 'returns empty array when no process exists' do
+      let(:name) { 'no-such-process' }
+      it { is_expected.to be == [] }
+    end
+
+    describe 'returns non-empty arry of Integers' do
+      let(:name) { 'ruby' }
+      it {
+        is_expected.not_to be_empty
+        expect(subject.first).to be_a Integer
+      }
+    end
+  end
+
+  context '#running_process?' do
+    subject { RunLoop::ProcessWaiter.new(name).running_process? }
+    describe 'false when no processes are found' do
+      let(:name) { 'no-such-process' }
+      it { is_expected.to be_falsey }
+    end
+
+    describe 'returns non-empty arry of Integers' do
+      let(:name) { 'ruby' }
+      it { is_expected.to be_truthy }
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

The simctl API and dylib API needs to do a lot of waiting for processes to start and processes to stop.

- [ ] @TobiasRoikjer Can you review?  

Can be merged after CI passes.