### PR TITLE
Avoid permission collision of parent temp folder when running multiple instances from different user accounts on the same machine

### DIFF
--- a/lib/run_loop/host_cache.rb
+++ b/lib/run_loop/host_cache.rb
@@ -24,7 +24,7 @@ module RunLoop
     # @return [String] Expanded path to the default cache directory.
     def self.default_directory
       uid = RunLoop::Environment.uid
-      File.expand_path("/tmp/com.xamarin.calabash.run-loop/host-cache/#{uid}")
+      File.expand_path("/tmp/com.xamarin.calabash.run-loop_host-cache_#{uid}")
     end
 
     # The default cache.

--- a/spec/lib/host_cache_spec.rb
+++ b/spec/lib/host_cache_spec.rb
@@ -39,7 +39,7 @@ describe RunLoop::HostCache do
     it 'returns a user-specific directory when possible' do
       uid = 501
       expect(RunLoop::Environment).to receive(:uid).and_return(uid)
-      expected = File.expand_path("/tmp/com.xamarin.calabash.run-loop/host-cache/#{uid}")
+      expected = File.expand_path("/tmp/com.xamarin.calabash.run-loop_host-cache_#{uid}")
       expect(RunLoop::HostCache.default_directory).to be == expected
     end
   end


### PR DESCRIPTION
We parallelize work by running multiple instances on different user accounts on the same Mac. By having a folder structure under /tmp, there is permissions collision based on which instance creates the parent folder. This PR proposes a flat folder structure under /tmp per uid to avoid this issue.