### PR TITLE
Feature/fixup env var handling

### DIFF
--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -53,7 +53,12 @@ module RunLoop
     #
     # Use of APP_BUNDLE_PATH is deprecated and will be removed.
     def self.path_to_app_bundle
-      ENV['APP_BUNDLE_PATH'] || ENV['APP']
+      value = ENV['APP_BUNDLE_PATH'] || ENV['APP']
+      if !value || value == ''
+        nil
+      else
+        value
+      end
     end
 
     # Returns the value of DEVELOPER_DIR

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -66,7 +66,12 @@ module RunLoop
     # @note Never call this directly.  Always create an XCTool instance
     #   and allow it to derive the path to the Xcode toolchain.
     def self.developer_dir
-      ENV['DEVELOPER_DIR']
+      value = ENV['DEVELOPER_DIR']
+      if !value || value == ''
+        nil
+      else
+        value
+      end
     end
   end
 end

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -39,7 +39,12 @@ module RunLoop
 
     # Returns the value of BUNDLE_ID
     def self.bundle_id
-      ENV['BUNDLE_ID']
+      value = ENV['BUNDLE_ID']
+      if !value || value == ''
+        nil
+      else
+        value
+      end
     end
 
     # Returns to the path to the app bundle (simulator builds).

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -127,4 +127,15 @@ describe RunLoop::Environment do
     end
   end
 
+  describe '.developer_dir' do
+    it 'return value' do
+      stub_env('DEVELOPER_DIR', '/some/xcode/path')
+      expect(RunLoop::Environment.developer_dir).to be == '/some/xcode/path'
+    end
+
+    it 'returns nil if value is the empty string' do
+      stub_env('DEVELOPER_DIR', '')
+      expect(RunLoop::Environment.developer_dir).to be == nil
+    end
+  end
 end

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -66,9 +66,16 @@ describe RunLoop::Environment do
     end
   end
 
-  it '.bundle_id' do
-    stub_env('BUNDLE_ID', 'com.example.Foo')
-    expect(RunLoop::Environment.bundle_id).to be == 'com.example.Foo'
+  describe '.bundle_id' do
+    it 'correctly returns bundle id env var' do
+      stub_env('BUNDLE_ID', 'com.example.Foo')
+      expect(RunLoop::Environment.bundle_id).to be == 'com.example.Foo'
+    end
+
+    it 'returns nil when bundle id is the empty string' do
+      stub_env('BUNDLE_ID', '')
+      expect(RunLoop::Environment.bundle_id).to be == nil
+    end
   end
 
   describe '.path_to_app_bundle' do

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -102,11 +102,29 @@ describe RunLoop::Environment do
       allow(ENV).to receive(:[]).with('APP').and_return('/some/other/path.app')
       expect(RunLoop::Environment.path_to_app_bundle).to be == abp
     end
-  end
 
-  it '.developer_dir' do
-    stub_env('DEVELOPER_DIR', '/some/xcode/path')
-    expect(RunLoop::Environment.developer_dir).to be == '/some/xcode/path'
+    describe 'empty strings should be interpreted as nil' do
+      it 'APP_BUNDLE_PATH' do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('APP_BUNDLE_PATH').and_return('')
+        allow(ENV).to receive(:[]).with('APP').and_return(nil)
+        expect(RunLoop::Environment.path_to_app_bundle).to be == nil
+      end
+
+      it 'APP' do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('APP_BUNDLE_PATH').and_return(nil)
+        allow(ENV).to receive(:[]).with('APP').and_return('')
+        expect(RunLoop::Environment.path_to_app_bundle).to be == nil
+      end
+
+      it 'both' do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('APP_BUNDLE_PATH').and_return('')
+        allow(ENV).to receive(:[]).with('APP').and_return('')
+        expect(RunLoop::Environment.path_to_app_bundle).to be == nil
+      end
+    end
   end
 
 end


### PR DESCRIPTION
### Motivation

* **if an ENV var is `""` - the empty string - we are incorrectly treating it as truthy** #151