### PR TITLE
Xcode 7 beta support

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -391,7 +391,9 @@ module RunLoop
     # @param [RunLoop::XCTools] xcode_tools Used to detect the current xcode
     #  version.
     def self.default_simulator(xcode_tools=RunLoop::XCTools.new)
-      if xcode_tools.xcode_version_gte_64?
+      if xcode_tools.xcode_version_gte_7?
+        'iPhone 5s (9.0 Simulator)'
+      elsif xcode_tools.xcode_version_gte_64?
         'iPhone 5s (8.4 Simulator)'
       elsif xcode_tools.xcode_version_gte_63?
         'iPhone 5s (8.3 Simulator)'

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -639,6 +639,8 @@ module RunLoop
       #
       # Xcode 6 Beta versions also return paths, but revert to 'normal'
       # behavior when GM is released.
+      #
+      # Xcode 7 Beta versions appear to behavior like Xcode 6 Beta versions.
       res = templates.select { |name| name == 'Automation' }.first
       return res if res
 

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -604,7 +604,8 @@ module RunLoop
     #
     # @return [String, nil] The pid as a String or nil if no process is found.
     def sim_pid
-      `xcrun ps x -o pid,command | grep "#{sim_name}" | grep -v grep`.strip.split(' ').first
+      process_name = "MacOS/#{sim_name}"
+      `xcrun ps x -o pid,command | grep "#{process_name}" | grep -v grep`.strip.split(' ').first
     end
 
     # @!visibility private

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -637,7 +637,9 @@ module RunLoop
     def sim_app_path
       @sim_app_path ||= lambda {
         dev_dir = xctools.xcode_developer_dir
-        if xcode_version_gte_6?
+        if xcode_version_gte_7?
+          "#{dev_dir}/Applications/Simulator.app"
+        elsif xcode_version_gte_6?
           "#{dev_dir}/Applications/iOS Simulator.app"
         else
           "#{dev_dir}/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app"

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -21,6 +21,16 @@ module RunLoop
     end
 
     # @!visibility private
+    # Are we running Xcode 7 or above?
+    #
+    # This is a convenience method.
+    #
+    # @return [Boolean] `true` if the current Xcode version is >= 7.0
+    def xcode_version_gte_7?
+      xctools.xcode_version_gte_7?
+    end
+
+    # @!visibility private
     # Are we running Xcode 6 or above?
     #
     # This is a convenience method.

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -619,7 +619,9 @@ module RunLoop
     #  launching the current simulator.
     def sim_name
       @sim_name ||= lambda {
-        if xcode_version_gte_6?
+        if xcode_version_gte_7?
+          'Simulator'
+        elsif xcode_version_gte_6?
           'iOS Simulator'
         else
           'iPhone Simulator'

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -130,7 +130,13 @@ module RunLoop
       # SimControl.new.quit_sim({:post_quit_wait => 0.5})
 
       processes =
-            ['iPhone Simulator.app', 'iOS Simulator.app',
+            [
+                  # Xcode < 5.1
+                  'iPhone Simulator.app',
+                  # 7.0 < Xcode <= 6.0
+                  'iOS Simulator.app',
+                  # Xcode >= 7.0
+                  'Simulator.app',
 
              # Multiple launchd_sim processes have been causing problems.  This
              # is a first pass at investigating what it would mean to kill the

--- a/lib/run_loop/simctl/bridge.rb
+++ b/lib/run_loop/simctl/bridge.rb
@@ -374,7 +374,8 @@ module RunLoop::Simctl
 
       # @todo Does not always appear?
       # RunLoop::ProcessWaiter.new('CoreSimulatorBridge', WAIT_FOR_APP_LAUNCH_OPTS).wait_for_any
-      RunLoop::ProcessWaiter.new('iOS Simulator', WAIT_FOR_APP_LAUNCH_OPTS).wait_for_any
+      sim_name = @sim_control.send(:sim_name)
+      RunLoop::ProcessWaiter.new(sim_name, WAIT_FOR_APP_LAUNCH_OPTS).wait_for_any
       RunLoop::ProcessWaiter.new('SimulatorBridge', WAIT_FOR_APP_LAUNCH_OPTS).wait_for_any
       wait_for_device_state 'Booted'
       sleep(SIM_POST_LAUNCH_WAIT)

--- a/lib/run_loop/simctl/bridge.rb
+++ b/lib/run_loop/simctl/bridge.rb
@@ -27,10 +27,7 @@ module RunLoop::Simctl
       @pbuddy = RunLoop::PlistBuddy.new
 
       @sim_control = RunLoop::SimControl.new
-      @path_to_ios_sim_app_bundle = lambda {
-        dev_dir = @sim_control.xctools.xcode_developer_dir
-        "#{dev_dir}/Applications/iOS Simulator.app"
-      }.call
+      @path_to_ios_sim_app_bundle = @sim_control.send(:sim_app_path)
 
       @app = RunLoop::App.new(app_bundle_path)
 

--- a/lib/run_loop/simctl/bridge.rb
+++ b/lib/run_loop/simctl/bridge.rb
@@ -174,8 +174,10 @@ module RunLoop::Simctl
     def terminate_core_simulator_processes
       debug_logging = RunLoop::Environment.debug?
       [
-            # Probably no.
+            # Takes forever to kill this process.
             #'com.apple.CoreSimulator.CoreSimulatorService',
+
+            # Probably do not need to quit this.
             #'com.apple.CoreSimulator.SimVerificationService',
 
             # Started by Xamarin Studio, this is the parent process of the

--- a/lib/run_loop/xctools.rb
+++ b/lib/run_loop/xctools.rb
@@ -15,6 +15,14 @@ module RunLoop
   # @todo Refactor instruments related code to instruments class.
   class XCTools
 
+    # Returns a version instance for `Xcode 7.0`; used to check for the
+    # availability of features and paths to various items on the filesystem.
+    #
+    # @return [RunLoop::Version] 7.0
+    def v70
+      @xc70 ||= RunLoop::Version.new('7.0')
+    end
+
     # Returns a version instance for `Xcode 6.4`; used to check for the
     # availability of features and paths to various items on the filesystem.
     #
@@ -104,6 +112,13 @@ module RunLoop
     # @return [Boolean] `true` if the current Xcode version is >= 6.0
     def xcode_version_gte_6?
       @xcode_gte_6 ||= xcode_version >= v60
+    end
+
+    # Are we running Xcode 6 or above?
+    #
+    # @return [Boolean] `true` if the current Xcode version is >= 6.0
+    def xcode_version_gte_7?
+      @xcode_gte_6 ||= xcode_version >= v70
     end
 
     # Are we running Xcode 5.1 or above?

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -92,6 +92,15 @@ describe RunLoop::Core do
       actual = RunLoop::Core.default_simulator(xctools)
       expect(actual).to be == expected
     end
+
+    it "when Xcode 7.0 it returns 'iPhone 5s (9.0 Simulator)'" do
+      version = RunLoop::Version.new('7.0')
+      xctools = RunLoop::XCTools.new
+      expect(xctools).to receive(:xcode_version).at_least(:once).and_return(version)
+      expected = 'iPhone 5s (9.0 Simulator)'
+      actual = RunLoop::Core.default_simulator(xctools)
+      expect(actual).to be == expected
+    end
   end
 
   describe '.udid_and_bundle_for_launcher' do

--- a/spec/lib/sim_control_spec.rb
+++ b/spec/lib/sim_control_spec.rb
@@ -17,14 +17,14 @@ describe RunLoop::SimControl do
   describe '#sim_name' do
     it 'for Xcode >= 6.0' do
       xctools = sim_control.xctools
-      expect(xctools).to receive(:xcode_version).and_return(xctools.v60)
-      expect(sim_control.instance_eval { sim_name }).to be == 'iOS Simulator'
+      expect(xctools).to receive(:xcode_version).at_least(:once).and_return(xctools.v60)
+      expect(sim_control.send(:sim_name)).to be == 'iOS Simulator'
     end
 
     it 'for Xcode < 6.0' do
       xctools = sim_control.xctools
       expect(xctools).to receive(:xcode_version).and_return(xctools.v51)
-      expect(sim_control.instance_eval { sim_name }).to be == 'iPhone Simulator'
+      expect(sim_control.send(:sim_name)).to be == 'iPhone Simulator'
     end
   end
 

--- a/spec/lib/sim_control_spec.rb
+++ b/spec/lib/sim_control_spec.rb
@@ -15,7 +15,13 @@ describe RunLoop::SimControl do
   end
 
   describe '#sim_name' do
-    it 'for Xcode >= 6.0' do
+    it 'for Xcode >= 7.0' do
+      xctools = sim_control.xctools
+      expect(xctools).to receive(:xcode_version).at_least(:once).and_return(xctools.v70)
+      expect(sim_control.send(:sim_name)).to be == 'Simulator'
+    end
+
+    it 'for 7.0 < Xcode >= 6.0' do
       xctools = sim_control.xctools
       expect(xctools).to receive(:xcode_version).at_least(:once).and_return(xctools.v60)
       expect(sim_control.send(:sim_name)).to be == 'iOS Simulator'
@@ -23,7 +29,7 @@ describe RunLoop::SimControl do
 
     it 'for Xcode < 6.0' do
       xctools = sim_control.xctools
-      expect(xctools).to receive(:xcode_version).and_return(xctools.v51)
+      expect(xctools).to receive(:xcode_version).at_least(:once).and_return(xctools.v51)
       expect(sim_control.send(:sim_name)).to be == 'iPhone Simulator'
     end
   end

--- a/spec/lib/sim_control_spec.rb
+++ b/spec/lib/sim_control_spec.rb
@@ -45,20 +45,31 @@ describe RunLoop::SimControl do
   end
 
   describe '#sim_app_path' do
-    it 'for Xcode >= 6.0' do
+    it 'for Xcode >= 7.0' do
       xctools = sim_control.xctools
       expect(xctools).to receive(:xcode_developer_dir).and_return('/Xcode')
-      expect(xctools).to receive(:xcode_version).and_return(xctools.v60)
+      expect(xctools).to receive(:xcode_version).at_least(:once).and_return(xctools.v70)
+      expected = '/Xcode/Applications/Simulator.app'
+      expect(sim_control.send(:sim_app_path)).to be == expected
+      expect(sim_control.instance_variable_get(:@sim_app_path)).to be == expected
+    end
+
+    it 'for 7.0 < Xcode >= 6.0' do
+      xctools = sim_control.xctools
+      expect(xctools).to receive(:xcode_developer_dir).and_return('/Xcode')
+      expect(xctools).to receive(:xcode_version).at_least(:once).and_return(xctools.v60)
       expected = '/Xcode/Applications/iOS Simulator.app'
       expect(sim_control.send(:sim_app_path)).to be == expected
+      expect(sim_control.instance_variable_get(:@sim_app_path)).to be == expected
     end
 
     it 'for Xcode < 6.0' do
       xctools = sim_control.xctools
       expect(xctools).to receive(:xcode_developer_dir).and_return('/Xcode')
-      expect(xctools).to receive(:xcode_version).and_return(xctools.v51)
+      expect(xctools).to receive(:xcode_version).at_least(:once).and_return(xctools.v51)
       expected = '/Xcode/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app'
       expect(sim_control.send(:sim_app_path)).to be == expected
+      expect(sim_control.instance_variable_get(:@sim_app_path)).to be == expected
     end
 
     it 'returns a path that exists' do

--- a/spec/lib/sim_control_spec.rb
+++ b/spec/lib/sim_control_spec.rb
@@ -50,7 +50,7 @@ describe RunLoop::SimControl do
       expect(xctools).to receive(:xcode_developer_dir).and_return('/Xcode')
       expect(xctools).to receive(:xcode_version).and_return(xctools.v60)
       expected = '/Xcode/Applications/iOS Simulator.app'
-      expect(sim_control.instance_eval { sim_app_path }).to be == expected
+      expect(sim_control.send(:sim_app_path)).to be == expected
     end
 
     it 'for Xcode < 6.0' do
@@ -58,7 +58,7 @@ describe RunLoop::SimControl do
       expect(xctools).to receive(:xcode_developer_dir).and_return('/Xcode')
       expect(xctools).to receive(:xcode_version).and_return(xctools.v51)
       expected = '/Xcode/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app'
-      expect(sim_control.instance_eval { sim_app_path }).to be == expected
+      expect(sim_control.send(:sim_app_path)).to be == expected
     end
 
     it 'returns a path that exists' do

--- a/spec/lib/xctools_spec.rb
+++ b/spec/lib/xctools_spec.rb
@@ -33,6 +33,11 @@ describe RunLoop::XCTools do
     it { expect(xctools.instruments_supports_hyphen_s? '4.6.3').to be == false }
   end
 
+  it '#xc70' do
+    expect(xctools.v70).to be == RunLoop::Version.new('7.0')
+    expect(xctools.instance_variable_get(:@xc70)).to be == RunLoop::Version.new('7.0')
+  end
+
   describe '#xc62' do
     it { expect(xctools.v62).to be == RunLoop::Version.new('6.2') }
   end
@@ -73,6 +78,18 @@ describe RunLoop::XCTools do
           end
         end
       end
+    end
+  end
+
+  describe '#xcode_version_gte_70?' do
+    it 'returns true for Xcode >= 7.0' do
+      expect(xctools).to receive(:xcode_version).and_return(RunLoop::Version.new('7.0'))
+      expect(xctools.xcode_version_gte_7?).to be == true
+    end
+
+    it 'returns false for Xcode < 7.0' do
+      expect(xctools).to receive(:xcode_version).and_return(RunLoop::Version.new('6.4'))
+      expect(xctools.xcode_version_gte_7?).to be == false
     end
   end
 


### PR DESCRIPTION
### Motivation

Xcode 7 changed the name and location of the iOS Simulator application and changed the name.

Unit tests are passing on Xcode 6 + 7.