### PR TITLE
Replace ENV['DEBUG'] calls

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -36,7 +36,7 @@ module RunLoop
     end
 
     def self.log_run_loop_options(options, xctools)
-      return unless ENV['DEBUG'] == '1'
+      return unless RunLoop::Environment.debug?
       # Ignore :sim_control b/c it is a ruby object; printing is not useful.
       ignored_keys = [:sim_control]
       options_to_log = {}
@@ -117,12 +117,12 @@ module RunLoop
 
         lipo = RunLoop::Lipo.new(launch_options[:bundle_dir_or_bundle_id])
         lipo.expect_compatible_arch(simulator)
-        if ENV['DEBUG'] == '1'
+        if RunLoop::Environment.debug?
           puts "Simulator instruction set '#{simulator.instruction_set}' is compatible with #{lipo.info}"
         end
         true
       else
-        if ENV['DEBUG'] == '1'
+        if RunLoop::Environment.debug?
           puts "Xcode #{sim_control.xctools.xcode_version} detected; skipping simulator architecture check."
         end
         false
@@ -189,7 +189,7 @@ module RunLoop
       log_file ||= File.join(results_dir, 'run_loop.out')
 
       after = Time.now
-      if ENV['DEBUG'] == '1'
+      if RunLoop::Environment.debug?
         puts "Preparation took #{after-before} seconds"
       end
 
@@ -247,14 +247,14 @@ module RunLoop
           end
         end
       rescue TimeoutError => e
-        if ENV['DEBUG'] == '1'
+        if RunLoop::Environment.debug?
           puts "Failed to launch."
           puts "#{e}: #{e && e.message}"
         end
         raise TimeoutError, "Time out waiting for UIAutomation run-loop to Start. \n Logfile #{log_file} \n\n #{File.read(log_file)}\n"
       end
 
-      if ENV['DEBUG']=='1'
+      if RunLoop::Environment.debug?
         puts "Launching took #{Time.now-before} seconds"
       end
 
@@ -437,7 +437,7 @@ module RunLoop
       repl_path = run_loop[:repl_path]
       index = run_loop[:index]
       cmd_str = "#{index}:#{escape_host_command(cmd)}"
-      should_log = (ENV['DEBUG'] == '1')
+      should_log = RunLoop::Environment.debug?
       RunLoop.log_info(logger, cmd_str) if should_log
       write_succeeded = false
       2.times do |i|
@@ -589,14 +589,14 @@ module RunLoop
     end
 
     def self.log(message)
-      if ENV['DEBUG']=='1'
+      if RunLoop::Environment.debug?
         puts "#{Time.now } #{message}"
         $stdout.flush
       end
     end
 
     def self.log_header(message)
-      if ENV['DEBUG']=='1'
+      if RunLoop::Environment.debug?
         puts "\n\e[#{35}m### #{message} ###\e[0m"
         $stdout.flush
       end
@@ -780,7 +780,7 @@ module RunLoop
     if logger && logger.respond_to?(:info)
       logger.info(msg)
     else
-      puts msg if ENV['DEBUG'] == '1'
+      puts msg if RunLoop::Environment.debug?
     end
   end
 end

--- a/lib/run_loop/instruments.rb
+++ b/lib/run_loop/instruments.rb
@@ -70,7 +70,7 @@ module RunLoop
     # @todo Is this jruby compatible?
     def spawn(automation_template, options, log_file)
       splat_args = spawn_arguments(automation_template, options)
-      if ENV['DEBUG'] == '1'
+      if RunLoop::Environment.debug?
         puts  "#{Time.now} xcrun #{splat_args.join(' ')} >& #{log_file}"
         $stdout.flush
       end

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -265,13 +265,11 @@ describe RunLoop::Core do
             :uia_strategy => :preferences,
       }
     }
+
     let(:xctools) { RunLoop::XCTools.new }
 
-    before(:each) { ENV.delete('DEBUG') }
-    after(:each) { ENV.delete('DEBUG') }
-
     it "when DEBUG != '1' it logs nothing" do
-      ENV['DEBUG'] = '0'
+      stub_env('DEBUG', '0')
       out = capture_stdout do
         RunLoop::Core.log_run_loop_options(options, xctools)
       end
@@ -279,7 +277,7 @@ describe RunLoop::Core do
     end
 
     describe "when DEBUG == '1'" do
-      before(:each) { ENV['DEBUG'] = '1' }
+      before(:each) { stub_env('DEBUG', '1') }
       it 'does some logging' do
         out = capture_stdout do
           RunLoop::Core.log_run_loop_options(options, xctools)


### PR DESCRIPTION
### Motivation

We need to get away from accessing this variable directly.

In the gem, use `RunLoop::Environment.debug?`.

In rspec tests, use `stub_env('DEBUG', < new value >)`.  In the rspec tests, you can wrap specs in a `Resources.share.with_debugging {}` to enable a debug mode in the context of the block.

