### PR TITLE
Stablize lldb examples

### DIFF
--- a/lib/run_loop/lldb.rb
+++ b/lib/run_loop/lldb.rb
@@ -34,9 +34,7 @@ module RunLoop
     def self.kill_lldb_processes
       self.lldb_pids.each do |pid|
         unless self.kill_with_signal(pid, 'TERM')
-          unless self.kill_with_signal(pid, 'QUIT')
-            self.kill_with_signal(pid, 'KILL')
-          end
+          self.kill_with_signal(pid, 'KILL')
         end
       end
     end

--- a/spec/integration/lldb_spec.rb
+++ b/spec/integration/lldb_spec.rb
@@ -1,17 +1,26 @@
-describe RunLoop::LLDB do
+unless Resources.shared.travis_ci?
+  describe RunLoop::LLDB do
 
-  before (:each) { Resources.shared.kill_lldb_processes }
+    before (:each) { Resources.shared.kill_lldb_processes }
 
-  it '.kill_lldb_processes' do
-    Resources.shared.with_debugging do
-      3.times {
+    describe '.lldb_pids' do
+      it 'returns empty list when there are no lldb processes' do
+        expect(RunLoop::LLDB.lldb_pids).to be == []
+      end
+
+      it 'returns array of integers when there are lldb processes' do
+        Resources.shared.spawn_lldb_process
+        RunLoop::ProcessWaiter.new('lldb').wait_for_any
+        expect(RunLoop::LLDB.lldb_pids.length).to be == 1
+      end
+    end
+
+    it '.kill_lldb_processes' do
+      2.times {
         Resources.shared.spawn_lldb_process
       }
 
-      RunLoop::ProcessWaiter.new('lldb').wait_for_any
       RunLoop::LLDB.kill_lldb_processes
-      RunLoop::ProcessWaiter.new('lldb').wait_for_none
-
       expect(RunLoop::LLDB.lldb_pids.length).to be == 0
     end
   end

--- a/spec/integration/process_waiter_spec.rb
+++ b/spec/integration/process_waiter_spec.rb
@@ -1,7 +1,5 @@
 describe RunLoop::ProcessWaiter do
 
-  before(:each) { Resources.shared.kill_fake_instruments_process }
-
   context '#wait_for_any' do
     describe 'returns true' do
       it 'fast if process is running' do
@@ -39,7 +37,6 @@ describe RunLoop::ProcessWaiter do
     end
   end
 
-
   context '#wait_for_none' do
     describe 'returns true' do
       it 'fast if no process is running' do
@@ -73,4 +70,42 @@ describe RunLoop::ProcessWaiter do
     end
   end
 
+  context '#wait_for_n' do
+    describe 'raises an error when' do
+      it 'n is not an Integer' do
+        expect { RunLoop::ProcessWaiter.new('ruby').wait_for_n 2.0 }.to raise_error ArgumentError
+      end
+
+      it 'n is < 0' do
+        expect { RunLoop::ProcessWaiter.new('ruby').wait_for_n 0 }.to raise_error ArgumentError
+        expect { RunLoop::ProcessWaiter.new('ruby').wait_for_n -1 }.to raise_error ArgumentError
+      end
+
+      it 'cannot find n processes and options say :raise' do
+        options = {:timeout => 1, :raise_on_timeout => true }
+        waiter = RunLoop::ProcessWaiter.new('ruby', options)
+        expect { waiter.wait_for_n(1000) }.to raise_error
+      end
+    end
+
+    it 'return true when there are N processes' do
+      waiter = RunLoop::ProcessWaiter.new('ruby', {:timeout => 1})
+      vals = [[], [0], [0, 1], [0, 1, 2], [0, 1, 2, 3]]
+      expect(waiter).to receive(:pids).exactly(4).times.and_return(*vals)
+      expect(waiter.wait_for_n(4)).to be == true
+    end
+
+    it 'returns false' do
+      waiter = RunLoop::ProcessWaiter.new('ruby', {:timeout => 1})
+      expect(waiter.wait_for_none).to be == false
+    end
+
+    it 'can log how long it waited' do
+      expect(RunLoop::Environment).to receive(:debug?).at_least(:once).and_return(true)
+      waiter = RunLoop::ProcessWaiter.new('ruby', {:timeout => 1.0, :interval => 0.5})
+      vals = [[], [0], [0, 1]]
+      expect(waiter).to receive(:pids).exactly(3).times.and_return(*vals)
+      expect(waiter.wait_for_n(3)).to be == false
+    end
+  end
 end

--- a/spec/lib/lldb_spec.rb
+++ b/spec/lib/lldb_spec.rb
@@ -1,7 +1,5 @@
 describe RunLoop::LLDB do
 
-  before (:each) { Resources.shared.kill_lldb_processes }
-
   context '.is_lldb_process?' do
     it 'return true when passed an invocation of lldb' do
       ps_details = '/Xcode/6.1.1/Xcode.app/Contents/Developer/usr/bin/lldb'
@@ -21,18 +19,14 @@ describe RunLoop::LLDB do
         expect(RunLoop::LLDB.is_lldb_process?(ps_details)).to be_falsey
       end
     end
-
   end
 
-  describe '.lldb_pids' do
-    it 'returns empty list when there are no lldb processes' do
-      expect(RunLoop::LLDB.lldb_pids).to be == []
-    end
-
-    it 'returns array of integers when there are lldb processes' do
-      Resources.shared.spawn_lldb_process
-      RunLoop::ProcessWaiter.new('lldb').wait_for_any
-      expect(RunLoop::LLDB.lldb_pids.length).to be == 1
-    end
+  it '.kill_lldb_processes' do
+    expect(RunLoop::LLDB).to receive(:lldb_pids).and_return([1, 2])
+    expect(RunLoop::LLDB).to receive(:kill_with_signal).with(1, 'TERM').exactly(1).times.and_return(false)
+    expect(RunLoop::LLDB).to receive(:kill_with_signal).with(1, 'KILL').exactly(1).times.and_return(true)
+    expect(RunLoop::LLDB).to receive(:kill_with_signal).with(2, 'TERM').exactly(1).times.and_return(false)
+    expect(RunLoop::LLDB).to receive(:kill_with_signal).with(2, 'KILL').exactly(1).times.and_return(true)
+    expect(RunLoop::LLDB.kill_lldb_processes).to be_truthy
   end
 end

--- a/spec/resources.rb
+++ b/spec/resources.rb
@@ -373,14 +373,7 @@ class Resources
     return if @lldb_process_pids.nil?
     begin
       @lldb_process_pids.each do |pid|
-        Process.kill('TERM', pid)
-        begin
-          Process.wait(pid)
-        rescue Errno::ESRCH => _
-          # ignore this
-        rescue Errno::ECHILD => _
-          # ignore this
-        end
+        RunLoop::ProcessTerminator.new(pid, 'KILL', 'lldb').kill_process
       end
     ensure
       @lldb_process_pids = []


### PR DESCRIPTION
### Motivation

LLDB tests are flickering on Travis; disabled them after an analysis.  lldb is refusing to start for > 10 seconds.

Replaced integration test for kill_lldb_processes with a mocked unit test.