### PR TITLE
simctl bridge can uninstall an app

### DIFF
--- a/lib/run_loop/simctl/bridge.rb
+++ b/lib/run_loop/simctl/bridge.rb
@@ -237,7 +237,9 @@ module RunLoop::Simctl
     end
 
     def launch_simulator
-      `xcrun open -a "#{@simulator_app_path}" --args -CurrentDeviceUDID #{udid}`
+      args = ['open', '-a', @simulator_app_path, '--args', '-CurrentDeviceUDID', udid]
+      pid = spawn('xcrun', *args)
+      Process.detach(pid)
       sleep(5)
     end
 

--- a/spec/integration/simctl/bridge_spec.rb
+++ b/spec/integration/simctl/bridge_spec.rb
@@ -9,11 +9,28 @@ describe RunLoop::Simctl::Bridge do
     end
   end
 
-  it 'can install an app and launch the simulator' do
+  it 'can launch a specific simulator' do
+    device = select_random_shutdown_sim
+    abp = Resources.shared.app_bundle_path
+    bridge = RunLoop::Simctl::Bridge.new(device, abp)
+    bridge.launch_simulator
+  end
+
+  it 'can install an app on a simulator and launch it' do
     device = select_random_shutdown_sim
     abp = Resources.shared.app_bundle_path
     bridge = RunLoop::Simctl::Bridge.new(device, abp)
     expect(bridge.launch).to be == true
+  end
+
+  it 'can install an app, launch it, and uninstall it' do
+    device = select_random_shutdown_sim
+    abp = Resources.shared.app_bundle_path
+    bridge = RunLoop::Simctl::Bridge.new(device, abp)
+    expect(bridge.launch).to be == true
+
+    bridge = RunLoop::Simctl::Bridge.new(device, abp)
+    expect(bridge.uninstall).to be == true
   end
 
 end


### PR DESCRIPTION
### Motivation

Two items:

1. **Xcode 6.3 - instruments cannot launch an app that is already installed on iOS 8.3 Simulators** https://github.com/calabash/calabash-ios/issues/744
2. run-loop should provide a way to uninstall an app to avoid stale binaries

@rasmuskl @acroos @john7doe 
