### PR TITLE
Detect Xcode-beta.app (new in Xcode 6.3 beta 3)

### DIFF
--- a/lib/run_loop/xctools.rb
+++ b/lib/run_loop/xctools.rb
@@ -139,7 +139,7 @@ module RunLoop
     # @return [Boolean] True if the Xcode version is beta.
     def xcode_is_beta?
       @xcode_is_beta ||= lambda {
-        (xcode_developer_dir =~ /Xcode-Beta.app/) != nil
+        (xcode_developer_dir =~ /Xcode-[Bb]eta.app/) != nil
       }.call
     end
 

--- a/spec/lib/xctools_spec.rb
+++ b/spec/lib/xctools_spec.rb
@@ -142,6 +142,11 @@ describe RunLoop::XCTools do
       expect(RunLoop::XCTools.new.xcode_is_beta?).to be == true
     end
 
+    it 'returns true if the bundle name is Xcode-Beta.app' do
+      stub_env('DEVELOPER_DIR', '/Xcode/6.2/Xcode-beta.app/Contents/Developer')
+      expect(RunLoop::XCTools.new.xcode_is_beta?).to be == true
+    end
+
     it 'returns false if the bundle name is not Xcode-Beta.app' do
       stub_env('DEVELOPER_DIR', '/Xcode/6.2/Xcode.app/Contents/Developer')
       expect(RunLoop::XCTools.new.xcode_is_beta?).to be == false


### PR DESCRIPTION
### Motivation

Xcode 6.3 betas are expanding to `Xcode-beta.app`, not `Xcode-Beta.app`.

