### PR TITLE
Simctl::Bridge should manage Xamarin's csproxy

### DIFF
--- a/lib/run_loop/simctl/bridge.rb
+++ b/lib/run_loop/simctl/bridge.rb
@@ -181,6 +181,11 @@ module RunLoop::Simctl
             #'com.apple.CoreSimulator.CoreSimulatorService',
             #'com.apple.CoreSimulator.SimVerificationService',
 
+            # Started by Xamarin Studio, this is the parent process of the
+            # processes launched by Xamarin's interaction with
+            # CoreSimulatorBridge
+            'csproxy',
+
             # Yes.
             'SimulatorBridge',
             'configd_sim',


### PR DESCRIPTION
### Motivation

Xamarin Studio uses a `csproxy` process to interact with the CoreSimulatorBridge.framework.

This is the parent process of the processes launched by Xamarin's interaction with CoreSimulatorBridge.

I recently ended up with a bunch of orphaned processes after force quitting Xamarin Studio.  The intent here is to kill the parent `csproxy` if it is running.