### PR TITLE
Implement fix for Xcode 6.3 + iOS 8.3 simulators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ rvm:
   - 2.0.0
   - 2.2.1
 
+env: CAL_SIM_POST_LAUNCH_WAIT=4.0
+
 notifications:
   email:
     recipients:

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -105,6 +105,18 @@ module RunLoop
       end
     end
 
+    # Prepares the simulator for running.
+    #
+    # 1. enabling accessibility and software keyboard
+    # 2. installing / uninstalling apps
+    # 3. NYI resetting the app sandbox
+    #
+    # @todo only enable accessibility on the targeted simulator and only if necessary
+    def self.prepare_simulator(merged_options, sim_control)
+      # Surprise!  This also enables software keyboard in CoreSimulator environments.
+      sim_control.enable_accessibility_on_sims({:verbose => false})
+    end
+
     def self.run_with_options(options)
       before = Time.now
 
@@ -185,9 +197,8 @@ module RunLoop
       merged_options = options.merge(discovered_options)
 
       if self.simulator_target?(merged_options, sim_control)
-        # @todo only enable accessibility on the targeted simulator
-        sim_control.enable_accessibility_on_sims({:verbose => false})
         self.expect_compatible_simulator_architecture(merged_options, sim_control)
+        self.prepare_simulator(merged_options, sim_control)
       end
 
       self.log_run_loop_options(merged_options, xctools)

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -503,7 +503,7 @@ module RunLoop
         end
 
         if /FBSOpenApplicationErrorDomain error/.match(output)
-          msg = "Instrument failed to launch app: 'FBSOpenApplicationErrorDomain error 8"
+          msg = "Instruments failed to launch app: 'FBSOpenApplicationErrorDomain error 8"
           if RunLoop::Environment.debug?
             self.log_instruments_error(msg)
           end
@@ -511,7 +511,7 @@ module RunLoop
         end
 
         if /Error: Script threw an uncaught JavaScript error: unknown JavaScript exception/.match(output)
-          msg = "Instrument failed to launch: because of an unknown JavaScript exception"
+          msg = "Instruments failed to launch: because of an unknown JavaScript exception"
           if RunLoop::Environment.debug?
             self.log_instruments_error(msg)
           end

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -48,23 +48,6 @@ module RunLoop
       RunLoop::Logging.log_debug(logger, "\n" + message)
     end
 
-    # @deprecated since 1.0.0
-    # still used extensively in calabash-ios launcher
-    def self.above_or_eql_version?(target_version, xcode_version)
-      if target_version.is_a?(RunLoop::Version)
-        target = target_version
-      else
-        target = RunLoop::Version.new(target_version)
-      end
-
-      if xcode_version.is_a?(RunLoop::Version)
-        xcode = xcode_version
-      else
-        xcode = RunLoop::Version.new(xcode_version)
-      end
-      target >= xcode
-    end
-
     def self.script_for_key(key)
       if SCRIPTS[key].nil?
         return nil
@@ -607,6 +590,23 @@ module RunLoop
     # @deprecated 1.0.0 replaced with Xctools#version
     def self.xcode_version(xctools=RunLoop::XCTools.new)
       xctools.xcode_version.to_s
+    end
+
+    # @deprecated since 1.0.0
+    # still used extensively in calabash-ios launcher
+    def self.above_or_eql_version?(target_version, xcode_version)
+      if target_version.is_a?(RunLoop::Version)
+        target = target_version
+      else
+        target = RunLoop::Version.new(target_version)
+      end
+
+      if xcode_version.is_a?(RunLoop::Version)
+        xcode = xcode_version
+      else
+        xcode = RunLoop::Version.new(xcode_version)
+      end
+      target >= xcode
     end
   end
 

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -409,11 +409,6 @@ module RunLoop
       return udid, bundle_dir_or_bundle_id
     end
 
-    # @deprecated 1.0.0 replaced with Xctools#version
-    def self.xcode_version(xctools=RunLoop::XCTools.new)
-      xctools.xcode_version.to_s
-    end
-
     def self.create_uia_pipe(repl_path)
       begin
         Timeout::timeout(5, RunLoop::TimeoutError) do
@@ -607,6 +602,11 @@ module RunLoop
     # @deprecated 1.0.5
     def self.instruments_pids
       RunLoop::Instruments.new.instruments_pids
+    end
+
+    # @deprecated 1.0.0 replaced with Xctools#version
+    def self.xcode_version(xctools=RunLoop::XCTools.new)
+      xctools.xcode_version.to_s
     end
   end
 

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -493,8 +493,7 @@ module RunLoop
 
         if /AXError: Could not auto-register for pid status change/.match(output)
           if /kAXErrorServerNotFound/.match(output)
-            $stderr.puts "\n\n****** Accessibility is not enabled on device/simulator, please enable it *** \n\n"
-            $stderr.flush
+            self.log_instruments_error('Accessibility is not enabled on device/simulator, please enable it.')
           end
           raise RunLoop::TimeoutError.new('AXError: Could not auto-register for pid status change')
         end

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -545,11 +545,6 @@ module RunLoop
       result
     end
 
-    # @deprecated 1.0.5
-    def self.pids_for_run_loop(run_loop, &block)
-      RunLoop::Instruments.new.instruments_pids(&block)
-    end
-
     def self.automation_template(xctools, candidate = RunLoop::Environment.trace_template)
       unless candidate && File.exist?(candidate)
         candidate = default_tracetemplate xctools
@@ -619,6 +614,10 @@ module RunLoop
       end
       target >= xcode
     end
-  end
 
+    # @deprecated 1.0.5
+    def self.pids_for_run_loop(run_loop, &block)
+      RunLoop::Instruments.new.instruments_pids(&block)
+    end
+  end
 end

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -73,5 +73,33 @@ module RunLoop
         value
       end
     end
+
+    # Returns the value of CAL_SIM_POST_LAUNCH_WAIT
+    #
+    # Controls how long to wait _after_ the simulator is opened.
+    #
+    # Defaults to 1.0
+    #
+    # In CoreSimulator environments, the iOS Simulator starts many async
+    # processes that must be allowed to finish before we start operating on the
+    # simulator.  Until we find the right combination of processes to wait for,
+    # this variable will give us the opportunity to control how long we wait.
+    #
+    # Essential for managed envs like Travis + Jenkins and on slower machines.
+    def self.sim_post_launch_wait
+      value = ENV['CAL_SIM_POST_LAUNCH_WAIT']
+      float = nil
+      begin
+        float = value.to_f
+      rescue NoMethodError => _
+
+      end
+
+      if float.nil? || float == 0.0
+        nil
+      else
+        float
+      end
+    end
   end
 end

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -78,7 +78,7 @@ module RunLoop
     #
     # Controls how long to wait _after_ the simulator is opened.
     #
-    # Defaults to 1.0
+    # The default wait time is 1.0.  This was arrived at through testing.
     #
     # In CoreSimulator environments, the iOS Simulator starts many async
     # processes that must be allowed to finish before we start operating on the

--- a/lib/run_loop/process_waiter.rb
+++ b/lib/run_loop/process_waiter.rb
@@ -13,7 +13,7 @@ module RunLoop
     # Collect a list of Integer pids.
     # @return [Array<Integer>] An array of integer pids for the `process_name`
     def pids
-      process_info = `ps x -o pid,comm | grep -v grep | grep #{process_name}`
+      process_info = `ps x -o pid,comm | grep -v grep | grep '#{process_name}'`
       process_array = process_info.split("\n")
       process_array.map { |process| process.split(' ').first.strip.to_i }
     end

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -82,7 +82,7 @@ module RunLoop
     # @todo Consider migrating apple script call to xctools.
     def launch_sim(opts={})
       unless sim_is_running?
-        default_opts = {:post_launch_wait => 2.0,
+        default_opts = {:post_launch_wait => RunLoop::Environment.sim_post_launch_wait || 2.0,
                         :hide_after => false}
         merged_opts = default_opts.merge(opts)
         `xcrun open -a "#{sim_app_path}"`
@@ -107,7 +107,7 @@ module RunLoop
     #  tired of your editor losing focus. :)
     def relaunch_sim(opts={})
       default_opts = {:post_quit_wait => 1.0,
-                      :post_launch_wait => 2.0,
+                      :post_launch_wait => RunLoop::Environment.sim_post_launch_wait || 2.0,
                       :hide_after => false}
       merged_opts = default_opts.merge(opts)
       quit_sim(merged_opts)
@@ -199,7 +199,7 @@ module RunLoop
     #  **NOTE:** This option is ignored in Xcode < 6.
     def reset_sim_content_and_settings(opts={})
       default_opts = {:post_quit_wait => 1.0,
-                      :post_launch_wait => 3.0,
+                      :post_launch_wait => RunLoop::Environment.sim_post_launch_wait || 3.0,
                       :hide_after => false,
                       :sim_udid => nil}
       merged_opts = default_opts.merge(opts)

--- a/lib/run_loop/simctl/bridge.rb
+++ b/lib/run_loop/simctl/bridge.rb
@@ -32,6 +32,11 @@ module RunLoop::Simctl
 
       @device = device
 
+      # It may seem weird to do this in the initialize, but you cannot make
+      # simctl calls successfully unless the simulator is:
+      # 1. closed
+      # 2. the device you are trying to operate on is Shutdown
+      # 3. the CoreSimulator processes are terminated
       RunLoop::SimControl.terminate_all_sims
       shutdown
       terminate_core_simulator_processes

--- a/lib/run_loop/simctl/bridge.rb
+++ b/lib/run_loop/simctl/bridge.rb
@@ -257,7 +257,11 @@ module RunLoop::Simctl
       args = ['open', '-a', @path_to_ios_sim_app_bundle, '--args', '-CurrentDeviceUDID', device.udid]
       pid = spawn('xcrun', *args)
       Process.detach(pid)
-      sleep(5)
+      RunLoop::ProcessWaiter.new('CoreSimulatorBridge', WAIT_FOR_APP_LAUNCH_OPTS).wait_for_any
+      RunLoop::ProcessWaiter.new('iOS Simulator', WAIT_FOR_APP_LAUNCH_OPTS).wait_for_any
+      RunLoop::ProcessWaiter.new('SimulatorBridge', WAIT_FOR_APP_LAUNCH_OPTS).wait_for_any
+      wait_for_device_state 'Booted'
+      sleep(SIM_POST_LAUNCH_WAIT)
     end
 
     def launch
@@ -303,6 +307,8 @@ module RunLoop::Simctl
                 :tries => 100,
                 :interval => 0.1
           }
+
+    SIM_POST_LAUNCH_WAIT = RunLoop::Environment.sim_post_launch_wait || 1.0
 
     # @!visibility private
     def fetch_matching_device

--- a/spec/integration/simctl/bridge_spec.rb
+++ b/spec/integration/simctl/bridge_spec.rb
@@ -1,41 +1,45 @@
-describe RunLoop::Simctl::Bridge do
+unless Luffa::Environment.travis_ci?
 
-  let (:abp) { Resources.shared.app_bundle_path }
-  let (:sim_control) { RunLoop::SimControl.new }
-  let (:device) {
-    sim_control.simulators.shuffle.detect do |device|
-      [device.state == 'Shutdown',
-       device.name != 'rspec-0test-device',
-       !device.name[/Resizable/,0]].all?
+  describe RunLoop::Simctl::Bridge do
+
+    let (:abp) { Resources.shared.app_bundle_path }
+    let (:sim_control) { RunLoop::SimControl.new }
+    let (:device) {
+      sim_control.simulators.shuffle.detect do |device|
+        [device.state == 'Shutdown',
+         device.name != 'rspec-0test-device',
+         !device.name[/Resizable/,0]].all?
+      end
+    }
+
+    let(:bridge) { RunLoop::Simctl::Bridge.new(device, abp) }
+
+    it 'can launch a specific simulator' do
+      bridge.launch_simulator
     end
-  }
 
-  let(:bridge) { RunLoop::Simctl::Bridge.new(device, abp) }
+    it 'can install an app on a simulator and launch it' do
+      expect(bridge.launch).to be == true
+    end
 
-  it 'can launch a specific simulator' do
-    bridge.launch_simulator
-  end
+    it 'can install an app, launch it, and uninstall it' do
+      expect(bridge.launch).to be == true
 
-  it 'can install an app on a simulator and launch it' do
-    expect(bridge.launch).to be == true
-  end
+      new_bridge = RunLoop::Simctl::Bridge.new(device, abp)
+      expect(new_bridge.uninstall).to be == true
+      expect(new_bridge.app_is_installed?).to be_falsey
+    end
 
-  it 'can install an app, launch it, and uninstall it' do
-    expect(bridge.launch).to be == true
-
-    new_bridge = RunLoop::Simctl::Bridge.new(device, abp)
-    expect(new_bridge.uninstall).to be == true
-    expect(new_bridge.app_is_installed?).to be_falsey
-  end
-
-  describe '#update_device_state' do
-    it 'when no valid device state can be found' do
-      options = {:tries => 5, :interval => 0.1}
-      expect(bridge).to receive(:fetch_matching_device).at_least(:once).and_return(bridge.device)
-      expect(bridge.device).to receive(:state).at_least(5).times.and_return(nil)
-      expect {
-        bridge.update_device_state(options)
-      }.to raise_error(RunLoop::Simctl::SimctlError)
+    describe '#update_device_state' do
+      it 'when no valid device state can be found' do
+        options = {:tries => 5, :interval => 0.1}
+        expect(bridge).to receive(:fetch_matching_device).at_least(:once).and_return(bridge.device)
+        expect(bridge.device).to receive(:state).at_least(5).times.and_return(nil)
+        expect {
+          bridge.update_device_state(options)
+        }.to raise_error(RunLoop::Simctl::SimctlError)
+      end
     end
   end
+
 end

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -138,4 +138,29 @@ describe RunLoop::Environment do
       expect(RunLoop::Environment.developer_dir).to be == nil
     end
   end
+
+  describe '.sim_post_launch_wait' do
+    it 'returns float value' do
+      stub_env('CAL_SIM_POST_LAUNCH_WAIT', '1.0')
+      expect(RunLoop::Environment.sim_post_launch_wait).to be == 1.0
+
+      stub_env('CAL_SIM_POST_LAUNCH_WAIT', 1.0)
+      expect(RunLoop::Environment.sim_post_launch_wait).to be == 1.0
+
+      stub_env('CAL_SIM_POST_LAUNCH_WAIT', '1')
+      expect(RunLoop::Environment.sim_post_launch_wait).to be == 1.0
+    end
+
+    it 'returns nil if the value cannot be converted to non-zero float' do
+      stub_env('CAL_SIM_POST_LAUNCH_WAIT', '')
+      expect(RunLoop::Environment.sim_post_launch_wait).to be == nil
+
+      stub_env({'CAL_SIM_POST_LAUNCH_WAIT' => nil})
+      expect(RunLoop::Environment.sim_post_launch_wait).to be == nil
+
+      stub_env('CAL_SIM_POST_LAUNCH_WAIT', true)
+      expect(RunLoop::Environment.sim_post_launch_wait).to be == nil
+    end
+  end
+
 end


### PR DESCRIPTION
### Motivation

Two items:

1. **Xcode 6.3 - instruments cannot launch an app that is already installed on iOS 8.3 Simulators** https://github.com/calabash/calabash-ios/issues/744
2. run-loop should provide a way to uninstall an app to avoid stale binaries

@rasmuskl @acroos @john7doe 

cc @krukow 

### Testing

I tested with the WebView and SmokeApp against Xcode 6.3:

* iOS 8.3
* iOS 8.2
* iOS 8.1
* iOS 7.1

iOS 7.0.3 does not launch on Yosemite (known limitation).


