### PR TITLE
Revise Xcode l10n support

### DIFF
--- a/lib/run_loop/xctools.rb
+++ b/lib/run_loop/xctools.rb
@@ -330,7 +330,7 @@ module RunLoop
       ## 2 char + _ + sub localization
       # en_GB.lproj
       lang_dir_name = "#{localized_lang}.lproj".sub('-','_')
-      if(File.exists?(File.join(l10n_path, lang_dir_name)))
+      if File.exists?(File.join(l10n_path, lang_dir_name))
         return lang_dir_name
       end
 
@@ -338,7 +338,7 @@ module RunLoop
       # vi.lproj
       two_char_country_code = localized_lang.split('-')[0]
       lang_dir_name = "#{two_char_country_code}.lproj"
-      if(File.exists?(File.join(l10n_path, lang_dir_name)))
+      if File.exists?(File.join(l10n_path, lang_dir_name))
         return lang_dir_name
       end
 

--- a/lib/run_loop/xctools.rb
+++ b/lib/run_loop/xctools.rb
@@ -312,6 +312,16 @@ module RunLoop
 
     UIKIT_AXBUNDLE_PATH = '/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/AccessibilityBundles/UIKit.axbundle/'
 
+    LANG_CODE_TO_LANG_NAME_MAP = {
+          'en' => 'English',
+          'nl' => 'Dutch',
+          'fr' => 'French',
+          'de' => 'German',
+          'es' => 'Spanish',
+          'it' => 'Italian',
+          'jp' => 'Japanese'
+    }
+
     # maps the ios keyboard localization to a language directory where we can
     # find a key-code -> localized-label mapping
     def lang_dir(localized_lang)
@@ -334,7 +344,7 @@ module RunLoop
 
       # Full name
       # e.g. Dutch.lproj
-      lang_dir_name = "#{@@full_name_lookup[two_char_country_code]}.lproj"
+      lang_dir_name = "#{LANG_CODE_TO_LANG_NAME_MAP[two_char_country_code]}.lproj"
       if is_full_name?(two_char_country_code) &&
             File.exists?(File.join(l10n_path, lang_dir_name))
         return lang_dir_name
@@ -349,18 +359,8 @@ module RunLoop
       end
     end
 
-    @@full_name_lookup = {
-          'en' => 'English',
-          'nl' => 'Dutch',
-          'fr' => 'French',
-          'de' => 'German',
-          'es' => 'Spanish',
-          'it' => 'Italian',
-          'jp' => 'Japanese'
-    }
-
     def is_full_name?(two_letter_country_code)
-      @@full_name_lookup.has_key?(two_letter_country_code)
+      LANG_CODE_TO_LANG_NAME_MAP.has_key?(two_letter_country_code)
     end
 
     def key_name_lookup_table(lang_dir_name)

--- a/lib/run_loop/xctools.rb
+++ b/lib/run_loop/xctools.rb
@@ -349,6 +349,7 @@ module RunLoop
             File.exists?(File.join(l10n_path, lang_dir_name))
         return lang_dir_name
       end
+      nil
     end
 
     def uikit_bundle_l10n_path

--- a/lib/run_loop/xctools.rb
+++ b/lib/run_loop/xctools.rb
@@ -365,7 +365,8 @@ module RunLoop
     end
 
     def key_name_lookup_table(lang_dir_name)
-      JSON.parse(`plutil -convert json #{File.join(uikit_bundle_l10n_path, lang_dir_name, 'Accessibility.strings')} -o -`)
+      path = File.join(uikit_bundle_l10n_path, lang_dir_name, 'Accessibility.strings')
+      JSON.parse(`plutil -convert json #{path} -o -`)
     end
 
 

--- a/lib/run_loop/xctools.rb
+++ b/lib/run_loop/xctools.rb
@@ -310,6 +310,8 @@ module RunLoop
 
     private
 
+    UIKIT_AXBUNDLE_PATH = '/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/AccessibilityBundles/UIKit.axbundle/'
+
     # maps the ios keyboard localization to a language directory where we can
     # find a key-code -> localized-label mapping
     def lang_dir(localized_lang)
@@ -343,8 +345,7 @@ module RunLoop
       if !xcode_developer_dir
         nil
       else
-        uikit_bundle_path = "./Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/AccessibilityBundles/UIKit.axbundle/"
-        File.join(xcode_developer_dir, uikit_bundle_path);
+        File.join(xcode_developer_dir, UIKIT_AXBUNDLE_PATH)
       end
     end
 

--- a/lib/run_loop/xctools.rb
+++ b/lib/run_loop/xctools.rb
@@ -369,6 +369,5 @@ module RunLoop
       JSON.parse(`plutil -convert json #{path} -o -`)
     end
 
-
   end
 end

--- a/lib/run_loop/xctools.rb
+++ b/lib/run_loop/xctools.rb
@@ -308,63 +308,63 @@ module RunLoop
       }.call
     end
 
-  private
+    private
 
-  # maps the ios keyboard localization to a language directory where we can
-  # find a key-code -> localized-label mapping 
-  def lang_dir(localized_lang)
-    l10n_path = uikit_bundle_l10n_path
+    # maps the ios keyboard localization to a language directory where we can
+    # find a key-code -> localized-label mapping
+    def lang_dir(localized_lang)
+      l10n_path = uikit_bundle_l10n_path
 
-    ## 2 char + _ + sub localization
-    # en_GB.lproj
-    lang_dir_name = "#{localized_lang}.lproj".sub('-','_')
-    if(File.exists?(File.join(l10n_path, lang_dir_name)))
-      return lang_dir_name
+      ## 2 char + _ + sub localization
+      # en_GB.lproj
+      lang_dir_name = "#{localized_lang}.lproj".sub('-','_')
+      if(File.exists?(File.join(l10n_path, lang_dir_name)))
+        return lang_dir_name
+      end
+
+      # 2 char iso language code
+      # vi.lproj
+      two_char_country_code = localized_lang.split('-')[0]
+      lang_dir_name = "#{two_char_country_code}.lproj"
+      if(File.exists?(File.join(l10n_path, lang_dir_name)))
+        return lang_dir_name
+      end
+
+      # Full name
+      # e.g. Dutch.lproj
+      lang_dir_name = "#{@@full_name_lookup[two_char_country_code]}.lproj"
+      if is_full_name?(two_char_country_code) &&
+            File.exists?(File.join(l10n_path, lang_dir_name))
+        return lang_dir_name
+      end
     end
 
-    # 2 char iso language code
-    # vi.lproj
-    two_char_country_code = localized_lang.split('-')[0]
-    lang_dir_name = "#{two_char_country_code}.lproj"
-    if(File.exists?(File.join(l10n_path, lang_dir_name)))
-      return lang_dir_name
+    def uikit_bundle_l10n_path
+      if !xcode_developer_dir
+        nil
+      else
+        uikit_bundle_path = "./Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/AccessibilityBundles/UIKit.axbundle/"
+        File.join(xcode_developer_dir, uikit_bundle_path);
+      end
     end
 
-    # Full name
-    # e.g. Dutch.lproj
-    lang_dir_name = "#{@@full_name_lookup[two_char_country_code]}.lproj"
-    if is_full_name?(two_char_country_code) &&
-        File.exists?(File.join(l10n_path, lang_dir_name))
-      return lang_dir_name
+    @@full_name_lookup = {
+          'en' => 'English',
+          'nl' => 'Dutch',
+          'fr' => 'French',
+          'de' => 'German',
+          'es' => 'Spanish',
+          'it' => 'Italian',
+          'jp' => 'Japanese'
+    }
+
+    def is_full_name?(two_letter_country_code)
+      @@full_name_lookup.has_key?(two_letter_country_code)
     end
-  end
 
-  def uikit_bundle_l10n_path
-    if !xcode_developer_dir
-      nil
-    else
-      uikit_bundle_path = "./Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/AccessibilityBundles/UIKit.axbundle/"
-      File.join(xcode_developer_dir, uikit_bundle_path);
+    def key_name_lookup_table(lang_dir_name)
+      JSON.parse(`plutil -convert json #{File.join(uikit_bundle_l10n_path, lang_dir_name, 'Accessibility.strings')} -o -`)
     end
-  end
-
-  @@full_name_lookup = {
-    'en' => 'English',
-    'nl' => 'Dutch',
-    'fr' => 'French',
-    'de' => 'German',
-    'es' => 'Spanish',
-    'it' => 'Italian',
-    'jp' => 'Japanese'
-  }
-
-  def is_full_name?(two_letter_country_code)
-    @@full_name_lookup.has_key?(two_letter_country_code)
-  end
-
-  def key_name_lookup_table(lang_dir_name)
-    JSON.parse(`plutil -convert json #{File.join(uikit_bundle_l10n_path, lang_dir_name, 'Accessibility.strings')} -o -`)
-  end
 
 
   end

--- a/spec/lib/xctools_spec.rb
+++ b/spec/lib/xctools_spec.rb
@@ -26,20 +26,20 @@ describe RunLoop::XCTools do
 
   describe '#lookup_localization_name' do
 
-    subject { xctools.lookup_localization_name("delete.key", localization) }
+    subject { xctools.lookup_localization_name('delete.key', localization) }
 
     context 'when using the danish localization' do
-      let('localization') { "da" }
-      it { is_expected.to be == "Slet" }
+      let('localization') { 'da' }
+      it { is_expected.to be == 'Slet' }
     end
 
     context 'when using an unknown localization' do
-      let('localization') { "not-real" }
+      let('localization') { 'not-real' }
       it { is_expected.to be == nil }
     end
   end
 
-  describe "#lang_dir" do
+  describe '#lang_dir' do
     subject { xctools.send(:lang_dir, localization) }
 
     context 'existing sub localization' do
@@ -62,7 +62,7 @@ describe RunLoop::XCTools do
       it { is_expected.to be == 'English.lproj' }
     end
 
-    context 'non-exisiting sub localization with iso super-localization' do
+    context 'non-existing sub localization with iso super-localization' do
       let(:localization) { 'vi-VN' }
       it { is_expected.to be == 'vi.lproj' }
     end

--- a/spec/lib/xctools_spec.rb
+++ b/spec/lib/xctools_spec.rb
@@ -56,8 +56,8 @@ describe RunLoop::XCTools do
       it { is_expected.to be == 'Dutch.lproj' }
     end
 
-    context 'non-exisiting sub localization with specially named super-localization' do
-      let(:localization) { 'en-AU' }
+    context 'non-existing sub localization with specially named super-localization' do
+      let(:localization) { 'en-XX' }
       it { is_expected.to be == 'English.lproj' }
     end
 

--- a/spec/lib/xctools_spec.rb
+++ b/spec/lib/xctools_spec.rb
@@ -66,6 +66,11 @@ describe RunLoop::XCTools do
       let(:localization) { 'vi-VN' }
       it { is_expected.to be == 'vi.lproj' }
     end
+
+    context 'unknown localization' do
+      let(:localization) { 'xx' }
+      it { is_expected.to be == nil }
+    end
   end
 
   describe '#instruments' do

--- a/spec/lib/xctools_spec.rb
+++ b/spec/lib/xctools_spec.rb
@@ -18,8 +18,9 @@ describe RunLoop::XCTools do
   describe '#uikit_bundle_l10n_path' do
     it 'return value' do
       stub_env('DEVELOPER_DIR', '/some/xcode/path')
-      expected_uikit_l10n_path = "./Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/AccessibilityBundles/UIKit.axbundle/"
-      expect(xctools.instance_eval {uikit_bundle_l10n_path}).to be == File.join('/some/xcode/path', expected_uikit_l10n_path);
+      axbundle_path = RunLoop::XCTools.const_get('UIKIT_AXBUNDLE_PATH')
+      expected = File.join('/some/xcode/path', axbundle_path)
+      expect(xctools.instance_eval {uikit_bundle_l10n_path}).to be == expected
     end
   end
 

--- a/spec/lib/xctools_spec.rb
+++ b/spec/lib/xctools_spec.rb
@@ -20,7 +20,7 @@ describe RunLoop::XCTools do
       stub_env('DEVELOPER_DIR', '/some/xcode/path')
       axbundle_path = RunLoop::XCTools.const_get('UIKIT_AXBUNDLE_PATH')
       expected = File.join('/some/xcode/path', axbundle_path)
-      expect(xctools.instance_eval {uikit_bundle_l10n_path}).to be == expected
+      expect(xctools.send(:uikit_bundle_l10n_path)).to be == expected
     end
   end
 


### PR DESCRIPTION
### Motivation

* Xcode 7 includes an en_AU localization
* Match project style
* Prefer `send` vs. `instance_eval` for testing private methods (there are many examples that use `instance_eval`; they should all be changed at some point)
* Prefer constants over class variables

@svevang Sorry that the diff is so cluttered; I had to adjust the indentation of the l10n block in XCTools.