### PR TITLE
Filter watch simulators out of simctl output

### DIFF
--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -1160,8 +1160,8 @@ module RunLoop
             next
           end
 
-          unavailable_skd = line[/Unavailable/, 0]
-          if unavailable_skd
+          unavailable_sdk = line[/Unavailable/, 0]
+          if unavailable_sdk
             current_sdk = nil
             next
           end

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -1166,6 +1166,18 @@ module RunLoop
             next
           end
 
+          watch_os = line[/watchOS/, 0]
+          if watch_os
+            current_sdk = nil
+            next
+          end
+
+          watch = line[/Apple Watch/, 0]
+          if watch
+            current_sdk = nil
+            next
+          end
+
           if current_sdk
             unless line[/unavailable/,0]
               name = line.split('(').first.strip


### PR DESCRIPTION
### Motivation

Xcode 7's simctl includes watchOS simulators.