### PR TITLE
Move ENV vars to environment.rb

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -356,7 +356,7 @@ module RunLoop
     end
 
     def self.udid_and_bundle_for_launcher(device_target, options, xctools=RunLoop::XCTools.new)
-      bundle_dir_or_bundle_id = options[:app] || ENV['BUNDLE_ID']|| ENV['APP_BUNDLE_PATH'] || ENV['APP']
+      bundle_dir_or_bundle_id = options[:app] || RunLoop::Environment.bundle_id || ENV['APP_BUNDLE_PATH'] || ENV['APP']
 
       unless bundle_dir_or_bundle_id
         raise 'key :app or environment variable APP_BUNDLE_PATH, BUNDLE_ID or APP must be specified as path to app bundle (simulator) or bundle id (device)'

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -552,7 +552,7 @@ module RunLoop
       RunLoop::Instruments.new.instruments_pids(&block)
     end
 
-    def self.automation_template(xctools, candidate = ENV['TRACE_TEMPLATE'])
+    def self.automation_template(xctools, candidate = RunLoop::Environment.trace_template)
       unless candidate && File.exist?(candidate)
         candidate = default_tracetemplate xctools
       end

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -226,7 +226,7 @@ module RunLoop
                   :log_file => log_file,
                   :results_dir => results_dir}
 
-      uia_timeout = options[:uia_timeout] || (ENV['UIA_TIMEOUT'] && ENV['UIA_TIMEOUT'].to_f) || 10
+      uia_timeout = options[:uia_timeout] || RunLoop::Environment.uia_timeout || 10
 
       before = Time.now
       begin

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -474,6 +474,8 @@ module RunLoop
     end
 
     def self.read_response(run_loop, expected_index, empty_file_timeout=10, search_for_property='index')
+      debug_read = RunLoop::Environment.debug_read?
+
       log_file = run_loop[:log_file]
       initial_offset = run_loop[:initial_offset] || 0
       offset = initial_offset
@@ -499,7 +501,7 @@ module RunLoop
           raise RunLoop::TimeoutError.new('Exception while running script')
         end
         index_if_found = output.index(START_DELIMITER)
-        if ENV['DEBUG_READ']=='1'
+        if debug_read
           puts output.gsub('*', '')
           puts "Size #{size}"
           puts "offset #{offset}"
@@ -521,7 +523,7 @@ module RunLoop
           json = rest[0..index_of_json]
 
 
-          if ENV['DEBUG_READ']=='1'
+          if debug_read
             puts "Index #{index_if_found}, Size: #{size} Offset #{offset}"
 
             puts ("parse #{json}")
@@ -529,7 +531,7 @@ module RunLoop
 
           offset = offset + json.size
           parsed_result = JSON.parse(json)
-          if ENV['DEBUG_READ']=='1'
+          if debug_read
             p parsed_result
           end
           json_index_if_present = parsed_result[search_for_property]

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -356,7 +356,7 @@ module RunLoop
     end
 
     def self.udid_and_bundle_for_launcher(device_target, options, xctools=RunLoop::XCTools.new)
-      bundle_dir_or_bundle_id = options[:app] || RunLoop::Environment.bundle_id || ENV['APP_BUNDLE_PATH'] || ENV['APP']
+      bundle_dir_or_bundle_id = options[:app] || RunLoop::Environment.bundle_id || RunLoop::Environment.path_to_app_bundle
 
       unless bundle_dir_or_bundle_id
         raise 'key :app or environment variable APP_BUNDLE_PATH, BUNDLE_ID or APP must be specified as path to app bundle (simulator) or bundle id (device)'

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -22,8 +22,19 @@ module RunLoop
       ENV['XAMARIN_TEST_CLOUD'] == '1'
     end
 
+    # Returns the value of TRACE_TEMPLATE; the Instruments template to use
+    # during testing.
     def self.trace_template
       ENV['TRACE_TEMPLATE']
+    end
+
+    # Returns the value of UIA_TIMEOUT.  Use this control how long to wait
+    # for instruments to launch and attach to your application.
+    #
+    # Non-empty values are converted to a float.
+    def self.uia_timeout
+      timeout = ENV['UIA_TIMEOUT']
+      timeout ? timeout.to_f : nil
     end
   end
 end

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -50,5 +50,13 @@ module RunLoop
     def self.path_to_app_bundle
       ENV['APP_BUNDLE_PATH'] || ENV['APP']
     end
+
+    # Returns the value of DEVELOPER_DIR
+    #
+    # @note Never call this directly.  Always create an XCTool instance
+    #   and allow it to derive the path to the Xcode toolchain.
+    def self.developer_dir
+      ENV['DEVELOPER_DIR']
+    end
   end
 end

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -12,6 +12,12 @@ module RunLoop
       ENV['DEBUG'] == '1'
     end
 
+    # Returns true if read debugging is enabled.
+    def self.debug_read?
+      ENV['DEBUG_READ'] == '1'
+    end
+
+    # Returns true if we are running on the XTC
     def self.xtc?
       ENV['XAMARIN_TEST_CLOUD'] == '1'
     end

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -36,5 +36,10 @@ module RunLoop
       timeout = ENV['UIA_TIMEOUT']
       timeout ? timeout.to_f : nil
     end
+
+    # Returns the value of BUNDLE_ID
+    def self.bundle_id
+      ENV['BUNDLE_ID']
+    end
   end
 end

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -41,5 +41,14 @@ module RunLoop
     def self.bundle_id
       ENV['BUNDLE_ID']
     end
+
+    # Returns to the path to the app bundle (simulator builds).
+    #
+    # Both APP_BUNDLE_PATH and APP are checked and in that order.
+    #
+    # Use of APP_BUNDLE_PATH is deprecated and will be removed.
+    def self.path_to_app_bundle
+      ENV['APP_BUNDLE_PATH'] || ENV['APP']
+    end
   end
 end

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -15,5 +15,9 @@ module RunLoop
     def self.xtc?
       ENV['XAMARIN_TEST_CLOUD'] == '1'
     end
+
+    def self.trace_template
+      ENV['TRACE_TEMPLATE']
+    end
   end
 end

--- a/lib/run_loop/xctools.rb
+++ b/lib/run_loop/xctools.rb
@@ -125,8 +125,8 @@ module RunLoop
     # @return [String] path to current developer directory
     def xcode_developer_dir
       @xcode_developer_dir ||=
-            if ENV['DEVELOPER_DIR']
-              ENV['DEVELOPER_DIR']
+            if RunLoop::Environment.developer_dir
+              RunLoop::Environment.developer_dir
             else
               # fall back to xcode-select
               `xcode-select --print-path`.chomp

--- a/spec/integration/core_spec.rb
+++ b/spec/integration/core_spec.rb
@@ -2,15 +2,11 @@ require 'tmpdir'
 
 describe RunLoop::Core do
 
-  before(:each) { ENV.delete('TRACE_TEMPLATE') }
-
   describe '.automation_template' do
-
-    after(:each) { ENV.delete('TRACE_TEMPLATE') }
 
     it 'ignores the TRACE_TEMPLATE env var if the tracetemplate does not exist' do
       tracetemplate = '/tmp/some.tracetemplate'
-      ENV['TRACE_TEMPLATE']=tracetemplate
+      expect(RunLoop::Environment).to receive(:trace_template).and_return(tracetemplate)
       xctools = RunLoop::XCTools.new
       actual = RunLoop::Core.automation_template(xctools)
       expect(actual).not_to be == nil

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -2,17 +2,13 @@ require 'tmpdir'
 
 describe RunLoop::Core do
 
-  before(:each) { ENV.delete('TRACE_TEMPLATE')  }
-
   describe '.automation_template' do
-
-    after(:each) { ENV.delete('TRACE_TEMPLATE') }
 
     it 'respects the TRACE_TEMPLATE env var if the tracetemplate exists' do
       dir = Dir.mktmpdir('tracetemplate')
       tracetemplate = File.expand_path(File.join(dir, 'some.tracetemplate'))
       FileUtils.touch tracetemplate
-      ENV['TRACE_TEMPLATE']=tracetemplate
+      expect(RunLoop::Environment).to receive(:trace_template).and_return(tracetemplate)
       xctools = RunLoop::XCTools.new
       expect(RunLoop::Core.automation_template xctools).to be == tracetemplate
     end

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -22,6 +22,18 @@ describe RunLoop::Environment do
     end
   end
 
+  describe '.debug_read?' do
+    it "returns true when DEBUG_READ == '1'" do
+      stub_env('DEBUG_READ', '1')
+      expect(RunLoop::Environment.debug_read?).to be == true
+    end
+
+    it "returns false when DEBUG_READ != '1'" do
+      stub_env('DEBUG_READ', 1)
+      expect(RunLoop::Environment.debug_read?).to be == false
+    end
+  end
+
   describe '.xtc?' do
     it "returns true when XAMARIN_TEST_CLOUD == '1'" do
       stub_env('XAMARIN_TEST_CLOUD', '1')

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -21,4 +21,16 @@ describe RunLoop::Environment do
       expect(RunLoop::Environment.debug?).to be == false
     end
   end
+
+  describe '.xtc?' do
+    it "returns true when XAMARIN_TEST_CLOUD == '1'" do
+      stub_env('XAMARIN_TEST_CLOUD', '1')
+      expect(RunLoop::Environment.xtc?).to be == true
+    end
+
+    it "returns false when XAMARIN_TEST_CLOUD != '1'" do
+      stub_env('XAMARIN_TEST_CLOUD', 1)
+      expect(RunLoop::Environment.xtc?).to be == false
+    end
+  end
 end

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -71,4 +71,29 @@ describe RunLoop::Environment do
     expect(RunLoop::Environment.bundle_id).to be == 'com.example.Foo'
   end
 
+  describe '.path_to_app_bundle' do
+    let (:abp) { '/my/app/bundle/path.app' }
+    describe 'only one is defined' do
+      it 'APP_BUNDLE_PATH' do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('APP_BUNDLE_PATH').and_return(abp)
+        allow(ENV).to receive(:[]).with('APP').and_return(nil)
+        expect(RunLoop::Environment.path_to_app_bundle).to be == abp
+      end
+
+      it 'APP' do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('APP_BUNDLE_PATH').and_return(nil)
+        allow(ENV).to receive(:[]).with('APP').and_return(abp)
+        expect(RunLoop::Environment.path_to_app_bundle).to be == abp
+      end
+    end
+
+    it 'when both APP_BUNDLE_PATH and APP are defined, the first takes precedence' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('APP_BUNDLE_PATH').and_return(abp)
+      allow(ENV).to receive(:[]).with('APP').and_return('/some/other/path.app')
+      expect(RunLoop::Environment.path_to_app_bundle).to be == abp
+    end
+  end
 end

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -96,4 +96,10 @@ describe RunLoop::Environment do
       expect(RunLoop::Environment.path_to_app_bundle).to be == abp
     end
   end
+
+  it '.developer_dir' do
+    stub_env('DEVELOPER_DIR', '/some/xcode/path')
+    expect(RunLoop::Environment.developer_dir).to be == '/some/xcode/path'
+  end
+
 end

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -50,4 +50,19 @@ describe RunLoop::Environment do
     stub_env('TRACE_TEMPLATE', '/my/tracetemplate')
     expect(RunLoop::Environment.trace_template).to be == '/my/tracetemplate'
   end
+
+  describe '.uia_timeout' do
+    it 'returns the value of UIA_TIMEOUT' do
+      stub_env('UIA_TIMEOUT', 10.0)
+      expect(RunLoop::Environment.uia_timeout).to be == 10.0
+    end
+
+    it 'converts non-floats to floats' do
+      stub_env('UIA_TIMEOUT', '10.0')
+      expect(RunLoop::Environment.uia_timeout).to be == 10.0
+
+      stub_env('UIA_TIMEOUT', 10)
+      expect(RunLoop::Environment.uia_timeout).to be == 10.0
+    end
+  end
 end

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -65,4 +65,10 @@ describe RunLoop::Environment do
       expect(RunLoop::Environment.uia_timeout).to be == 10.0
     end
   end
+
+  it '.bundle_id' do
+    stub_env('BUNDLE_ID', 'com.example.Foo')
+    expect(RunLoop::Environment.bundle_id).to be == 'com.example.Foo'
+  end
+
 end

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -33,4 +33,9 @@ describe RunLoop::Environment do
       expect(RunLoop::Environment.xtc?).to be == false
     end
   end
+
+  it '.trace_template' do
+    stub_env('TRACE_TEMPLATE', '/my/tracetemplate')
+    expect(RunLoop::Environment.trace_template).to be == '/my/tracetemplate'
+  end
 end


### PR DESCRIPTION
#### Motivation

We should stop accessing environment variables directly with ENV.

* TRACE_TEMPLATE needs to be in Environment #141