### PR TITLE
Make simctl bridge production ready

### DIFF
--- a/lib/run_loop/simctl/bridge.rb
+++ b/lib/run_loop/simctl/bridge.rb
@@ -39,10 +39,6 @@ module RunLoop::Simctl
       terminate_core_simulator_processes
     end
 
-    def fullname
-      @fullname ||= device.instruments_identifier
-    end
-
     def bundle_identifier
       app.bundle_identifier
     end
@@ -167,7 +163,7 @@ module RunLoop::Simctl
       puts "Waited for #{timeout} seconds for '#{bundle_identifier}' to install."
 
       unless is_installed
-        raise "Expected app to be installed on #{fullname}"
+        raise "Expected app to be installed on #{device.instruments_identifier}"
       end
 
       true
@@ -190,7 +186,7 @@ module RunLoop::Simctl
       puts "Waited for #{timeout} seconds for '#{bundle_identifier}' to uninstall."
 
       unless not_installed
-        raise "Expected app to be installed on #{fullname}"
+        raise "Expected app to be installed on #{device.instruments_identifier}"
       end
 
       true
@@ -200,7 +196,7 @@ module RunLoop::Simctl
       return true if update_device_state == 'Shutdown'
 
       if device.state != 'Booted'
-        raise "Cannot handle state '#{device.state}' for #{fullname}"
+        raise "Cannot handle state '#{device.state}' for #{device.instruments_identifier}"
       end
 
       args = "simctl shutdown #{device.udid}".split(' ')
@@ -208,7 +204,7 @@ module RunLoop::Simctl
         err = stderr.read.strip
         exit_status = status.value.exitstatus
         if exit_status != 0
-          raise "Could not shutdown #{fullname}: #{exit_status} => '#{err}'"
+          raise "Could not shutdown #{device.instruments_identifier}: #{exit_status} => '#{err}'"
         end
       end
       wait_for_device_state('Shutdown')
@@ -218,7 +214,7 @@ module RunLoop::Simctl
       return true if update_device_state == 'Booted'
 
       if device.state != 'Shutdown'
-        raise "Cannot handle state '#{device.state}' for #{fullname}"
+        raise "Cannot handle state '#{device.state}' for #{device.instruments_identifier}"
       end
 
       args = "simctl boot #{device.udid}".split(' ')
@@ -226,7 +222,7 @@ module RunLoop::Simctl
         err = stderr.read.strip
         exit_status = status.value.exitstatus
         if exit_status != 0
-          raise "Could not boot #{fullname}: #{exit_status} => '#{err}'"
+          raise "Could not boot #{device.instruments_identifier}: #{exit_status} => '#{err}'"
         end
       end
       wait_for_device_state('Booted')
@@ -285,7 +281,7 @@ module RunLoop::Simctl
         err = stderr.read.strip
         exit_status = process_status.value.exitstatus
         unless exit_status == 0
-          raise "Could not simctl launch '#{bundle_identifier}' on '#{fullname}': #{exit_status} => '#{err}'"
+          raise "Could not simctl launch '#{bundle_identifier}' on '#{device.instruments_identifier}': #{exit_status} => '#{err}'"
         end
       end
 

--- a/lib/run_loop/simctl/bridge.rb
+++ b/lib/run_loop/simctl/bridge.rb
@@ -7,9 +7,7 @@ module RunLoop::Simctl
   # @!visibility private
   # This is not a public API.  You have been warned.
   #
-  # TODO Rename this class.
   # TODO Some code is duplicated from sim_control.rb
-  # TODO Uninstall
   # TODO Reinstall if checksum does not match.
   # TODO Analyze terminate_core_simulator_processes
   class Bridge

--- a/lib/run_loop/simctl/bridge.rb
+++ b/lib/run_loop/simctl/bridge.rb
@@ -50,12 +50,12 @@ module RunLoop::Simctl
       }.call
     end
 
-    def update_device_state
-
+    def update_device_state(options={})
+      merged_options = UPDATE_DEVICE_STATE_OPTS.merge(options)
       debug_logging = RunLoop::Environment.debug?
 
-      interval = UPDATE_DEVICE_STATE_OPTS[:interval]
-      tries = UPDATE_DEVICE_STATE_OPTS[:tries]
+      interval = merged_options[:interval]
+      tries = merged_options[:tries]
 
       on_retry = Proc.new do |_, try, elapsed_time, next_interval|
         if debug_logging

--- a/lib/run_loop/simctl/bridge.rb
+++ b/lib/run_loop/simctl/bridge.rb
@@ -39,10 +39,6 @@ module RunLoop::Simctl
       terminate_core_simulator_processes
     end
 
-    def bundle_identifier
-      app.bundle_identifier
-    end
-
     def executable_name
       app.executable_name
     end
@@ -140,7 +136,7 @@ module RunLoop::Simctl
       sim_app_dir = simulator_app_dir
       return false if !File.exist?(sim_app_dir)
       app_path = Dir.glob("#{sim_app_dir}/**/*.app").detect do |path|
-        RunLoop::App.new(path).bundle_identifier == bundle_identifier
+        RunLoop::App.new(path).bundle_identifier == app.bundle_identifier
       end
 
       !app_path.nil?
@@ -160,7 +156,7 @@ module RunLoop::Simctl
         sleep delay
       end
 
-      puts "Waited for #{timeout} seconds for '#{bundle_identifier}' to install."
+      puts "Waited for #{timeout} seconds for '#{app.bundle_identifier}' to install."
 
       unless is_installed
         raise "Expected app to be installed on #{device.instruments_identifier}"
@@ -183,7 +179,7 @@ module RunLoop::Simctl
         sleep delay
       end
 
-      puts "Waited for #{timeout} seconds for '#{bundle_identifier}' to uninstall."
+      puts "Waited for #{timeout} seconds for '#{app.bundle_identifier}' to uninstall."
 
       unless not_installed
         raise "Expected app to be installed on #{device.instruments_identifier}"
@@ -238,7 +234,7 @@ module RunLoop::Simctl
         err = stderr.read.strip
         exit_status = process_status.value.exitstatus
         if exit_status != 0
-          raise "Could not install '#{bundle_identifier}': #{exit_status} => '#{err}'."
+          raise "Could not install '#{app.bundle_identifier}': #{exit_status} => '#{err}'."
         end
       end
 
@@ -256,7 +252,7 @@ module RunLoop::Simctl
         err = stderr.read.strip
         exit_status = process_status.value.exitstatus
         if exit_status != 0
-          raise "Could not uninstall '#{bundle_identifier}': #{exit_status} => '#{err}'."
+          raise "Could not uninstall '#{app.bundle_identifier}': #{exit_status} => '#{err}'."
         end
       end
 
@@ -276,12 +272,12 @@ module RunLoop::Simctl
       install
       launch_simulator
 
-      args = "simctl launch #{device.udid} #{bundle_identifier}".split(' ')
+      args = "simctl launch #{device.udid} #{app.bundle_identifier}".split(' ')
       Open3.popen3('xcrun', *args) do |_, _, stderr, process_status|
         err = stderr.read.strip
         exit_status = process_status.value.exitstatus
         unless exit_status == 0
-          raise "Could not simctl launch '#{bundle_identifier}' on '#{device.instruments_identifier}': #{exit_status} => '#{err}'"
+          raise "Could not simctl launch '#{app.bundle_identifier}' on '#{device.instruments_identifier}': #{exit_status} => '#{err}'"
         end
       end
 

--- a/lib/run_loop/simctl/bridge.rb
+++ b/lib/run_loop/simctl/bridge.rb
@@ -7,10 +7,6 @@ module RunLoop::Simctl
   # @!visibility private
   # This is not a public API.  You have been warned.
   #
-  # Proof of concept for using simctl to install and launch an app on a device.
-  #
-  # Do not use this in production code.
-  #
   # TODO Rename this class.
   # TODO Some code is duplicated from sim_control.rb
   # TODO Uninstall

--- a/lib/run_loop/simctl/bridge.rb
+++ b/lib/run_loop/simctl/bridge.rb
@@ -39,10 +39,6 @@ module RunLoop::Simctl
       terminate_core_simulator_processes
     end
 
-    def executable_name
-      app.executable_name
-    end
-
     def simulator_app_dir
       @simulator_app_dir ||= lambda {
         device_dir = File.expand_path('~/Library/Developer/CoreSimulator/Devices')
@@ -281,7 +277,7 @@ module RunLoop::Simctl
         end
       end
 
-      RunLoop::ProcessWaiter.new(executable_name, WAIT_FOR_APP_LAUNCH_OPTS).wait_for_any
+      RunLoop::ProcessWaiter.new(app.executable_name, WAIT_FOR_APP_LAUNCH_OPTS).wait_for_any
       true
     end
 

--- a/spec/integration/simctl/bridge_spec.rb
+++ b/spec/integration/simctl/bridge_spec.rb
@@ -1,36 +1,30 @@
 describe RunLoop::Simctl::Bridge do
 
-  def select_random_shutdown_sim
-    simctl = RunLoop::SimControl.new
-    simctl.simulators.shuffle.detect do |device|
+  let (:abp) { Resources.shared.app_bundle_path }
+  let (:sim_control) { RunLoop::SimControl.new }
+  let (:device) {
+    sim_control.simulators.shuffle.detect do |device|
       [device.state == 'Shutdown',
-       device.name != 'rspec-test-device',
+       device.name != 'rspec-0test-device',
        !device.name[/Resizable/,0]].all?
     end
-  end
+  }
+
+  let(:bridge) { RunLoop::Simctl::Bridge.new(device, abp) }
 
   it 'can launch a specific simulator' do
-    device = select_random_shutdown_sim
-    abp = Resources.shared.app_bundle_path
-    bridge = RunLoop::Simctl::Bridge.new(device, abp)
     bridge.launch_simulator
   end
 
   it 'can install an app on a simulator and launch it' do
-    device = select_random_shutdown_sim
-    abp = Resources.shared.app_bundle_path
-    bridge = RunLoop::Simctl::Bridge.new(device, abp)
     expect(bridge.launch).to be == true
   end
 
   it 'can install an app, launch it, and uninstall it' do
-    device = select_random_shutdown_sim
-    abp = Resources.shared.app_bundle_path
-    bridge = RunLoop::Simctl::Bridge.new(device, abp)
     expect(bridge.launch).to be == true
 
-    bridge = RunLoop::Simctl::Bridge.new(device, abp)
-    expect(bridge.uninstall).to be == true
+    new_bridge = RunLoop::Simctl::Bridge.new(device, abp)
+    expect(new_bridge.uninstall).to be == true
+    expect(new_bridge.app_is_installed?).to be_falsey
   end
-
 end

--- a/spec/integration/simctl/bridge_spec.rb
+++ b/spec/integration/simctl/bridge_spec.rb
@@ -27,4 +27,14 @@ describe RunLoop::Simctl::Bridge do
     expect(new_bridge.uninstall).to be == true
     expect(new_bridge.app_is_installed?).to be_falsey
   end
+
+  describe '#update_device_state' do
+    it 'when no valid device state can be found' do
+      expect(bridge).to receive(:fetch_matching_device).at_least(:once).and_return(bridge.device)
+      expect(bridge.device).to receive(:state).at_least(100).times.and_return(nil)
+      expect {
+        bridge.update_device_state
+      }.to raise_error(RunLoop::Simctl::SimctlError)
+    end
+  end
 end

--- a/spec/integration/simctl/bridge_spec.rb
+++ b/spec/integration/simctl/bridge_spec.rb
@@ -30,10 +30,11 @@ describe RunLoop::Simctl::Bridge do
 
   describe '#update_device_state' do
     it 'when no valid device state can be found' do
+      options = {:tries => 5, :interval => 0.1}
       expect(bridge).to receive(:fetch_matching_device).at_least(:once).and_return(bridge.device)
-      expect(bridge.device).to receive(:state).at_least(100).times.and_return(nil)
+      expect(bridge.device).to receive(:state).at_least(5).times.and_return(nil)
       expect {
-        bridge.update_device_state
+        bridge.update_device_state(options)
       }.to raise_error(RunLoop::Simctl::SimctlError)
     end
   end

--- a/spec/lib/simctl/bridge_spec.rb
+++ b/spec/lib/simctl/bridge_spec.rb
@@ -63,6 +63,9 @@ describe RunLoop::Simctl::Bridge do
       expect(bridge).to receive(:fetch_matching_device).and_return(device)
       expect(device).to receive(:state).at_least(:once).and_return('Anything but nil or empty string')
       expect(bridge.update_device_state).to be == 'Anything but nil or empty string'
+
+      # Unexpected.  Device#state is immutable, so we replace Simctl @device
+      # when this method is called.
       expect(bridge.device).to be == device
     end
   end

--- a/spec/lib/simctl/bridge_spec.rb
+++ b/spec/lib/simctl/bridge_spec.rb
@@ -10,8 +10,9 @@ describe RunLoop::Simctl::Bridge do
     end
   }
 
+  let(:bridge) { RunLoop::Simctl::Bridge.new(device, abp) }
+
   describe '.new' do
-    let(:bridge) { RunLoop::Simctl::Bridge.new(device, abp) }
     it 'populates its attributes' do
       expect(bridge.sim_control).to be_a_kind_of(RunLoop::SimControl)
       expect(bridge.app).to be_a_kind_of(RunLoop::App)
@@ -33,6 +34,20 @@ describe RunLoop::Simctl::Bridge do
       expect {
         RunLoop::Simctl::Bridge.new(device, abp)
       }.to raise_error
+    end
+  end
+
+  describe '#simulator_app_dir' do
+    it 'device version < 8.0' do
+      expect(bridge.device).to receive(:version).and_return(RunLoop::Version.new('7.1'))
+      path = bridge.simulator_app_dir
+      expect(path[/Bundle/,0]).to be_falsey
+    end
+
+    it 'device version >= 8.0' do
+      expect(bridge.device).to receive(:version).and_return(RunLoop::Version.new('8.0'))
+      path = bridge.simulator_app_dir
+      expect(path[/Bundle/,0]).to be_truthy
     end
   end
 end

--- a/spec/lib/simctl/bridge_spec.rb
+++ b/spec/lib/simctl/bridge_spec.rb
@@ -1,0 +1,38 @@
+describe RunLoop::Simctl::Bridge do
+
+  let (:abp) { Resources.shared.app_bundle_path }
+  let (:sim_control) { RunLoop::SimControl.new }
+  let (:device) {
+    sim_control.simulators.shuffle.detect do |device|
+      [device.state == 'Shutdown',
+       device.name != 'rspec-0test-device',
+       !device.name[/Resizable/,0]].all?
+    end
+  }
+
+  describe '.new' do
+    let(:bridge) { RunLoop::Simctl::Bridge.new(device, abp) }
+    it 'populates its attributes' do
+      expect(bridge.sim_control).to be_a_kind_of(RunLoop::SimControl)
+      expect(bridge.app).to be_a_kind_of(RunLoop::App)
+      expect(bridge.device).to be_a_kind_of(RunLoop::Device)
+      path_to_sim_bundle = bridge.instance_variable_get(:@path_to_ios_sim_app_bundle)
+      expect(Dir.exist?(path_to_sim_bundle)).to be_truthy
+    end
+
+    it 'quits the simulator' do
+      expect(sim_control.sim_is_running?).to be_falsey
+    end
+
+    it 'the device is shutdown' do
+      expect(bridge.update_device_state).to be == 'Shutdown'
+    end
+
+    it 'raises an error if App cannot be created from app bundle path' do
+      allow_any_instance_of(RunLoop::App).to receive(:valid?).and_return(false)
+      expect {
+        RunLoop::Simctl::Bridge.new(device, abp)
+      }.to raise_error
+    end
+  end
+end

--- a/spec/lib/simctl/bridge_spec.rb
+++ b/spec/lib/simctl/bridge_spec.rb
@@ -50,4 +50,20 @@ describe RunLoop::Simctl::Bridge do
       expect(path[/Bundle/,0]).to be_truthy
     end
   end
+
+  describe '#update_device_state' do
+    it 'raises error when no matching device can be found' do
+      expect(bridge).to receive(:fetch_matching_device).and_return(nil)
+      expect {
+        bridge.update_device_state
+      }.to raise_error(RuntimeError)
+    end
+
+    it 'returns valid device state' do
+      expect(bridge).to receive(:fetch_matching_device).and_return(device)
+      expect(device).to receive(:state).at_least(:once).and_return('Anything but nil or empty string')
+      expect(bridge.update_device_state).to be == 'Anything but nil or empty string'
+      expect(bridge.device).to be == device
+    end
+  end
 end


### PR DESCRIPTION
### Motivation

Cleaned up the Simctl::Bridge implementation so it can be used in releases.

Two items:

1. **Xcode 6.3 - instruments cannot launch an app that is already installed on iOS 8.3 Simulators** https://github.com/calabash/calabash-ios/issues/744
2. run-loop should provide a way to uninstall an app to avoid stale binaries

@rasmuskl @acroos @john7doe 