### PR TITLE
Can use simulator UDID for DEVICE_TARGET

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -178,7 +178,7 @@ module RunLoop
       end
 
       # Compute udid and bundle_dir / bundle_id from options and target depending on Xcode version
-      udid, bundle_dir_or_bundle_id = udid_and_bundle_for_launcher(device_target, options, xctools)
+      udid, bundle_dir_or_bundle_id = self.udid_and_bundle_for_launcher(device_target, options, sim_control)
 
       args = options.fetch(:args, [])
 
@@ -355,7 +355,9 @@ module RunLoop
       end
     end
 
-    def self.udid_and_bundle_for_launcher(device_target, options, xctools=RunLoop::XCTools.new)
+    def self.udid_and_bundle_for_launcher(device_target, options, sim_control=RunLoop::SimControl.new)
+      xctools = sim_control.xctools
+
       bundle_dir_or_bundle_id = options[:app] || RunLoop::Environment.bundle_id || RunLoop::Environment.path_to_app_bundle
 
       unless bundle_dir_or_bundle_id

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -372,7 +372,7 @@ module RunLoop
         end
         udid = device_target
 
-        unless /simulator/i.match(device_target)
+        unless self.simulator_target?(options, sim_control)
           bundle_dir_or_bundle_id = options[:bundle_id] if options[:bundle_id]
         end
       else

--- a/spec/integration/run_sim_spec.rb
+++ b/spec/integration/run_sim_spec.rb
@@ -49,4 +49,26 @@ describe RunLoop do
       end
     end
   end
+
+  if Resources.shared.current_xcode_version >= RunLoop::Version.new('6.0')
+    it 'launching on a sim with CoreSimulator UDID' do
+      sim_control = RunLoop::SimControl.new
+      sim_control.reset_sim_content_and_settings
+      simulator = sim_control.simulators.sample(1).first
+      udid = simulator.udid
+
+      options =
+            {
+                  :app => Resources.shared.cal_app_bundle_path,
+                  :device_target => udid,
+                  :sim_control => sim_control
+            }
+
+      hash = nil
+      Retriable.retriable({:tries => Resources.shared.launch_retries}) do
+        hash = RunLoop.run(options)
+      end
+      expect(hash).not_to be nil
+    end
+  end
 end

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -104,38 +104,20 @@ describe RunLoop::Core do
       end
     end
 
-    describe 'when 6.0 <= xcode <= 6.0.1' do
+    describe 'when xcode <= 6.0' do
       options = {:app => Resources.shared.cal_app_bundle_path}
       valid_targets = [nil, '', 'simulator']
-      valid_versions = ['6.0', '6.0.1'].map { |elm| RunLoop::Version.new(elm) }
       valid_targets.each do |target|
-        valid_versions.each do |version|
-          it "returns 'iPhone 5s (8.0 Simulator)' for Xcode '#{version}' if simulator = '#{target.nil? ? 'nil' : target }'" do
-            sim_control = RunLoop::SimControl.new
-            xctools = sim_control.xctools
-            expect(xctools).to receive(:xcode_version).at_least(:once).and_return(version)
-            udid, apb = RunLoop::Core.udid_and_bundle_for_launcher(target, options, sim_control)
-            expect(udid).to be == 'iPhone 5s (8.0 Simulator)'
-            expect(apb).to be == options[:app]
-          end
-        end
-      end
-    end
-
-    describe 'when xcode >= 6.1' do
-      options = {:app => Resources.shared.cal_app_bundle_path}
-      valid_targets = [nil, '', 'simulator']
-      valid_versions = ['6.1'].map { |elm| RunLoop::Version.new(elm) }
-      valid_targets.each do |target|
-        valid_versions.each do |version|
-          it "returns 'iPhone 5s (8.1 Simulator)' for Xcode '#{version}' if simulator = '#{target.nil? ? 'nil' : target }'" do
-            sim_control = RunLoop::SimControl.new
-            xctools = sim_control.xctools
-            expect(xctools).to receive(:xcode_version).at_least(:once).and_return(version)
-            udid, apb = RunLoop::Core.udid_and_bundle_for_launcher(target, options, sim_control)
-            expect(udid).to be == 'iPhone 5s (8.1 Simulator)'
-            expect(apb).to be == options[:app]
-          end
+        it "returns 'iPhone 5s (8.0 Simulator)' for Xcode >= 6.0 if simulator = '#{target.nil? ? 'nil' : target }'" do
+          sim_control = RunLoop::SimControl.new
+          xctools = sim_control.xctools
+          version = RunLoop::Version.new('6.0')
+          expect(xctools).to receive(:xcode_version).at_least(:once).and_return(version)
+          default_sim = 'iPhone 5s (8.0 Simulator)'
+          expect(RunLoop::Core).to receive(:default_simulator).and_return(default_sim)
+          udid, apb = RunLoop::Core.udid_and_bundle_for_launcher(target, options, sim_control)
+          expect(udid).to be == default_sim
+          expect(apb).to be == options[:app]
         end
       end
     end

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -93,9 +93,10 @@ describe RunLoop::Core do
       valid_targets.each do |target|
         valid_versions.each do |version|
           it "returns 'iPhone Retina (4-inch) - Simulator - iOS 7.1' for Xcode '#{version}' if simulator = '#{target.nil? ? 'nil' : target }'" do
-            xctools = RunLoop::XCTools.new
+            sim_control = RunLoop::SimControl.new
+            xctools = sim_control.xctools
             expect(xctools).to receive(:xcode_version).at_least(:once).and_return(version)
-            udid, apb = RunLoop::Core.udid_and_bundle_for_launcher(target, options, xctools)
+            udid, apb = RunLoop::Core.udid_and_bundle_for_launcher(target, options, sim_control)
             expect(udid).to be == 'iPhone Retina (4-inch) - Simulator - iOS 7.1'
             expect(apb).to be == options[:app]
           end
@@ -110,9 +111,10 @@ describe RunLoop::Core do
       valid_targets.each do |target|
         valid_versions.each do |version|
           it "returns 'iPhone 5s (8.0 Simulator)' for Xcode '#{version}' if simulator = '#{target.nil? ? 'nil' : target }'" do
-            xctools = RunLoop::XCTools.new
+            sim_control = RunLoop::SimControl.new
+            xctools = sim_control.xctools
             expect(xctools).to receive(:xcode_version).at_least(:once).and_return(version)
-            udid, apb = RunLoop::Core.udid_and_bundle_for_launcher(target, options, xctools)
+            udid, apb = RunLoop::Core.udid_and_bundle_for_launcher(target, options, sim_control)
             expect(udid).to be == 'iPhone 5s (8.0 Simulator)'
             expect(apb).to be == options[:app]
           end
@@ -127,9 +129,10 @@ describe RunLoop::Core do
       valid_targets.each do |target|
         valid_versions.each do |version|
           it "returns 'iPhone 5s (8.1 Simulator)' for Xcode '#{version}' if simulator = '#{target.nil? ? 'nil' : target }'" do
-            xctools = RunLoop::XCTools.new
+            sim_control = RunLoop::SimControl.new
+            xctools = sim_control.xctools
             expect(xctools).to receive(:xcode_version).at_least(:once).and_return(version)
-            udid, apb = RunLoop::Core.udid_and_bundle_for_launcher(target, options, xctools)
+            udid, apb = RunLoop::Core.udid_and_bundle_for_launcher(target, options, sim_control)
             expect(udid).to be == 'iPhone 5s (8.1 Simulator)'
             expect(apb).to be == options[:app]
           end


### PR DESCRIPTION
### Motivation

Fixes: **setting DEVICE_TARGET to a simulator UDID causes crash**  [#714](https://github.com/calabash/calabash-ios/issues/714)