### PR TITLE
Fixed typo in xcode 7 check

### DIFF
--- a/lib/run_loop/xctools.rb
+++ b/lib/run_loop/xctools.rb
@@ -114,11 +114,11 @@ module RunLoop
       @xcode_gte_6 ||= xcode_version >= v60
     end
 
-    # Are we running Xcode 6 or above?
+    # Are we running Xcode 7 or above?
     #
-    # @return [Boolean] `true` if the current Xcode version is >= 6.0
+    # @return [Boolean] `true` if the current Xcode version is >= 7.0
     def xcode_version_gte_7?
-      @xcode_gte_6 ||= xcode_version >= v70
+      @xcode_gte_7 ||= xcode_version >= v70
     end
 
     # Are we running Xcode 5.1 or above?


### PR DESCRIPTION
A typo in the test for Xcode 7 causes inability to use Xcode 6.4 with Xcode 7 installed