### PR TITLE
Add slack notifications for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,5 @@ rvm:
   - 2.1.2
 
 notifications:
+  slack:
+    secure: gWmLS+smElUJwiCF0PYPPkFVDEowNhaD6yD9T3QxRAOamUahVq20NQg8qy1Gj2niiFDlbqYKpZZlZEwLyrcEbwWsBgyYYdNRphEqxBySzbWXZ9ebxwT7tp4bv8NMoVBe0WODx0L3kt48IUcUoSHU/aOBYmPRzf0rTFCZcwqd0W4=#calabash

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,7 @@ rvm:
   - 2.1.2
 
 notifications:
+  notifications:
+      email: false
   slack:
     secure: gWmLS+smElUJwiCF0PYPPkFVDEowNhaD6yD9T3QxRAOamUahVq20NQg8qy1Gj2niiFDlbqYKpZZlZEwLyrcEbwWsBgyYYdNRphEqxBySzbWXZ9ebxwT7tp4bv8NMoVBe0WODx0L3kt48IUcUoSHU/aOBYmPRzf0rTFCZcwqd0W4=#calabash

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,3 @@ rvm:
   - 2.1.2
 
 notifications:
-  email:
-    recipients:
-      - joshuajmoody@gmail.com
-      - karl.krukow@xamarin.com
-    on_success: change
-    on_failure: always


### PR DESCRIPTION
#### Motivation

Email is drag.  I use a Unix Terminal + Growl to keep an eye on Travis.

Let's try Slack?

Will post Travis CI notifications to the #calabash channel.