### PR TITLE
Expect {} raise_error should specify the error

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -644,10 +644,13 @@ module RunLoop
       res = templates.select { |name| name == 'Automation' }.first
       return res if res
 
-      res = templates.select do |path|
+      candidate = templates.select do |path|
         path =~ /\/Automation.tracetemplate/ and path =~ /Xcode/
-      end.first.tr("\"", '').strip
-      return res if res
+      end
+
+      if !candidate.empty? && !candidate.first.nil?
+        return candidate.first.tr("\"", '').strip
+      end
 
       msgs = ['Expected instruments to report an Automation tracetemplate.',
               'Please report this as bug:  https://github.com/calabash/run_loop/issues',

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -92,7 +92,7 @@ module RunLoop
         self.udid
       else
         unless xcode_tools.xcode_version_gte_6?
-          raise "Expected Xcode >= 6, but found version #{xcode_tools.version} - cannot create an identifier"
+          raise "Expected Xcode >= 6, but found version #{xcode_tools.xcode_version} - cannot create an identifier"
         end
         if self.version == RunLoop::Version.new('7.0.3')
           version_part = self.version.to_s

--- a/spec/lib/app_spec.rb
+++ b/spec/lib/app_spec.rb
@@ -39,7 +39,7 @@ describe RunLoop::App do
       let (:path) { FileUtils.mkdir_p(File.join(Dir.mktmpdir, 'foo.app')).first }
       it 'there is no info plist' do
         app = RunLoop::App.new(path)
-        expect { app.info_plist_path }.to raise_error
+        expect { app.info_plist_path }.to raise_error(RuntimeError)
       end
     end
   end
@@ -54,7 +54,7 @@ describe RunLoop::App do
         app = RunLoop::App.new(path)
         file = RunLoop::PlistBuddy.new.create_plist(File.join(path, 'Info.plist'))
         expect(File.exist?(file)).to be_truthy
-        expect { app.bundle_identifier }.to raise_error
+        expect { app.bundle_identifier }.to raise_error(RuntimeError)
       end
     end
   end
@@ -69,7 +69,7 @@ describe RunLoop::App do
         app = RunLoop::App.new(path)
         file = RunLoop::PlistBuddy.new.create_plist(File.join(path, 'Info.plist'))
         expect(File.exist?(file)).to be_truthy
-        expect { app.executable_name }.to raise_error
+        expect { app.executable_name }.to raise_error(RuntimeError)
       end
     end
   end

--- a/spec/lib/cli/errors_spec.rb
+++ b/spec/lib/cli/errors_spec.rb
@@ -5,7 +5,7 @@ describe RunLoop::CLI::ValidationError do
   it 'can be used to raise an error' do
     expect {
       raise RunLoop::CLI::ValidationError, 'Hey!'
-    }.to raise_error
+    }.to raise_error(RunLoop::CLI::ValidationError)
   end
 
 end
@@ -15,7 +15,7 @@ describe RunLoop::CLI::NotImplementedError do
   it 'can be used to raise an error' do
     expect {
       raise RunLoop::CLI::NotImplementedError, 'Hey!'
-    }.to raise_error
+    }.to raise_error(RunLoop::CLI::NotImplementedError)
   end
 
 end

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -25,7 +25,7 @@ describe RunLoop::Core do
                   "/Xcode/6.2/Xcode.app/Contents/Applications/Instruments.app/Contents/Resources/templates/Time Profiler.tracetemplate",
             ]
       expect(xctools).to receive(:instruments).with(:templates).and_return(templates)
-      expect { RunLoop::Core.default_tracetemplate(xctools) }.to raise_error
+      expect { RunLoop::Core.default_tracetemplate(xctools) }.to raise_error(RuntimeError)
     end
   end
 

--- a/spec/lib/device_spec.rb
+++ b/spec/lib/device_spec.rb
@@ -150,7 +150,7 @@ describe RunLoop::Device do
         let(:xcode_tools) { RunLoop::XCTools.new }
         it 'raises an error' do
           expect(xcode_tools).to receive(:xcode_version_gte_6?).and_return(false)
-          expect { device.instruments_identifier(xcode_tools) }.to raise_error
+          expect { device.instruments_identifier(xcode_tools) }.to raise_error(RuntimeError)
         end
       end
     end
@@ -160,7 +160,7 @@ describe RunLoop::Device do
     describe 'is a physical device' do
       it 'raises an error' do
         device = RunLoop::Device.new('name', '7.1.2', '30c4b52a41d0f6c64a44bd01ff2966f03105de1e', 'Shutdown')
-        expect { device.send(:instruction_set) }.to raise_error
+        expect { device.send(:instruction_set) }.to raise_error(RuntimeError)
       end
     end
 

--- a/spec/lib/lipo_spec.rb
+++ b/spec/lib/lipo_spec.rb
@@ -42,7 +42,7 @@ describe RunLoop::Lipo do
       expect(lipo).to receive(:execute_lipo).and_yield(stream.call(''),
                                                        stream.call('stderr output'),
                                                        RunLoop::Lipo::ProcessStatus.new)
-      expect { lipo.info }.to raise_error
+      expect { lipo.info }.to raise_error(RuntimeError)
     end
 
     context 'bundle path has spaces' do

--- a/spec/lib/patches/retriable_spec.rb
+++ b/spec/lib/patches/retriable_spec.rb
@@ -21,19 +21,19 @@ describe RunLoop::RetryOpts do
       it ':tries is not allowed' do
         expect {
           retry_module.tries_and_interval(3, 4, {:tries => 3})
-        }.to raise_error
+        }.to raise_error(RuntimeError)
       end
 
       it ':interval is not allowed' do
         expect {
           retry_module.tries_and_interval(3, 4, {:interval => 3})
-        }.to raise_error
+        }.to raise_error(RuntimeError)
       end
 
       it ':intervals is not allowed' do
         expect {
           retry_module.tries_and_interval(3, 4, {:intervals => 3})
-        }.to raise_error
+        }.to raise_error(RuntimeError)
       end
     end
 

--- a/spec/lib/simctl/bridge_spec.rb
+++ b/spec/lib/simctl/bridge_spec.rb
@@ -28,7 +28,7 @@ describe RunLoop::Simctl::Bridge do
       allow_any_instance_of(RunLoop::App).to receive(:valid?).and_return(false)
       expect {
         RunLoop::Simctl::Bridge.new(device, abp)
-      }.to raise_error
+      }.to raise_error(RuntimeError)
     end
   end
 


### PR DESCRIPTION
### Motivation

New behavior in rspec 3.3.x - warn if `raise_error` does not specify the error type.

Found two cases where not specifying the error was hiding unexpected behavior.