### PR TITLE
Avoid shelling out in popen3 call to simctl erase

### DIFF
--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -904,8 +904,8 @@ module RunLoop
       sim_details = sim_details(:udid)
 
       simctl_erase = lambda { |udid|
-        cmd = "xcrun simctl erase #{udid}"
-        Open3.popen3(cmd) do  |_, stdout,  stderr, wait_thr|
+        args = "simctl erase #{udid}".split(' ')
+        Open3.popen3('xcrun', *args) do  |_, stdout,  stderr, wait_thr|
           out = stdout.read.strip
           err = stderr.read.strip
           if ENV['DEBUG_UNIX_CALLS'] == '1'


### PR DESCRIPTION
### Motivation

A minor change that I want to run through CI.

I think we should be avoiding 'sh' when spawn processes.

