### PR TITLE
Add Device.device_with_identifer method

### DIFF
--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -33,6 +33,47 @@ module RunLoop
       end
     end
 
+    # Returns a device given a udid or name.  In the case of a physical device,
+    # the udid is the device identifier.  In the case of a simulator the name
+    # is the _instruments identifier_ as reported by
+    # `$ xcrun instruments -s devices` - this is the identifier that can be
+    # passed to instruments.
+    #
+    # @example
+    #  RunLoop::Device.device_with_identifier('iPhone 4s (8.3 Simulator')
+    #  RunLoop::Device.device_with_identifier('6E43E3CF-25F5-41CC-A833-588F043AE749')
+    #  RunLoop::Device.device_with_identifier('denis') # Simulator or device named 'denis'
+    #  RunLoop::Device.device_with_identifier('893688959205dc7eb48d603c558ede919ad8dd0c')
+    #
+    # Note that if you have a device and simulator with the same name, the
+    # simulator will always be selected.
+    #
+    # @param [String] udid_or_name A name or udid that identifies the device you
+    #  are looking for.
+    # @param [RunLoop::SimControl] sim_control An instance of SimControl that
+    #  can be used for looking of simulators and providing an XCTools instance.
+    #  Users should never need to provide this.
+    # @return [RunLoop::Device] A device that matches `udid_or_name`.
+    # @raise [ArgumentError] If no matching device can be found.
+    def self.device_with_identifier(udid_or_name, sim_control=RunLoop::SimControl.new)
+      simulator = sim_control.simulators.detect do |sim|
+        sim.instruments_identifier == udid_or_name ||
+              sim.udid == udid_or_name
+      end
+
+      return simulator if !simulator.nil?
+
+      physical_device = sim_control.xctools.instruments(:devices).detect do |device|
+        puts device
+        device.name == udid_or_name ||
+              device.udid == udid_or_name
+      end
+
+      return physical_device if !physical_device.nil?
+
+      raise ArgumentError, "Could not find a device with a UDID or name matching '#{udid_or_name}'"
+    end
+
     def to_s
       if simulator?
         "Simulator: #{instruments_identifier} #{udid} #{instruction_set}"

--- a/lib/run_loop/xctools.rb
+++ b/lib/run_loop/xctools.rb
@@ -168,6 +168,9 @@ module RunLoop
     # @example Getting list of known simulators.
     #  instruments(:sims) #=> < list of known simulators >
     #
+    # @example Getting list of physical devices.
+    #  instruments(:devices) #> < list of physical devices >
+    #
     # @param [Version] cmd controls the return value.  currently accepts `nil`,
     #   `:sims`, `:templates`, and `:version` as valid parameters
     # @return [String,Array,Version] based on the value of `cmd` version, a list known

--- a/spec/lib/device_spec.rb
+++ b/spec/lib/device_spec.rb
@@ -47,6 +47,60 @@ describe RunLoop::Device do
     end
   end
 
+  describe '.device_with_identifier' do
+    let(:sim_control) { RunLoop::SimControl.new }
+    it 'raises an error if no simulator or device with UDID or name is found' do
+      expect(sim_control).to receive(:simulators).and_return([])
+      expect(sim_control.xctools).to receive(:instruments).with(:devices).and_return([])
+      expect {
+        RunLoop::Device.device_with_identifier('a string or udid', sim_control)
+      }.to raise_error ArgumentError
+    end
+
+    describe 'physical devices' do
+      let(:device) { RunLoop::Device.new('denis',
+                                         '8.3',
+                                         '893688959205dc7eb48d603c558ede919ad8dd0c') }
+
+
+      it 'find by name' do
+        expect(sim_control).to receive(:simulators).and_return([])
+        expect(sim_control.xctools).to receive(:instruments).with(:devices).and_return([device])
+        actual = RunLoop::Device.device_with_identifier(device.name, sim_control)
+        expect(actual).to be_a_kind_of RunLoop::Device
+      end
+
+      it 'find by udid' do
+        expect(sim_control).to receive(:simulators).and_return([])
+        expect(sim_control.xctools).to receive(:instruments).with(:devices).and_return([device])
+        actual = RunLoop::Device.device_with_identifier(device.udid, sim_control)
+        expect(actual).to be_a_kind_of RunLoop::Device
+      end
+    end
+
+    describe 'simulators' do
+
+      let(:device) {
+        RunLoop::Device.new('iPhone 4s',
+                            '8.3',
+                            'CE5BA25E-9434-475A-8947-ECC3918E64E3 i386')
+      }
+
+      it 'find by name' do
+        expect(sim_control).to receive(:simulators).and_return([device])
+        actual = RunLoop::Device.device_with_identifier(device.instruments_identifier,
+                                                        sim_control)
+        expect(actual).to be_a_kind_of RunLoop::Device
+      end
+
+      it 'find by udid' do
+        expect(sim_control).to receive(:simulators).and_return([device])
+        actual = RunLoop::Device.device_with_identifier(device.udid, sim_control)
+        expect(actual).to be_a_kind_of RunLoop::Device
+      end
+    end
+  end
+
   context '#simulator?' do
     subject { device.simulator? }
     context 'is a simulator' do


### PR DESCRIPTION
### Motivation

Calabash 2.0 needs a convenient API for finding a device or simulator with a given name.