### PR TITLE
Remove LOAD_PATH shifting; it is unnecessary

### DIFF
--- a/run_loop.gemspec
+++ b/run_loop.gemspec
@@ -1,11 +1,5 @@
 # -*- encoding: utf-8 -*-
-# This should not be necessary according to the RubyGem docs
-# http://guides.rubygems.org/patterns/
-# Search for LOAD_PATH
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-# This should be sufficient to get the gem version.
 require File.join(File.dirname(__FILE__), 'lib', 'run_loop', 'version')
 
 ruby_files = Dir.glob('{lib}/**/*')


### PR DESCRIPTION
### Motivation

http://guides.rubygems.org/patterns/

### LOADING CODE

At its core, RubyGems exists to help you manage Ruby’s $LOAD_PATH, which is how the require statement picks up new code. There’s several things you can do to make sure you’re loading code the right way.

**Respect the global load path**

When packaging your gem files, you need to be careful of what is in your lib directory. Every gem you have installed gets its lib directory appended onto your $LOAD_PATH. This means any file on the top level of the lib directory could get required.

**Mangling the load path**

Gems should not change the $LOAD_PATH variable. RubyGems manages this for you. Code like this should not be necessary:

```
lp = File.expand_path(File.dirname(__FILE__))
unless $LOAD_PATH.include?(lp)
  $LOAD_PATH.unshift(lp)
end
```

Or:

```
__DIR__ = File.dirname(__FILE__)

$LOAD_PATH.unshift __DIR__ unless
  $LOAD_PATH.include?(__DIR__) ||
  $LOAD_PATH.include?(File.expand_path(__DIR__))
```

When RubyGems activates a gem, it adds your package’s lib folder to the $LOAD_PATH ready to be required normally by another lib or application. It is safe to assume you can then require any file in your lib folder.