### PR TITLE
Release/1.3.2: Wrong merge branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Change Log
 
+### 1.3.2
+
+* 'run-loop simctl install' command line interface #175
+* Retriable patch needs to retriable/version #173
+* Xcode 6.4b support #172
+
 ### 1.3.1
 
 This is a patch release for Xcode 6.3 + iOS 8.3 simulators.

--- a/lib/run_loop/version.rb
+++ b/lib/run_loop/version.rb
@@ -1,5 +1,5 @@
 module RunLoop
-  VERSION = '1.3.1'
+  VERSION = '1.3.2'
 
   # A model of a software release version that can be used to compare two versions.
   #


### PR DESCRIPTION
### 1.3.2

* 'run-loop simctl install' command line interface #175
* Retriable patch needs to retriable/version #173
* Xcode 6.4b support #172