### PR TITLE
FIX: #137 simctl should filter unavailable devices

### DIFF
--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -998,6 +998,7 @@ module RunLoop
         current_sdk = nil
         res = {}
         out.split("\n").each do |line|
+
           possible_sdk = line[/(\d\.\d(\.\d)?)/,0]
           if possible_sdk
             current_sdk = possible_sdk
@@ -1005,11 +1006,19 @@ module RunLoop
             next
           end
 
+          unavailable_skd = line[/Unavailable/, 0]
+          if unavailable_skd
+            current_sdk = nil
+            next
+          end
+
           if current_sdk
-            name = line.split('(').first.strip
-            udid = line[XCODE_6_SIM_UDID_REGEX,0]
-            state = line[/(Booted|Shutdown)/,0]
-            res[current_sdk] << {:name => name, :udid => udid, :state => state}
+            unless line[/unavailable/,0]
+              name = line.split('(').first.strip
+              udid = line[XCODE_6_SIM_UDID_REGEX,0]
+              state = line[/(Booted|Shutdown)/,0]
+              res[current_sdk] << {:name => name, :udid => udid, :state => state}
+            end
           end
         end
         res

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -1049,11 +1049,12 @@ module RunLoop
     def simctl_list_runtimes
       # The 'com.apple.CoreSimulator.SimRuntime.iOS-7-0' is the runtime-id,
       # which can be used to create devices.
-      cmd = 'xcrun simctl list runtimes'
-      Open3.popen3(cmd) do  |_, stdout,  stderr, _|
+      args = 'simctl list runtimes'.split(' ')
+      Open3.popen3('xcrun', *args) do  |_, stdout,  stderr, _|
         out = stdout.read.strip
         err = stderr.read.strip
         if ENV['DEBUG_UNIX_CALLS'] == '1'
+          cmd = "xcrun #{args.join(' ')}"
           puts "#{cmd}  => stdout: '#{out}' | stderr: '#{err}'"
         end
         # Ex.

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -987,11 +987,12 @@ module RunLoop
     #  base sdk version.
     # @see #simctl_list
     def simctl_list_devices
-      cmd = 'xcrun simctl list devices'
-      Open3.popen3(cmd) do  |_, stdout,  stderr, _|
+      args = 'simctl list devices'.split(' ')
+      Open3.popen3('xcrun', *args) do  |_, stdout,  stderr, _|
         out = stdout.read.strip
         err = stderr.read.strip
         if ENV['DEBUG_UNIX_CALLS'] == '1'
+          cmd = "xcrun #{args.join(' ')}"
           puts "#{cmd} => stdout: '#{out}' | stderr: '#{err}'"
         end
 


### PR DESCRIPTION
Fixes **SimControl is not filtering by "(unavailable, runtime profile not found)" causing failing builds when Xcode betas are installed** #137

Possibly related to:  **Simulator not found under Xcode 6.3 beta 2 using RESET_BETWEEN_SCENARIOS=1** [#724](https://github.com/calabash/calabash-ios/issues/724)
