### PR TITLE
Add an Xcode class

### DIFF
--- a/lib/run_loop.rb
+++ b/lib/run_loop.rb
@@ -1,6 +1,7 @@
 require 'run_loop/directory'
 require 'run_loop/environment'
 require 'run_loop/logging'
+require 'run_loop/xcode'
 require 'run_loop/process_terminator'
 require 'run_loop/process_waiter'
 require 'run_loop/lldb'

--- a/lib/run_loop/xcode.rb
+++ b/lib/run_loop/xcode.rb
@@ -67,7 +67,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 5.0
     def v50
-      @xc50 ||= RunLoop::Version.new('5.0')
+      fetch_version(:v50)
     end
 
     # Are we running Xcode 6.4 or above?

--- a/lib/run_loop/xcode.rb
+++ b/lib/run_loop/xcode.rb
@@ -70,53 +70,53 @@ module RunLoop
       fetch_version(:v50)
     end
 
-    # Are we running Xcode 6.4 or above?
-    #
-    # @return [Boolean] `true` if the current Xcode version is >= 6.4
-    def xcode_version_gte_64?
-      @xcode_gte_64 ||= version >= v64
-    end
-
-    # Are we running Xcode 6.3 or above?
-    #
-    # @return [Boolean] `true` if the current Xcode version is >= 6.3
-    def xcode_version_gte_63?
-      @xcode_gte_63 ||= version >= v63
-    end
-
-    # Are we running Xcode 6.2 or above?
-    #
-    # @return [Boolean] `true` if the current Xcode version is >= 6.2
-    def xcode_version_gte_62?
-      @xcode_gte_62 ||= version >= v62
-    end
-
-    # Are we running Xcode 6.1 or above?
-    #
-    # @return [Boolean] `true` if the current Xcode version is >= 6.1
-    def xcode_version_gte_61?
-      @xcode_gte_61 ||= version >= v61
-    end
-
-    # Are we running Xcode 6 or above?
-    #
-    # @return [Boolean] `true` if the current Xcode version is >= 6.0
-    def xcode_version_gte_6?
-      @xcode_gte_6 ||= version >= v60
-    end
-
-    # Are we running Xcode 7 or above?
+    # Is the active Xcode version 7 or above?
     #
     # @return [Boolean] `true` if the current Xcode version is >= 7.0
-    def xcode_version_gte_7?
-      @xcode_gte_7 ||= version >= v70
+    def version_gte_7?
+      version >= v70
     end
 
-    # Are we running Xcode 5.1 or above?
+    # Is the active Xcode version 6.4 or above?
+    #
+    # @return [Boolean] `true` if the current Xcode version is >= 6.4
+    def version_gte_64?
+      version >= v64
+    end
+
+    # Is the active Xcode version 6.3 or above?
+    #
+    # @return [Boolean] `true` if the current Xcode version is >= 6.3
+    def version_gte_63?
+      version >= v63
+    end
+
+    # Is the active Xcode version 6.2 or above?
+    #
+    # @return [Boolean] `true` if the current Xcode version is >= 6.2
+    def version_gte_62?
+      version >= v62
+    end
+
+    # Is the active Xcode version 6.1 or above?
+    #
+    # @return [Boolean] `true` if the current Xcode version is >= 6.1
+    def version_gte_61?
+      version >= v61
+    end
+
+    # Is the active Xcode version 6 or above?
+    #
+    # @return [Boolean] `true` if the current Xcode version is >= 6.0
+    def version_gte_6?
+      version >= v60
+    end
+
+    # Is the active Xcode version 5.1 or above?
     #
     # @return [Boolean] `true` if the current Xcode version is >= 5.1
-    def xcode_version_gte_51?
-      @xcode_gte_51 ||= version >= v51
+    def version_gte_51?
+      version >= v51
     end
 
     # Returns the current version of Xcode.

--- a/lib/run_loop/xcode.rb
+++ b/lib/run_loop/xcode.rb
@@ -1,0 +1,152 @@
+module RunLoop
+
+  # A model of the active Xcode version.
+  class Xcode
+
+
+    # Returns a version instance for `Xcode 7.0`; used to check for the
+    # availability of features and paths to various items on the filesystem.
+    #
+    # @return [RunLoop::Version] 7.0
+    def v70
+      @xc70 ||= RunLoop::Version.new('7.0')
+    end
+
+    # Returns a version instance for `Xcode 6.4`; used to check for the
+    # availability of features and paths to various items on the filesystem.
+    #
+    # @return [RunLoop::Version] 6.4
+    def v64
+      @xc64 ||= RunLoop::Version.new('6.4')
+    end
+
+    # Returns a version instance for `Xcode 6.3`; used to check for the
+    # availability of features and paths to various items on the filesystem.
+    #
+    # @return [RunLoop::Version] 6.3
+    def v63
+      @xc63 ||= RunLoop::Version.new('6.3')
+    end
+
+    # Returns a version instance for `Xcode 6.2`; used to check for the
+    # availability of features and paths to various items on the filesystem.
+    #
+    # @return [RunLoop::Version] 6.2
+    def v62
+      @xc62 ||= RunLoop::Version.new('6.2')
+    end
+
+    # Returns a version instance for `Xcode 6.1`; used to check for the
+    # availability of features and paths to various items on the filesystem.
+    #
+    # @return [RunLoop::Version] 6.1
+    def v61
+      @xc61 ||= RunLoop::Version.new('6.1')
+    end
+
+    # Returns a version instance for `Xcode 6.0`; used to check for the
+    # availability of features and paths to various items on the filesystem.
+    #
+    # @return [RunLoop::Version] 6.0
+    def v60
+      @xc60 ||= RunLoop::Version.new('6.0')
+    end
+
+    # Returns a version instance for `Xcode 5.1`; used to check for the
+    # availability of features and paths to various items on the filesystem.
+    #
+    # @return [RunLoop::Version] 5.1
+    def v51
+      @xc51 ||= RunLoop::Version.new('5.1')
+    end
+
+    # Returns a version instance for `Xcode 5.0`; ; used to check for the
+    # availability of features and paths to various items on the filesystem.
+    #
+    # @return [RunLoop::Version] 5.0
+    def v50
+      @xc50 ||= RunLoop::Version.new('5.0')
+    end
+
+    # Are we running Xcode 6.4 or above?
+    #
+    # @return [Boolean] `true` if the current Xcode version is >= 6.4
+    def xcode_version_gte_64?
+      @xcode_gte_64 ||= version >= v64
+    end
+
+    # Are we running Xcode 6.3 or above?
+    #
+    # @return [Boolean] `true` if the current Xcode version is >= 6.3
+    def xcode_version_gte_63?
+      @xcode_gte_63 ||= version >= v63
+    end
+
+    # Are we running Xcode 6.2 or above?
+    #
+    # @return [Boolean] `true` if the current Xcode version is >= 6.2
+    def xcode_version_gte_62?
+      @xcode_gte_62 ||= version >= v62
+    end
+
+    # Are we running Xcode 6.1 or above?
+    #
+    # @return [Boolean] `true` if the current Xcode version is >= 6.1
+    def xcode_version_gte_61?
+      @xcode_gte_61 ||= version >= v61
+    end
+
+    # Are we running Xcode 6 or above?
+    #
+    # @return [Boolean] `true` if the current Xcode version is >= 6.0
+    def xcode_version_gte_6?
+      @xcode_gte_6 ||= version >= v60
+    end
+
+    # Are we running Xcode 7 or above?
+    #
+    # @return [Boolean] `true` if the current Xcode version is >= 7.0
+    def xcode_version_gte_7?
+      @xcode_gte_7 ||= version >= v70
+    end
+
+    # Are we running Xcode 5.1 or above?
+    #
+    # @return [Boolean] `true` if the current Xcode version is >= 5.1
+    def xcode_version_gte_51?
+      @xcode_gte_51 ||= version >= v51
+    end
+
+
+    private
+
+    attr_reader :xcode_versions
+
+    def xcode_versions
+      @xcode_versions ||= {}
+    end
+
+    def fetch_version(key)
+      ensure_valid_version_key key
+      value = xcode_versions[key]
+
+      return value if value
+
+      version_string = string.split(/(?!^)/).join('.')
+      version = RunLoop::Version.new(version_string)
+      xcode_versions[key] = version
+      version
+    end
+
+    def ensure_valid_version_key(key)
+      string = key.to_s
+      if string.length != 3
+        raise "Expected version key '#{key}' to have exactly 3 characters"
+      end
+
+      unless string[/v\d{2}/, 0]
+        raise "Expected version key '#{key}' to match vXX pattern"
+      end
+    end
+  end
+end

--- a/lib/run_loop/xcode.rb
+++ b/lib/run_loop/xcode.rb
@@ -132,6 +132,28 @@ module RunLoop
       end.call
     end
 
+    # Returns the path to the current developer directory.
+    #
+    # From the man pages:
+    #
+    # ```
+    # $ man xcode-select
+    # DEVELOPER_DIR
+    # Overrides the active developer directory. When DEVELOPER_DIR is set,
+    # its value will be used instead of the system-wide active developer
+    # directory.
+    #```
+    #
+    # @return [String] path to current developer directory
+    def developer_dir
+      @xcode_developer_dir ||=
+            if RunLoop::Environment.developer_dir
+              RunLoop::Environment.developer_dir
+            else
+              xcode_select_path
+            end
+    end
+
     private
 
     attr_reader :xcode_versions
@@ -168,6 +190,12 @@ module RunLoop
     def execute_command(args)
       Open3.popen3('xcrun', 'xcodebuild', *args) do |_, stdout, stderr, wait_thr|
         yield stdout, stderr, wait_thr
+      end
+    end
+
+    def xcode_select_path
+      Open3.popen3('xcode-select', '--print-path') do |_, stdout, _, _|
+        stdout.read.chomp
       end
     end
   end

--- a/lib/run_loop/xcode.rb
+++ b/lib/run_loop/xcode.rb
@@ -9,7 +9,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 7.0
     def v70
-      @xc70 ||= RunLoop::Version.new('7.0')
+      fetch_version(:v70)
     end
 
     # Returns a version instance for `Xcode 6.4`; used to check for the
@@ -17,7 +17,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 6.4
     def v64
-      @xc64 ||= RunLoop::Version.new('6.4')
+      fetch_version(:v64)
     end
 
     # Returns a version instance for `Xcode 6.3`; used to check for the
@@ -25,7 +25,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 6.3
     def v63
-      @xc63 ||= RunLoop::Version.new('6.3')
+      fetch_version(:v63)
     end
 
     # Returns a version instance for `Xcode 6.2`; used to check for the
@@ -33,7 +33,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 6.2
     def v62
-      @xc62 ||= RunLoop::Version.new('6.2')
+      fetch_version(:v62)
     end
 
     # Returns a version instance for `Xcode 6.1`; used to check for the
@@ -41,7 +41,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 6.1
     def v61
-      @xc61 ||= RunLoop::Version.new('6.1')
+      fetch_version(:v61)
     end
 
     # Returns a version instance for `Xcode 6.0`; used to check for the
@@ -49,7 +49,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 6.0
     def v60
-      @xc60 ||= RunLoop::Version.new('6.0')
+      fetch_version(:v60)
     end
 
     # Returns a version instance for `Xcode 5.1`; used to check for the
@@ -57,10 +57,10 @@ module RunLoop
     #
     # @return [RunLoop::Version] 5.1
     def v51
-      @xc51 ||= RunLoop::Version.new('5.1')
+      fetch_version(:v51)
     end
 
-    # Returns a version instance for `Xcode 5.0`; ; used to check for the
+    # Returns a version instance for `Xcode 5.0`; used to check for the
     # availability of features and paths to various items on the filesystem.
     #
     # @return [RunLoop::Version] 5.0
@@ -117,7 +117,6 @@ module RunLoop
       @xcode_gte_51 ||= version >= v51
     end
 
-
     private
 
     attr_reader :xcode_versions
@@ -132,6 +131,8 @@ module RunLoop
 
       return value if value
 
+      string = key.to_s
+      string[0] = ''
       version_string = string.split(/(?!^)/).join('.')
       version = RunLoop::Version.new(version_string)
       xcode_versions[key] = version

--- a/spec/integration/xcode_spec.rb
+++ b/spec/integration/xcode_spec.rb
@@ -1,0 +1,20 @@
+describe RunLoop::Xcode do
+
+  let(:xcode) { RunLoop::Xcode.new }
+
+  it '#version' do
+    stdout = %q(
+Xcode 7.0.1
+Build version 7A192o
+)
+    yielded = [StringIO.new(stdout), StringIO.new(''), nil]
+    expect(xcode).to receive(:execute_command).with(['-version']).and_yield(*yielded)
+
+    expected = RunLoop::Version.new('7.0.1')
+    expect(xcode.version).to be == expected
+    expect(xcode.instance_variable_get(:@xcode_version)).to be == expected
+
+    #Testing memoization
+    expect(xcode.version).to be == expected
+  end
+end

--- a/spec/integration/xcode_spec.rb
+++ b/spec/integration/xcode_spec.rb
@@ -17,4 +17,10 @@ Build version 7A192o
     #Testing memoization
     expect(xcode.version).to be == expected
   end
+
+  it '#xcode_select_path' do
+    path = xcode.send(:xcode_select_path)
+    expect(Dir.exist?(path)).to be_truthy
+    expect(path[/Contents\/Developer/, 0]).to be_truthy
+  end
 end

--- a/spec/lib/xcode_spec.rb
+++ b/spec/lib/xcode_spec.rb
@@ -32,7 +32,37 @@ describe RunLoop::Xcode do
     it 'does not raise an error for valid keys' do
       expect do
         xcode.send(:ensure_valid_version_key, :v70)
-      end.not_to raise_error RuntimeError
+      end.not_to raise_error
     end
   end
+
+  it '#xcode_versions' do
+    expect(xcode.instance_variable_get(:@xcode_versions)).to be == nil
+    expect(xcode.send(:xcode_versions)).to be == {}
+    expect(xcode.instance_variable_get(:@xcode_versions)).to be == {}
+  end
+
+  it '#fetch_version' do
+    key = :v70
+    expect(xcode).to receive(:ensure_valid_version_key).with(key).twice
+
+    version = RunLoop::Version.new('7.0')
+    expect(xcode.send(:fetch_version, key)).to be == version
+    variable = xcode.instance_variable_get(:@xcode_versions)
+    expect(variable[key]).to be == version
+
+    # Test memoization
+    expect(xcode).to receive(:xcode_versions).once.and_call_original
+    expect(xcode.send(:fetch_version, key)).to be == version
+  end
+
+  it '#v70' do expect(xcode.v70).to be == RunLoop::Version.new('7.0') end
+  it '#v64' do expect(xcode.v64).to be == RunLoop::Version.new('6.4') end
+  it '#v63' do expect(xcode.v63).to be == RunLoop::Version.new('6.3') end
+  it '#v62' do expect(xcode.v62).to be == RunLoop::Version.new('6.2') end
+  it '#v61' do expect(xcode.v61).to be == RunLoop::Version.new('6.1') end
+  it '#v60' do expect(xcode.v60).to be == RunLoop::Version.new('6.0') end
+  it '#v51' do expect(xcode.v51).to be == RunLoop::Version.new('5.1') end
+  it '#v50' do expect(xcode.v50).to be == RunLoop::Version.new('5.0') end
+
 end

--- a/spec/lib/xcode_spec.rb
+++ b/spec/lib/xcode_spec.rb
@@ -1,0 +1,38 @@
+describe RunLoop::Xcode do
+
+  let(:xcode) { RunLoop::Xcode.new }
+
+  describe '#ensure_valid_version_key' do
+    describe 'raises error when key format is not correct' do
+      it 'key is too short' do
+        expect do
+          xcode.send(:ensure_valid_version_key, :v7)
+        end.to raise_error RuntimeError
+      end
+
+      it 'key is too long' do
+        expect do
+          xcode.send(:ensure_valid_version_key, :v701)
+        end.to raise_error RuntimeError
+      end
+
+      it 'key does not start with v' do
+        expect do
+          xcode.send(:ensure_valid_version_key, :a70)
+        end.to raise_error RuntimeError
+      end
+
+      it 'key does have two integers' do
+        expect do
+          xcode.send(:ensure_valid_version_key, :v7a)
+        end.to raise_error RuntimeError
+      end
+    end
+
+    it 'does not raise an error for valid keys' do
+      expect do
+        xcode.send(:ensure_valid_version_key, :v70)
+      end.not_to raise_error RuntimeError
+    end
+  end
+end

--- a/spec/lib/xcode_spec.rb
+++ b/spec/lib/xcode_spec.rb
@@ -170,4 +170,30 @@ describe RunLoop::Xcode do
       expect(xcode.version_gte_51?).to be_falsey
     end
   end
+
+  describe '#developer_dir' do
+    it 'respects the DEVELOPER_DIR env var' do
+      expected = '/developer/dir'
+      stub_env({'DEVELOPER_DIR' => expected})
+
+      expect(xcode.developer_dir).to be == expected
+
+      expect(RunLoop::Environment).not_to receive(:developer_dir)
+
+      expect(xcode.instance_variable_get(:@xcode_developer_dir)).to be == expected
+    end
+
+    it 'or it returns the value of xcode-select' do
+      expected = '/xcode-select/path'
+      expect(xcode).to receive(:xcode_select_path).and_return(expected)
+      stub_env({'DEVELOPER_DIR' => nil})
+
+      expect(xcode.developer_dir).to be == '/xcode-select/path'
+
+      expect(RunLoop::Environment).not_to receive(:developer_dir)
+      expect(xcode).not_to receive(:xcode_select_path)
+
+      expect(xcode.instance_variable_get(:@xcode_developer_dir)).to be == expected
+    end
+  end
 end

--- a/spec/lib/xcode_spec.rb
+++ b/spec/lib/xcode_spec.rb
@@ -65,4 +65,109 @@ describe RunLoop::Xcode do
   it '#v51' do expect(xcode.v51).to be == RunLoop::Version.new('5.1') end
   it '#v50' do expect(xcode.v50).to be == RunLoop::Version.new('5.0') end
 
+  describe '#version_gte_7?' do
+    it 'true' do
+      expect(xcode).to receive(:version).and_return(xcode.v70,
+                                                    RunLoop::Version.new('8.0'))
+
+      expect(xcode.version_gte_7?).to be_truthy
+      expect(xcode.version_gte_7?).to be_truthy
+    end
+
+    it 'false' do
+      expect(xcode).to receive(:version).and_return xcode.v64
+
+      expect(xcode.version_gte_7?).to be_falsey
+    end
+  end
+
+  describe '#version_gte_64?' do
+    it 'true' do
+      expect(xcode).to receive(:version).and_return(xcode.v64, xcode.v70)
+
+      expect(xcode.version_gte_64?).to be_truthy
+      expect(xcode.version_gte_64?).to be_truthy
+    end
+
+    it 'false' do
+      expect(xcode).to receive(:version).and_return xcode.v63
+
+      expect(xcode.version_gte_64?).to be_falsey
+    end
+  end
+
+  describe '#version_gte_63?' do
+    it 'true' do
+      expect(xcode).to receive(:version).and_return(xcode.v63, xcode.v64)
+
+      expect(xcode.version_gte_63?).to be_truthy
+      expect(xcode.version_gte_63?).to be_truthy
+    end
+
+    it 'false' do
+      expect(xcode).to receive(:version).and_return xcode.v62
+
+      expect(xcode.version_gte_63?).to be_falsey
+    end
+  end
+
+  describe '#version_gte_62?' do
+    it 'true' do
+      expect(xcode).to receive(:version).and_return(xcode.v62, xcode.v63)
+
+      expect(xcode.version_gte_62?).to be_truthy
+      expect(xcode.version_gte_62?).to be_truthy
+    end
+
+    it 'false' do
+      expect(xcode).to receive(:version).and_return xcode.v61
+
+      expect(xcode.version_gte_62?).to be_falsey
+    end
+  end
+
+  describe '#version_gte_61?' do
+    it 'true' do
+      expect(xcode).to receive(:version).and_return(xcode.v61, xcode.v62)
+
+      expect(xcode.version_gte_61?).to be_truthy
+      expect(xcode.version_gte_61?).to be_truthy
+    end
+
+    it 'false' do
+      expect(xcode).to receive(:version).and_return xcode.v60
+
+      expect(xcode.version_gte_61?).to be_falsey
+    end
+  end
+
+  describe '#version_gte_6?' do
+    it 'true' do
+      expect(xcode).to receive(:version).and_return(xcode.v60, xcode.v70)
+
+      expect(xcode.version_gte_6?).to be_truthy
+      expect(xcode.version_gte_6?).to be_truthy
+    end
+
+    it 'false' do
+      expect(xcode).to receive(:version).and_return xcode.v51
+
+      expect(xcode.version_gte_6?).to be_falsey
+    end
+  end
+
+  describe '#version_gte_51?' do
+    it 'true' do
+      expect(xcode).to receive(:version).and_return(xcode.v51, xcode.v60)
+
+      expect(xcode.version_gte_51?).to be_truthy
+      expect(xcode.version_gte_51?).to be_truthy
+    end
+
+    it 'false' do
+      expect(xcode).to receive(:version).and_return xcode.v50
+
+      expect(xcode.version_gte_51?).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
### Motivation

Xcode 7.0's instruments output has changed.

This new Xcode class is designed to take over some of the duties of the XCTools.

The XCTools class will be deprecated and its behaviors divided into three classes:

* Xcode
* Instruments
* L10n
