### PR TITLE
Travis CI: disable any test that starts a simulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ before_script:
 
 script:
   - scripts/ci/travis/install-gem-ci.rb
-# - scripts/ci/travis/rspec-ci.rb
-  - bundle exec rake unit
+  - scripts/ci/travis/rspec-ci.rb
 
 rvm:
 # - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ script:
   - scripts/ci/travis/rspec-ci.rb
 
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.2.1
+# - 1.9.3
+# - 2.0.0
+ - 2.2.1
 
 env: CAL_SIM_POST_LAUNCH_WAIT=4.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ script:
   - scripts/ci/travis/rspec-ci.rb
 
 rvm:
-# - 1.9.3
-# - 2.0.0
- - 2.2.1
+  - 1.9.3
+  - 2.0.0
+  - 2.2.1
 
 env: CAL_SIM_POST_LAUNCH_WAIT=4.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ before_script:
 
 script:
   - scripts/ci/travis/install-gem-ci.rb
-  - scripts/ci/travis/rspec-ci.rb
+# - scripts/ci/travis/rspec-ci.rb
+  - bundle exec rake unit
 
 rvm:
 # - 1.9.3

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,13 @@
 require 'bundler'
 Bundler::GemHelper.install_tasks
 
-require 'rspec/core/rake_task'
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
 
-RSpec::Core::RakeTask.new do |t|
-  t.pattern = Dir.glob('spec/**/*_spec.rb')
+  RSpec::Core::RakeTask.new(:unit) do |task|
+    task.pattern = 'spec/lib/**{,/*/**}/*_spec.rb'
+  end
+rescue LoadError => _
 end
+

--- a/scripts/ci/travis/rspec-ci.rb
+++ b/scripts/ci/travis/rspec-ci.rb
@@ -6,8 +6,8 @@ working_directory = File.expand_path(File.join(File.dirname(__FILE__), '..', '..
 
 Dir.chdir working_directory do
 
-  do_system('bundle exec rake spec',
-            {:pass_msg => 'rspec tests passed',
-             :fail_msg => 'spec tests did not pass'})
+  do_system('bundle exec rake unit',
+            {:pass_msg => 'rspec unit tests passed',
+             :fail_msg => 'rspec unit tests did not pass'})
 
 end

--- a/spec/lib/instruments_spec.rb
+++ b/spec/lib/instruments_spec.rb
@@ -33,34 +33,24 @@ describe RunLoop::Instruments do
   describe '#is_instruments_process?' do
     describe 'returns false when process description' do
       it 'is nil' do
-        expect(instruments.instance_eval {
-          is_instruments_process?(nil)
-        }).to be == false
+        expect(instruments.send(:is_instruments_process?, nil)).to be_falsey
       end
 
       it 'does not match instruments regex' do
-        expect( instruments.instance_eval {
-          is_instruments_process?('/usr/bin/foo')
-        }).to be == false
-        expect( instruments.instance_eval {
-          is_instruments_process?('instruments')
-        }).to be == false
+        expect(instruments.send(:is_instruments_process?, '/usr/bin/foo')).to be_falsey
+        expect(instruments.send(:is_instruments_process?, 'instruments')).to be_falsey
       end
 
       it "starts with 'sh -c xcrun instruments'" do
         description = "sh -c xcrun instruments -w \"43be3f89d9587e9468c24672777ff6241bd91124\" < args >"
-        expect( instruments.instance_eval {
-                  is_instruments_process?(description)
-                }).to be == false
+        expect(instruments.send(:is_instruments_process?, description)).to be_falsey
       end
     end
 
     describe 'returns true when process description' do
       it "contains '/usr/bin/instruments'" do
         description = "/Xcode/6.0.1/Xcode.app/Contents/Developer/usr/bin/instruments -w \"43be3f89d9587e9468c24672777ff6241bd91124\" < args >"
-        expect( instruments.instance_eval {
-          is_instruments_process?(description)
-        }).to be == true
+        expect(instruments.send(:is_instruments_process?, description)).to be_truthy
       end
     end
   end
@@ -68,9 +58,7 @@ describe RunLoop::Instruments do
   describe '#pids_from_ps_output' do
     it 'when no instruments process are running returns an empty array' do
       ps_cmd = 'ps x -o pid,command | grep -v grep | grep a-process-that-does-not-exist'
-      expect( instruments.instance_eval {
-        pids_from_ps_output(ps_cmd).count
-      }).to be == 0
+      expect(instruments.send(:pids_from_ps_output, ps_cmd).count).to be == 0
     end
 
     it 'can parse pids from typical ps output' do
@@ -83,8 +71,7 @@ describe RunLoop::Instruments do
 
       expect(instruments).to receive(:ps_for_instruments).and_return(ps_output)
       expected = [98081, 98082, 98083]
-      actual = []
-      instruments.instance_eval { actual = pids_from_ps_output }
+      actual = instruments.send(:pids_from_ps_output)
       expect(actual).to match_array expected
     end
   end
@@ -125,9 +112,7 @@ describe RunLoop::Instruments do
     it 'the current Xcode version' do
       xcode_tools = RunLoop::XCTools.new
       expected =  xcode_tools.xcode_version_gte_6? ? 'QUIT' : 'TERM'
-      expect(instruments.instance_eval {
-        kill_signal(xcode_tools)
-      }).to be == expected
+      expect(instruments.send(:kill_signal, xcode_tools)).to be == expected
     end
 
     describe 'regression' do
@@ -142,9 +127,7 @@ describe RunLoop::Instruments do
             Resources.shared.with_developer_dir(developer_dir) do
               xcode_tools = RunLoop::XCTools.new
               expected =  xcode_tools.xcode_version_gte_6? ? 'QUIT' : 'TERM'
-              expect(instruments.instance_eval {
-                       kill_signal(xcode_tools)
-                     }).to be == expected
+              expect(instruments.send(:kill_signal, xcode_tools)).to be == expected
             end
           end
         end

--- a/spec/lib/instruments_spec.rb
+++ b/spec/lib/instruments_spec.rb
@@ -20,11 +20,12 @@ describe RunLoop::Instruments do
   describe '#ps_for_instruments' do
     it 'can find instruments processes' do
       cmd = 'ps x -o pid,command | grep -v grep | grep fake-instruments'
-      3.times { Resources.shared.fork_fake_instruments_process }
-      output = []
-      instruments.instance_eval {
-        output = ps_for_instruments(cmd).strip.split("\n")
-      }
+      3.times do
+        Resources.shared.fork_fake_instruments_process
+        sleep(0.1) if Luffa::Environment.travis_ci?
+      end
+
+      output = instruments.send(:ps_for_instruments, cmd).strip.split("\n")
       expect(output.count).to be == 3
     end
   end


### PR DESCRIPTION
### Motivation

iOS Simulators on Travis are just not stable enough.

