### PR TITLE
prevent simulator from stealing focus between scenarios

### DIFF
--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -183,7 +183,6 @@ module RunLoop
     def reset_sim_content_and_settings(opts={})
       default_opts = {:post_quit_wait => 1.0,
                       :post_launch_wait => RunLoop::Environment.sim_post_launch_wait || 3.0,
-                      :hide_after => false,
                       :sim_udid => nil}
       merged_opts = default_opts.merge(opts)
 

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -178,11 +178,6 @@ module RunLoop
     #  simulator has launched.  Waits longer than normal because we need the
     #  simulator directories to be repopulated. **NOTE:** This option is ignored
     #  in Xcode 6.
-    # @option opts [Boolean] :hide_after (false) If true, will attempt to Hide
-    #  the simulator after it is launched.  This is useful `only when testing
-    #  gem features` that require the simulator be launched repeated and you are
-    #  tired of your editor losing focus. :) **NOTE:** This option is ignored
-    #  in Xcode 6.
     # @option opts [String] :sim_udid (nil) The udid of the simulator to reset.
     #  **NOTE:** This option is ignored in Xcode < 6.
     def reset_sim_content_and_settings(opts={})

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -85,7 +85,7 @@ module RunLoop
         default_opts = {:post_launch_wait => RunLoop::Environment.sim_post_launch_wait || 2.0,
                         :hide_after => false}
         merged_opts = default_opts.merge(opts)
-        `xcrun open -a "#{sim_app_path}"`
+        `xcrun open -g -a "#{sim_app_path}"`
         if merged_opts[:hide_after]
           `xcrun /usr/bin/osascript -e 'tell application "System Events" to keystroke "h" using command down'`
         end

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -96,8 +96,7 @@ module RunLoop
     #  simulator has launched.
     def relaunch_sim(opts={})
       default_opts = {:post_quit_wait => 1.0,
-                      :post_launch_wait => RunLoop::Environment.sim_post_launch_wait || 2.0,
-                      :hide_after => false}
+                      :post_launch_wait => RunLoop::Environment.sim_post_launch_wait || 2.0}
       merged_opts = default_opts.merge(opts)
       quit_sim(merged_opts)
       launch_sim(merged_opts)

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -69,15 +69,12 @@ module RunLoop
     end
 
     # If it is not already running, launch the simulator for the current version
-    # of Xcode.
+    # of Xcode.  Launches the simulator in the background so it does not
+    # steal focus.
     #
     # @param [Hash] opts Optional controls.
     # @option opts [Float] :post_launch_wait (2.0) How long to sleep after the
     #  simulator has launched.
-    # @option opts [Boolean] :hide_after (false) If true, will attempt to Hide
-    #  the simulator after it is launched.  This is useful `only when testing
-    #  gem features` that require the simulator be launched repeated and you are
-    #  tired of your editor losing focus. :)
     #
     # @todo Consider migrating apple script call to xctools.
     def launch_sim(opts={})

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -94,10 +94,6 @@ module RunLoop
     #  simulator has quit.
     # @option opts [Float] :post_launch_wait (2.0) How long to sleep after the
     #  simulator has launched.
-    # @option opts [Boolean] :hide_after (false) If true, will attempt to Hide
-    #  the simulator after it is launched.  This is useful `only when testing
-    #  gem features` that require the simulator be launched repeated and you are
-    #  tired of your editor losing focus. :)
     def relaunch_sim(opts={})
       default_opts = {:post_quit_wait => 1.0,
                       :post_launch_wait => RunLoop::Environment.sim_post_launch_wait || 2.0,

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -79,13 +79,9 @@ module RunLoop
     # @todo Consider migrating apple script call to xctools.
     def launch_sim(opts={})
       unless sim_is_running?
-        default_opts = {:post_launch_wait => RunLoop::Environment.sim_post_launch_wait || 2.0,
-                        :hide_after => false}
+        default_opts = {:post_launch_wait => RunLoop::Environment.sim_post_launch_wait || 2.0}
         merged_opts = default_opts.merge(opts)
         `xcrun open -g -a "#{sim_app_path}"`
-        if merged_opts[:hide_after]
-          `xcrun /usr/bin/osascript -e 'tell application "System Events" to keystroke "h" using command down'`
-        end
         sleep(merged_opts[:post_launch_wait]) if merged_opts[:post_launch_wait]
       end
     end

--- a/lib/run_loop/simctl/bridge.rb
+++ b/lib/run_loop/simctl/bridge.rb
@@ -371,7 +371,7 @@ module RunLoop::Simctl
     end
 
     def launch_simulator
-      args = ['open', '-a', @path_to_ios_sim_app_bundle, '--args', '-CurrentDeviceUDID', device.udid]
+      args = ['open', '-g', '-a', @path_to_ios_sim_app_bundle, '--args', '-CurrentDeviceUDID', device.udid]
       pid = spawn('xcrun', *args)
       Process.detach(pid)
 

--- a/spec/integration/sim_control_spec.rb
+++ b/spec/integration/sim_control_spec.rb
@@ -10,7 +10,7 @@ describe RunLoop::SimControl do
       before(:each) { RunLoop::SimControl.terminate_all_sims }
 
       it "with Xcode #{Resources.shared.current_xcode_version}" do
-        sim_control.launch_sim({:hide_after => false})
+        sim_control.launch_sim
         expect(sim_control.sim_is_running?).to be == true
 
         sim_control.quit_sim
@@ -24,7 +24,7 @@ describe RunLoop::SimControl do
             it "#{developer_dir}" do
               Resources.shared.with_developer_dir(developer_dir) do
                 local_sim_control = RunLoop::SimControl.new
-                local_sim_control.launch_sim({:hide_after => true})
+                local_sim_control.launch_sim
                 expect(local_sim_control.sim_is_running?).to be == true
 
                 local_sim_control.quit_sim
@@ -42,7 +42,7 @@ describe RunLoop::SimControl do
     before(:each) { RunLoop::SimControl.terminate_all_sims }
 
     it "with Xcode #{Resources.shared.current_xcode_version}" do
-      sim_control.relaunch_sim({:hide_after => true})
+      sim_control.relaunch_sim
       expect(sim_control.sim_is_running?).to be == true
     end
 
@@ -53,7 +53,7 @@ describe RunLoop::SimControl do
           it "#{developer_dir}" do
             Resources.shared.with_developer_dir(developer_dir) do
               local_sim_control = RunLoop::SimControl.new
-              local_sim_control.relaunch_sim({:hide_after => true})
+              local_sim_control.relaunch_sim
               expect(local_sim_control.sim_is_running?).to be == true
             end
           end
@@ -65,7 +65,7 @@ describe RunLoop::SimControl do
   describe '#sim_app_support_dir' do
     before(:each) {  RunLoop::SimControl.terminate_all_sims }
     it "with Xcode #{Resources.shared.current_xcode_version} returns a path that exists" do
-      sim_control.relaunch_sim({:hide_after => true})
+      sim_control.relaunch_sim
       path = sim_control.instance_eval { sim_app_support_dir }
       expect(File.exist?(path)).to be == true
     end
@@ -82,7 +82,7 @@ describe RunLoop::SimControl do
             RunLoop::SimControl.terminate_all_sims
             Resources.shared.with_developer_dir(developer_dir) do
               local_sim_control = RunLoop::SimControl.new
-              local_sim_control.relaunch_sim({:hide_after => true})
+              local_sim_control.relaunch_sim
               path = local_sim_control.instance_eval { sim_app_support_dir }
               expect(File.exist?(path)).to be == true
             end
@@ -97,11 +97,10 @@ describe RunLoop::SimControl do
 
       before(:each) do
         RunLoop::SimControl.terminate_all_sims
-        @opts = {:hide_after => true}
       end
 
       it "with Xcode #{Resources.shared.current_xcode_version}" do
-        sim_control.reset_sim_content_and_settings(@opts)
+        sim_control.reset_sim_content_and_settings
         actual = sim_control.instance_eval { existing_sim_sdk_or_device_data_dirs }
         expect(actual).to be_a Array
         expect(actual.count).to be >= 1
@@ -112,7 +111,7 @@ describe RunLoop::SimControl do
         describe "with Xcode #{Resources.shared.current_xcode_version}" do
           it "can reset the content and settings on a single simulator" do
             udid = sim_control.instance_eval { sim_details :udid }.keys.sample
-            options = @opts.merge({:sim_udid => udid})
+            options = {:sim_udid => udid}
             sim_control.reset_sim_content_and_settings(options)
             containers_dir = Resources.shared.core_simulator_device_containers_dir(udid)
             expect(File.exist? containers_dir).to be == false


### PR DESCRIPTION
Each time the simulator launches it steals keyboard focus. This is super distracting when trying to do anything else while the tests run.

From `man open`

        -g  Do not bring the application to the foreground. 