### PR TITLE
uikit localization lookups in runloop

### DIFF
--- a/lib/run_loop/xctools.rb
+++ b/lib/run_loop/xctools.rb
@@ -172,28 +172,11 @@ module RunLoop
     #
     # @return [String] the localized name
     def lookup_localization_name(key_code, localized_lang)
+      lookup_table_dir = lang_dir(localized_lang)
+      return nil unless lookup_table_dir
 
-      l10n_path = uikit_bundle_l10n_path
-
-      lang_dir_name = "#{localized_lang}.lproj".sub('-','_')
-
-      if(File.exists?(File.join(l10n_path, lang_dir_name)))
-        return key_name_lookup_table(lang_dir_name)[key_code]
-      end
-
-      two_char_country_code = localized_lang.split('-')[0]
-      lang_dir_name = "#{two_char_country_code}.lproj"
-      if(File.exists?(File.join(l10n_path, lang_dir_name)))
-        return key_name_lookup_table(lang_dir_name)[key_code]
-      end
-
-      if is_full_name?(two_char_country_code)
-        return key_name_lookup_table("#{@@full_name_lookup[two_char_country_code]}.lproj")[key_code]
-      end
-
-      return nil
+      key_name_lookup_table(lookup_table_dir)[key_code]
     end
-
 
     # Is this a beta version of Xcode?
     #
@@ -326,6 +309,35 @@ module RunLoop
     end
 
   private
+
+  # maps the ios keyboard localization to a language directory where we can
+  # find a key-code -> localized-label mapping 
+  def lang_dir(localized_lang)
+    l10n_path = uikit_bundle_l10n_path
+
+    ## 2 char + _ + sub localization
+    # en_GB.lproj
+    lang_dir_name = "#{localized_lang}.lproj".sub('-','_')
+    if(File.exists?(File.join(l10n_path, lang_dir_name)))
+      return lang_dir_name
+    end
+
+    # 2 char iso language code
+    # vi.lproj
+    two_char_country_code = localized_lang.split('-')[0]
+    lang_dir_name = "#{two_char_country_code}.lproj"
+    if(File.exists?(File.join(l10n_path, lang_dir_name)))
+      return lang_dir_name
+    end
+
+    # Full name
+    # e.g. Dutch.lproj
+    lang_dir_name = "#{@@full_name_lookup[two_char_country_code]}.lproj"
+    if is_full_name?(two_char_country_code) &&
+        File.exists?(File.join(l10n_path, lang_dir_name))
+      return lang_dir_name
+    end
+  end
 
   def uikit_bundle_l10n_path
     if !xcode_developer_dir

--- a/spec/lib/xctools_spec.rb
+++ b/spec/lib/xctools_spec.rb
@@ -15,11 +15,11 @@ describe RunLoop::XCTools do
     end
   end
 
-  describe '.uikit_bundle_l18n_path' do
+  describe '#uikit_bundle_l10n_path' do
     it 'return value' do
       stub_env('DEVELOPER_DIR', '/some/xcode/path')
-      expected_uikit_l18n_path = "./Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/AccessibilityBundles/UIKit.axbundle/"
-      expect(xctools.uikit_bundle_l18n_path).to be == File.join('/some/xcode/path', expected_uikit_l18n_path);
+      expected_uikit_l10n_path = "./Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/AccessibilityBundles/UIKit.axbundle/"
+      expect(xctools.instance_eval {uikit_bundle_l10n_path}).to be == File.join('/some/xcode/path', expected_uikit_l10n_path);
     end
   end
 

--- a/spec/lib/xctools_spec.rb
+++ b/spec/lib/xctools_spec.rb
@@ -36,7 +36,35 @@ describe RunLoop::XCTools do
       let('localization') { "not-real" }
       it { is_expected.to be == nil }
     end
+  end
 
+  describe "#lang_dir" do
+    subject { xctools.send(:lang_dir, localization) }
+
+    context 'existing sub localization' do
+      let(:localization) { 'en-GB' }
+      it { is_expected.to be == 'en_GB.lproj' }
+    end
+
+    context 'existing iso localization' do
+      let(:localization) { 'vi' }
+      it { is_expected.to be == 'vi.lproj' }
+    end
+
+    context 'specially named localization' do
+      let(:localization) { 'nl' }
+      it { is_expected.to be == 'Dutch.lproj' }
+    end
+
+    context 'non-exisiting sub localization with specially named super-localization' do
+      let(:localization) { 'en-AU' }
+      it { is_expected.to be == 'English.lproj' }
+    end
+
+    context 'non-exisiting sub localization with iso super-localization' do
+      let(:localization) { 'vi-VN' }
+      it { is_expected.to be == 'vi.lproj' }
+    end
   end
 
   describe '#instruments' do

--- a/spec/lib/xctools_spec.rb
+++ b/spec/lib/xctools_spec.rb
@@ -15,6 +15,14 @@ describe RunLoop::XCTools do
     end
   end
 
+  describe '.uikit_bundle_l18n_path' do
+    it 'return value' do
+      stub_env('DEVELOPER_DIR', '/some/xcode/path')
+      expected_uikit_l18n_path = "./Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/AccessibilityBundles/UIKit.axbundle/"
+      expect(xctools.uikit_bundle_l18n_path).to be == File.join('/some/xcode/path', expected_uikit_l18n_path);
+    end
+  end
+
   describe '#instruments' do
     it 'checks its arguments' do
       expect { xctools.instruments(:foo) }.to raise_error(ArgumentError)

--- a/spec/lib/xctools_spec.rb
+++ b/spec/lib/xctools_spec.rb
@@ -23,6 +23,22 @@ describe RunLoop::XCTools do
     end
   end
 
+  describe '#lookup_localization_name' do
+
+    subject { xctools.lookup_localization_name("delete.key", localization) }
+
+    context 'when using the danish localization' do
+      let('localization') { "da" }
+      it { is_expected.to be == "Slet" }
+    end
+
+    context 'when using an unknown localization' do
+      let('localization') { "not-real" }
+      it { is_expected.to be == nil }
+    end
+
+  end
+
   describe '#instruments' do
     it 'checks its arguments' do
       expect { xctools.instruments(:foo) }.to raise_error(ArgumentError)


### PR DESCRIPTION
Using the new `keyboard-language` route proposed in https://github.com/calabash/calabash-ios-server/pull/221, this PR adds a facility in runloop to lookup the localized name of things like buttons and keys:

    (RunLoop::XCTools.new).lookup_localization_name('delete.key', 'da') 
    => "Slet"
    