### PR TITLE
Add more privacy alert auto-dismiss regular expressions

### DIFF
--- a/scripts/run_loop_fast_uia.js
+++ b/scripts/run_loop_fast_uia.js
@@ -206,7 +206,13 @@ function isLocationPrompt(alert) {
             ["OK", /Would Like to Access Your Photos/],
             ["OK", /Would Like to Access Your Contacts/],
             ["OK", /Location Accuracy/],
-            ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/]
+            ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/],
+            ["OK", /Access the Microphone/],
+            ["OK", /enviarle notificaiones/],
+            ["OK", /Would Like to Access Your Calendar/],
+            ["OK", /Would Like to Access Your Reminders/],
+            ["OK", /Would Like to Access Your Motion Activity/],
+            ["OK", /Would Like to Access the Camera/]
         ],
         ans, exp,
         txt;

--- a/scripts/run_loop_host.js
+++ b/scripts/run_loop_host.js
@@ -224,7 +224,13 @@ function isLocationPrompt(alert) {
             ["OK", /Would Like to Access Your Photos/],
             ["OK", /Would Like to Access Your Contacts/],
             ["OK", /Location Accuracy/],
-            ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/]
+            ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/],
+            ["OK", /Access the Microphone/],
+            ["OK", /enviarle notificaiones/],
+            ["OK", /Would Like to Access Your Calendar/],
+            ["OK", /Would Like to Access Your Reminders/],
+            ["OK", /Would Like to Access Your Motion Activity/],
+            ["OK", /Would Like to Access the Camera/]
         ],
         ans, exp,
         txt;

--- a/scripts/run_loop_shared_element.js
+++ b/scripts/run_loop_shared_element.js
@@ -206,7 +206,13 @@ function isLocationPrompt(alert) {
             ["OK", /Would Like to Access Your Photos/],
             ["OK", /Would Like to Access Your Contacts/],
             ["OK", /Location Accuracy/],
-            ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/]
+            ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/],
+            ["OK", /Access the Microphone/],
+            ["OK", /enviarle notificaiones/],
+            ["OK", /Would Like to Access Your Calendar/],
+            ["OK", /Would Like to Access Your Reminders/],
+            ["OK", /Would Like to Access Your Motion Activity/],
+            ["OK", /Would Like to Access the Camera/]
         ],
         ans, exp,
         txt;


### PR DESCRIPTION
### Motivation

The only surprise here is: `["OK", /enviarle notificaiones/]`, which was requested by @GlennWilson (client request).

Resolves: **Privacy dialog: Microphone** #170

Tested with @Oddj0b [Permissions.app](https://github.com/Oddj0b/Permissions) :+1: :pizza: 

Messes with **Feature/refactor onalert javascript** #106  which needs rebasing or updating to handle these changes (@svevang ).

