### PR TITLE
Stabilize integration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ For continuous TDD/BDD see the Guard section below.
 
 Do not try to run the integration tests in a tmux session.  Trust me.
 
+```
+$ be rake integration
+```
+
 ##### Device Testing
 
 * Requires ideviceinstaller.
@@ -97,7 +101,7 @@ the rspec tests will do regression testing against each version.
 Requires MacOS Growl - available in the AppStore.
 
 ```
-$ bundle exec guard start
+$ be guard
 ```
 
 Only the unit tests are run by guard.

--- a/Rakefile
+++ b/Rakefile
@@ -2,12 +2,20 @@ require 'bundler'
 Bundler::GemHelper.install_tasks
 
 begin
+
   require 'rspec/core/rake_task'
-  RSpec::Core::RakeTask.new(:spec)
+  RSpec::Core::RakeTask.new(:spec) do |task|
+    task.pattern = 'spec/lib/**{,/*/**}/*_spec.rb'
+  end
 
   RSpec::Core::RakeTask.new(:unit) do |task|
     task.pattern = 'spec/lib/**{,/*/**}/*_spec.rb'
   end
+
+  RSpec::Core::RakeTask.new(:integration) do |task|
+    task.pattern = 'spec/integration/**{,/*/**}/*_spec.rb'
+  end
+
 rescue LoadError => _
 end
 

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -134,8 +134,10 @@ module RunLoop
         # CoreSimulator
 
         udid = launch_options[:udid]
+        xcode = sim_control.xcode
+
         device = sim_control.simulators.detect do |sim|
-          sim.udid == udid || sim.instruments_identifier == udid
+          sim.udid == udid || sim.instruments_identifier(xcode) == udid
         end
 
         if device.nil?

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -667,15 +667,15 @@ Please update your sources to pass an instance of RunLoop::Instruments))
       # behavior when GM is released.
       #
       # Xcode 7 Beta versions appear to behavior like Xcode 6 Beta versions.
-      res = templates.select { |name| name == 'Automation' }.first
-      return res if res
+      template = templates.find { |name| name == 'Automation' }
+      return template if template
 
-      candidate = templates.select do |path|
+      candidate = templates.find do |path|
         path =~ /\/Automation.tracetemplate/ and path =~ /Xcode/
       end
 
-      if !candidate.empty? && !candidate.first.nil?
-        return candidate.first.tr("\"", '').strip
+      if !candidate.nil?
+        return candidate.tr("\"", '').strip
       end
 
       message = ['Expected instruments to report an Automation tracetemplate.',

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -56,7 +56,7 @@ module RunLoop
     #  optimize performance (via memoization).
     # @option options [RunLoop::SimControl] :sim_control An instance of
     #  SimControl.
-    # @option options [RunLoop::Instruments] :instrumetns An instance of
+    # @option options [RunLoop::Instruments] :instruments An instance of
     #  Instruments.
     #
     # @return [RunLoop::Device] A device that matches `udid_or_name`.
@@ -82,8 +82,9 @@ Please update your sources.))
       instruments = merged_options[:instruments]
       sim_control = merged_options[:sim_control]
 
+      xcode = sim_control.xcode
       simulator = sim_control.simulators.detect do |sim|
-        sim.instruments_identifier == udid_or_name ||
+        sim.instruments_identifier(xcode) == udid_or_name ||
               sim.udid == udid_or_name
       end
 
@@ -101,7 +102,7 @@ Please update your sources.))
 
     def to_s
       if simulator?
-        "#<Simulator: #{instruments_identifier} #{udid} #{instruction_set}>"
+        "#<Simulator: #{name} #{udid} #{instruction_set}>"
       else
         "#<Device: #{name} #{udid}>"
       end
@@ -109,6 +110,9 @@ Please update your sources.))
 
     # Returns and instruments-ready device identifier that is a suitable value
     # for DEVICE_TARGET environment variable.
+    #
+    # @note As of 1.5.0, the XCTools optional argument has become a non-optional
+    #  Xcode argument.
     #
     # @param [RunLoop::Xcode, RunLoop::XCTools] xcode The version of the active
     #  Xcode.
@@ -119,7 +123,7 @@ Please update your sources.))
       if xcode.is_a?(RunLoop::XCTools)
         RunLoop.deprecated('1.5.0',
                            %q(
-RunLoop::XCTools has been replaced with RunLoop::Xcode.
+RunLoop::XCTools has been replaced with a non-optional RunLoop::Xcode argument.
 Please update your sources to pass an instance of RunLoop::Xcode))
       end
 

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -1012,7 +1012,7 @@ module RunLoop
       hash = {}
 
       simulators.each do |device|
-        launch_name = device.instruments_identifier
+        launch_name = device.instruments_identifier(xcode)
         udid = device.udid
         value = {
               :launch_name => device.instruments_identifier(xcode),

--- a/lib/run_loop/simctl/bridge.rb
+++ b/lib/run_loop/simctl/bridge.rb
@@ -194,7 +194,12 @@ module RunLoop::Simctl
             ['launchd_sim', true],
 
             # Yes, but does not always appear.
-            ['CoreSimulatorBridge', true]
+            ['CoreSimulatorBridge', true],
+
+            # Xcode 7
+            ['ids_simd', true],
+            ['com.apple.CoreSimulator.CoreSimulatorService', true],
+            ['com.apple.CoreSimulator.SimVerificationService', true]
       ].each do |pair|
         name = pair[0]
         send_term = pair[1]

--- a/spec/integration/bin/instruments_spec.rb
+++ b/spec/integration/bin/instruments_spec.rb
@@ -1,64 +1,117 @@
-unless Luffa::Environment.travis_ci?
-  require 'run_loop/cli/instruments'
+require 'run_loop/cli/instruments'
 
-  describe RunLoop::CLI::Instruments do
+describe RunLoop::CLI::Instruments do
 
-    context 'quit' do
-      it 'has help' do
-        expect(Luffa.unix_command('bundle exec run-loop instruments help quit',
-                                  {:exit_on_nonzero_status => false})).to be == 0
-      end
-
-      it 'can quit instruments' do
-        sim_control = RunLoop::SimControl.new
-        sim_control.reset_sim_content_and_settings
-
-        options =
-              {
-                    :app => Resources.shared.cal_app_bundle_path,
-                    :device_target => 'simulator',
-                    :sim_control => sim_control
-              }
-
-        hash = nil
-        Retriable.retriable({:tries => Resources.shared.launch_retries}) do
-          hash = RunLoop.run(options)
-        end
-        expect(hash).not_to be nil
-
-        instruments = RunLoop::Instruments.new
-        expect(instruments.instruments_pids.count).to be == 1
-        expect(Luffa.unix_command('bundle exec run-loop instruments quit',
-                                  {:exit_on_nonzero_status => false})).to be == 0
-      end
+  context 'quit' do
+    it 'has help' do
+      expect(Luffa.unix_command('run-loop instruments help quit',
+                                {:exit_on_nonzero_status => false})).to be == 0
     end
 
-    context 'launch' do
-      it 'launching an app on default simulator' do
-        cmd =
-              [
-                    'bundle exec run-loop instruments launch',
-                    "--app #{Resources.shared.cal_app_bundle_path}"
-              ].join(' ')
+    it 'can quit instruments' do
+      sim_control = RunLoop::SimControl.new
+      sim_control.reset_sim_content_and_settings
+
+      options =
+            {
+                  :app => Resources.shared.cal_app_bundle_path,
+                  :device_target => 'simulator',
+                  :sim_control => sim_control
+            }
+
+      hash = nil
+      Retriable.retriable({:tries => Resources.shared.launch_retries}) do
+        hash = RunLoop.run(options)
+      end
+      expect(hash).not_to be nil
+
+      instruments = RunLoop::Instruments.new
+      expect(instruments.instruments_pids.count).to be == 1
+      expect(Luffa.unix_command('run-loop instruments quit',
+                                {:exit_on_nonzero_status => false})).to be == 0
+    end
+  end
+
+  context 'launch' do
+    it 'launching an app on default simulator' do
+      cmd =
+            [
+                  'run-loop instruments launch',
+                  "--app #{Resources.shared.cal_app_bundle_path}"
+            ].join(' ')
 
 
-        expect(Luffa.unix_command(cmd,  {:exit_on_nonzero_status => false})).to be == 0
+      expect(Luffa.unix_command(cmd,  {:exit_on_nonzero_status => false})).to be == 0
+    end
+
+    describe 'launching different simulators' do
+      it 'iOS >= 9' do
+
+        sampled = RunLoop::Instruments.new.simulators.select do |device|
+          device.version >= RunLoop::Version.new('9.0')
+        end.sample
+
+        if sampled.nil?
+          Luffa.log_warn("Skipping test: no iOS Simulators >= 8.0 found")
+        else
+          simulator = sampled.instruments_identifier
+          cmd =
+                [
+                      'run-loop instruments launch',
+                      "--app #{Resources.shared.cal_app_bundle_path}",
+                      "--device \"#{simulator}\""
+                ].join(' ')
+
+          expect(Luffa.unix_command(cmd,  {:exit_on_nonzero_status => false})).to be == 0
+        end
       end
 
-      it 'launching an app on a different simulator' do
-        xcode = RunLoop::Xcode.new.version
-        shared = Luffa::Simulator.instance
-        simulator = shared.core_simulator_for_xcode_version('iPad',
-                                                            'Air',
-                                                            xcode)
-        cmd =
-              [
-                    'bundle exec run-loop instruments launch',
-                    "--app #{Resources.shared.cal_app_bundle_path}",
-                    "--device \"#{simulator}\""
-              ].join(' ')
 
-        expect(Luffa.unix_command(cmd,  {:exit_on_nonzero_status => false})).to be == 0
+      it '8.0 <= iOS < 9.0' do
+
+        sampled = RunLoop::Instruments.new.simulators.select do |device|
+          device.version >= RunLoop::Version.new('8.0') &&
+                device.version < RunLoop::Version.new('9.0') &&
+                device.name[/Resizable/, 0].nil?
+        end.sample
+
+        if sampled.nil?
+          Luffa.log_warn("Skipping test: no 8.0 <= iOS Simulators < 9.0 found")
+        else
+          simulator = sampled.instruments_identifier
+          cmd =
+                [
+                      'run-loop instruments launch',
+                      "--app #{Resources.shared.cal_app_bundle_path}",
+                      "--device \"#{simulator}\""
+                ].join(' ')
+
+          expect(Luffa.unix_command(cmd,  {:exit_on_nonzero_status => false})).to be == 0
+        end
+      end
+
+      it '7.1 <= iOS < 8.0' do
+        sampled = RunLoop::Instruments.new.simulators.select do |device|
+          device.version == RunLoop::Version.new('7.1')
+        end.sample
+
+        if sampled.nil?
+          Luffa.log_warn("Skipping test: no 7.1 <= iOS Simulators < 8.0 found")
+        else
+          simulator = sampled.instruments_identifier
+          cmd =
+                [
+                      'run-loop instruments launch',
+                      "--app #{Resources.shared.cal_app_bundle_path}",
+                      "--device \"#{simulator}\""
+                ].join(' ')
+
+          expect(Luffa.unix_command(cmd,  {:exit_on_nonzero_status => false})).to be == 0
+        end
+      end
+
+      it '7.0.3' do
+        Luffa.log_warn("Skipping iOS 7.0.3 Simulators because they are not supported on Yosemite")
       end
     end
   end

--- a/spec/integration/bin/instruments_spec.rb
+++ b/spec/integration/bin/instruments_spec.rb
@@ -45,16 +45,19 @@ describe RunLoop::CLI::Instruments do
     end
 
     describe 'launching different simulators' do
+      let(:instruments) { RunLoop::Instruments.new }
+      let(:xcode) { instruments.xcode }
+
       it 'iOS >= 9' do
 
-        sampled = RunLoop::Instruments.new.simulators.select do |device|
+        sampled = instruments.simulators.select do |device|
           device.version >= RunLoop::Version.new('9.0')
         end.sample
 
         if sampled.nil?
           Luffa.log_warn("Skipping test: no iOS Simulators >= 8.0 found")
         else
-          simulator = sampled.instruments_identifier
+          simulator = sampled.instruments_identifier(xcode)
           cmd =
                 [
                       'run-loop instruments launch',
@@ -69,7 +72,7 @@ describe RunLoop::CLI::Instruments do
 
       it '8.0 <= iOS < 9.0' do
 
-        sampled = RunLoop::Instruments.new.simulators.select do |device|
+        sampled = instruments.simulators.select do |device|
           device.version >= RunLoop::Version.new('8.0') &&
                 device.version < RunLoop::Version.new('9.0') &&
                 device.name[/Resizable/, 0].nil?
@@ -78,7 +81,7 @@ describe RunLoop::CLI::Instruments do
         if sampled.nil?
           Luffa.log_warn("Skipping test: no 8.0 <= iOS Simulators < 9.0 found")
         else
-          simulator = sampled.instruments_identifier
+          simulator = sampled.instruments_identifier(xcode)
           cmd =
                 [
                       'run-loop instruments launch',
@@ -91,14 +94,14 @@ describe RunLoop::CLI::Instruments do
       end
 
       it '7.1 <= iOS < 8.0' do
-        sampled = RunLoop::Instruments.new.simulators.select do |device|
+        sampled = instruments.simulators.select do |device|
           device.version == RunLoop::Version.new('7.1')
         end.sample
 
         if sampled.nil?
           Luffa.log_warn("Skipping test: no 7.1 <= iOS Simulators < 8.0 found")
         else
-          simulator = sampled.instruments_identifier
+          simulator = sampled.instruments_identifier(xcode)
           cmd =
                 [
                       'run-loop instruments launch',

--- a/spec/integration/bin/simctl_spec.rb
+++ b/spec/integration/bin/simctl_spec.rb
@@ -3,10 +3,13 @@ if Resources.shared.core_simulator_env?
 
   describe RunLoop::CLI::Simctl do
 
+    let(:sim_control) { RunLoop::SimControl.new }
+    let(:xcode) { sim_control.xcode }
+
     let(:bridge) {
       default = RunLoop::Core.default_simulator
-      device = RunLoop::SimControl.new.simulators.detect do |sim|
-        sim.instruments_identifier == default
+      device = sim_control.simulators.detect do |sim|
+        sim.instruments_identifier(xcode) == default
       end
       RunLoop::Simctl::Bridge.new(device, Resources.shared.app_bundle_path)
     }
@@ -89,7 +92,7 @@ if Resources.shared.core_simulator_env?
 
         it 'can install an app on simulator using name' do
           cmd << '--device'
-          cmd << device.instruments_identifier
+          cmd << device.instruments_identifier(xcode)
           Open3.popen3(cmd.shift, *cmd) do |_, stdout, stderr, process_status|
             out = stdout.read.strip
             ap out.split("\n")

--- a/spec/integration/bin/simctl_spec.rb
+++ b/spec/integration/bin/simctl_spec.rb
@@ -1,4 +1,4 @@
-unless Luffa::Environment.travis_ci?
+if Resources.shared.core_simulator_env?
   require 'run_loop/cli/simctl'
 
   describe RunLoop::CLI::Simctl do
@@ -11,9 +11,9 @@ unless Luffa::Environment.travis_ci?
       RunLoop::Simctl::Bridge.new(device, Resources.shared.app_bundle_path)
     }
 
-    describe 'bundle exec run-loop simctl booted' do
+    describe 'run-loop simctl booted' do
 
-      let(:cmd) { 'bundle exec run-loop simctl booted' }
+      let(:cmd) { 'run-loop simctl booted' }
 
       before {
         bridge.shutdown
@@ -24,7 +24,10 @@ unless Luffa::Environment.travis_ci?
         args = cmd.split(' ')
         Open3.popen3(args.shift, *args) do |_, stdout, _, process_status|
           out = stdout.read.strip
-          expect(out).to be == 'No simulator is booted.'
+          ap out.split("\n")
+          xcode_version = Resources.shared.current_xcode_version.to_s
+          expected = "No simulator for active Xcode (version #{xcode_version}) is booted."
+          expect(out).to be == expected
           expect(process_status.value.exitstatus).to be == 0
         end
       end
@@ -34,6 +37,7 @@ unless Luffa::Environment.travis_ci?
         args = cmd.split(' ')
         Open3.popen3(args.shift, *args) do |_, stdout, _, process_status|
           out = stdout.read.strip
+          ap out.split("\n")
           expect(out[/iPhone 5s/, 0]).to be_truthy
           expect(out[/x86_64/, 0]).to be_truthy
           expect(process_status.value.exitstatus).to be == 0
@@ -47,6 +51,10 @@ unless Luffa::Environment.travis_ci?
         'run-loop simctl install --debug --app spec/resources/CalSmoke.app'.split(' ')
       }
 
+      let(:bundle_id_regex) { /Installed 'sh.calaba.CalSmoke'/ }
+      let(:will_not_reinstall_regex) { /Will not re-install 'sh.calaba.CalSmoke' because the SHAs match/ }
+      let(:will_reinstall_regex) { /Will re-install 'sh.calaba.CalSmoke' because the SHAs don't match./}
+
       describe 'app is not installed' do
 
         before {
@@ -58,8 +66,9 @@ unless Luffa::Environment.travis_ci?
         it 'can install an app on default simulator' do
           Open3.popen3(cmd.shift, *cmd) do |_, stdout, stderr, process_status|
             out = stdout.read.strip
+            ap out.split("\n")
             expect(out[/iPhone 5s/, 0]).to be_truthy
-            expect(out[/Installed 'com.xamarin.CalSmoke'/, 0]).to be_truthy
+            expect(out[bundle_id_regex, 0]).to be_truthy
             expect(stderr.read).to be == ''
             expect(process_status.value.exitstatus).to be == 0
           end
@@ -70,8 +79,9 @@ unless Luffa::Environment.travis_ci?
           cmd << device.udid
           Open3.popen3(cmd.shift, *cmd) do |_, stdout, stderr, process_status|
             out = stdout.read.strip
+            ap out.split("\n")
             expect(out[/iPhone 5s/, 0]).to be_truthy
-            expect(out[/Installed 'com.xamarin.CalSmoke'/, 0]).to be_truthy
+            expect(out[bundle_id_regex, 0]).to be_truthy
             expect(stderr.read).to be == ''
             expect(process_status.value.exitstatus).to be == 0
           end
@@ -82,8 +92,9 @@ unless Luffa::Environment.travis_ci?
           cmd << device.instruments_identifier
           Open3.popen3(cmd.shift, *cmd) do |_, stdout, stderr, process_status|
             out = stdout.read.strip
+            ap out.split("\n")
             expect(out[/iPhone 5s/, 0]).to be_truthy
-            expect(out[/Installed 'com.xamarin.CalSmoke'/, 0]).to be_truthy
+            expect(out[bundle_id_regex, 0]).to be_truthy
             expect(stderr.read).to be == ''
             expect(process_status.value.exitstatus).to be == 0
           end
@@ -99,9 +110,10 @@ unless Luffa::Environment.travis_ci?
         it 'skips the install' do
           Open3.popen3(cmd.shift, *cmd) do |_, stdout, stderr, process_status|
             out = stdout.read.strip
+            ap out.split("\n")
             expect(out[/iPhone 5s/, 0]).to be_truthy
-            expect(out[/Installed 'com.xamarin.CalSmoke'/, 0]).to be_truthy
-            expect(out[/Will not re-install 'com.xamarin.CalSmoke' because the SHAs match/, 0]).to be_truthy
+            expect(out[bundle_id_regex, 0]).to be_truthy
+            expect(out[will_not_reinstall_regex, 0]).to be_truthy
             expect(stderr.read).to be == ''
             expect(process_status.value.exitstatus).to be == 0
           end
@@ -112,14 +124,18 @@ unless Luffa::Environment.travis_ci?
         it 're-installs the app' do
           app_bundle_dir = bridge.fetch_app_dir
           path = FileUtils.touch(File.join(app_bundle_dir, 'tmp.txt')).first
+
           File.open(path, 'w') do |file|
             file.write('some text')
           end
+
           Open3.popen3(cmd.shift, *cmd) do |_, stdout, stderr, process_status|
             out = stdout.read.strip
+            ap out.split("\n")
+
             expect(out[/iPhone 5s/, 0]).to be_truthy
-            expect(out[/Installed 'com.xamarin.CalSmoke'/, 0]).to be_truthy
-            expect(out[/Will re-install 'com.xamarin.CalSmoke' because the SHAs don't match/, 0]).to be_truthy
+            expect(out[bundle_id_regex, 0]).to be_truthy
+            expect(out[will_reinstall_regex, 0]).to be_truthy
             expect(stderr.read).to be == ''
             expect(process_status.value.exitstatus).to be == 0
           end
@@ -131,8 +147,9 @@ unless Luffa::Environment.travis_ci?
           cmd << '--force'
           Open3.popen3(cmd.shift, *cmd) do |_, stdout, stderr, process_status|
             out = stdout.read.strip
+            ap out.split("\n")
             expect(out[/iPhone 5s/, 0]).to be_truthy
-            expect(out[/Installed 'com.xamarin.CalSmoke'/, 0]).to be_truthy
+            expect(out[bundle_id_regex, 0]).to be_truthy
             expect(out[/Will force a re-install/, 0]).to be_truthy
             expect(stderr.read).to be == ''
             expect(process_status.value.exitstatus).to be == 0

--- a/spec/integration/dylib_injector_spec.rb
+++ b/spec/integration/dylib_injector_spec.rb
@@ -1,4 +1,4 @@
-if Resources.core_simulator_env? && Resources.shared.whoami == 'moody'
+if Resources.shared.core_simulator_env? && Resources.shared.whoami == 'moody'
 
   describe RunLoop::DylibInjector do
 

--- a/spec/integration/dylib_injector_spec.rb
+++ b/spec/integration/dylib_injector_spec.rb
@@ -1,4 +1,5 @@
-if !Resources.shared.travis_ci? && Resources.shared.whoami == 'moody'
+if Resources.core_simulator_env? && Resources.shared.whoami == 'moody'
+
   describe RunLoop::DylibInjector do
 
     def select_random_shutdown_sim
@@ -25,7 +26,7 @@ if !Resources.shared.travis_ci? && Resources.shared.whoami == 'moody'
           app = RunLoop::App.new(abp)
           dylib = Resources.shared.sim_dylib_path
           injector = RunLoop::DylibInjector.new(app.executable_name, dylib)
-          expect { injector.inject_dylib_with_timeout(1) }.to raise_error
+          expect { injector.inject_dylib_with_timeout(1) }.to raise_error RuntimeError
         end
       end
     end

--- a/spec/integration/instruments_spec.rb
+++ b/spec/integration/instruments_spec.rb
@@ -182,9 +182,7 @@ describe RunLoop::Instruments do
 
       Resources.shared.launch_sim_with_options(options) do |hash|
         expect(hash).not_to be nil
-        expect(instruments.instance_eval {
-                 pids_from_ps_output.count
-               }).to be == 1
+        expect(instruments.send(:pids_from_ps_output).count).to be == 1
       end
     end
   end

--- a/spec/integration/process_terminator_spec.rb
+++ b/spec/integration/process_terminator_spec.rb
@@ -13,7 +13,7 @@ describe RunLoop::ProcessTerminator do
         terminator = RunLoop::ProcessTerminator.new(pid, 'TERM', process_name, options)
         expect {
           terminator.send(:wait_for_process_to_terminate)
-        }.to raise_error
+        }.to raise_error RuntimeError
       end
     end
 

--- a/spec/integration/process_waiter_spec.rb
+++ b/spec/integration/process_waiter_spec.rb
@@ -25,7 +25,7 @@ describe RunLoop::ProcessWaiter do
       options = {:timeout => 1, :raise_on_timeout => true }
       waiter = RunLoop::ProcessWaiter.new('ruby', options)
       expect(waiter).to receive(:running_process?).at_least(:twice).and_return(false)
-      expect { waiter.wait_for_any }.to raise_error
+      expect { waiter.wait_for_any }.to raise_error RuntimeError
     end
 
     it 'can log how long it waited' do
@@ -60,7 +60,7 @@ describe RunLoop::ProcessWaiter do
     it 'raises an error' do
       options = {:timeout => 1, :raise_on_timeout => true }
       waiter = RunLoop::ProcessWaiter.new('ruby', options)
-      expect { waiter.wait_for_none }.to raise_error
+      expect { waiter.wait_for_none }.to raise_error RuntimeError
     end
 
     it 'can log how long it waited' do
@@ -84,7 +84,7 @@ describe RunLoop::ProcessWaiter do
       it 'cannot find n processes and options say :raise' do
         options = {:timeout => 1, :raise_on_timeout => true }
         waiter = RunLoop::ProcessWaiter.new('ruby', options)
-        expect { waiter.wait_for_n(1000) }.to raise_error
+        expect { waiter.wait_for_n(1000) }.to raise_error RuntimeError
       end
     end
 

--- a/spec/integration/run_loop_spec.rb
+++ b/spec/integration/run_loop_spec.rb
@@ -6,7 +6,7 @@ describe 'RunLoop' do
 
     it 'raises error if Instruments.app is running' do
       Resources.shared.launch_instruments_app
-      expect { RunLoop.run }.to raise_error
+      expect { RunLoop.run }.to raise_error RuntimeError
     end
   end
 end

--- a/spec/integration/sim_control_spec.rb
+++ b/spec/integration/sim_control_spec.rb
@@ -234,7 +234,7 @@ describe RunLoop::SimControl do
         end
 
         it 'SDK >= 9.0' do
-          if sdk8_device
+          if sdk9_device
             expect(sim_control.enable_accessibility(sdk9_device)).to be_truthy
           else
             Luffa.log_warn('Skipping test: could not find an iOS Simulator >= 9.0')

--- a/spec/integration/sim_control_spec.rb
+++ b/spec/integration/sim_control_spec.rb
@@ -66,7 +66,7 @@ describe RunLoop::SimControl do
     before(:each) {  RunLoop::SimControl.terminate_all_sims }
     it "with Xcode #{Resources.shared.current_xcode_version} returns a path that exists" do
       sim_control.relaunch_sim
-      path = sim_control.instance_eval { sim_app_support_dir }
+      path = sim_control.send(:sim_app_support_dir)
       expect(File.exist?(path)).to be == true
     end
 
@@ -83,7 +83,7 @@ describe RunLoop::SimControl do
             Resources.shared.with_developer_dir(developer_dir) do
               local_sim_control = RunLoop::SimControl.new
               local_sim_control.relaunch_sim
-              path = local_sim_control.instance_eval { sim_app_support_dir }
+              path = local_sim_control.send(:sim_app_support_dir)
               expect(File.exist?(path)).to be == true
             end
           end
@@ -101,7 +101,7 @@ describe RunLoop::SimControl do
 
       it "with Xcode #{Resources.shared.current_xcode_version}" do
         sim_control.reset_sim_content_and_settings
-        actual = sim_control.instance_eval { existing_sim_sdk_or_device_data_dirs }
+        actual = sim_control.send(:existing_sim_sdk_or_device_data_dirs)
         expect(actual).to be_a Array
         expect(actual.count).to be >= 1
       end
@@ -109,7 +109,7 @@ describe RunLoop::SimControl do
       if Resources.shared.core_simulator_env?
         describe "with Xcode #{Resources.shared.current_xcode_version}" do
           it "can reset the content and settings on a single simulator" do
-            udid = sim_control.instance_eval { sim_details :udid }.keys.sample
+            udid = sim_control.send(:sim_details, :udid).keys.sample
             options = {:sim_udid => udid}
             sim_control.reset_sim_content_and_settings(options)
             containers_dir = Resources.shared.core_simulator_device_containers_dir(udid)
@@ -138,7 +138,10 @@ describe RunLoop::SimControl do
     it 'raises an error if on Xcode < 6' do
       local_sim_control = RunLoop::SimControl.new
       expect(local_sim_control).to receive(:xcode_version_gte_6?).and_return(false)
-      expect { local_sim_control.instance_eval { simctl_reset } }.to raise_error RuntimeError
+
+      expect do
+        local_sim_control.send(:simctl_reset)
+      end.to raise_error RuntimeError
     end
 
     if Resources.shared.core_simulator_env?
@@ -152,9 +155,11 @@ describe RunLoop::SimControl do
       end
 
       describe 'when sim_udid arg is not nil' do
+
         it 'raises an error when the sim_udid is invalid' do
-          expect { sim_control.instance_eval { simctl_reset('unknown udid') } }.to raise_error RuntimeError
+          expect { sim_control.send(:simctl_reset, 'unknown udid') }.to raise_error RuntimeError
         end
+
         it 'resets the simulator with corresponding udid' do
           sim_details = sim_control.send(:sim_details, :udid)
           udid = sim_details.keys.sample
@@ -170,13 +175,13 @@ describe RunLoop::SimControl do
     if Resources.shared.core_simulator_env?
       describe 'returns a hash with the primary key' do
         it ':udid' do
-          actual = sim_control.instance_eval { sim_details :udid }
+          actual = sim_control.send(:sim_details, :udid)
           expect(actual).to be_a Hash
           expect(actual.count).to be > 1
         end
 
         it ':launch_name' do
-          actual = sim_control.instance_eval { sim_details :launch_name }
+          actual = sim_control.send(:sim_details, :launch_name)
           expect(actual).to be_a Hash
           expect(actual.count).to be > 1
         end

--- a/spec/integration/sim_control_spec.rb
+++ b/spec/integration/sim_control_spec.rb
@@ -156,9 +156,9 @@ describe RunLoop::SimControl do
           expect { sim_control.instance_eval { simctl_reset('unknown udid') } }.to raise_error RuntimeError
         end
         it 'resets the simulator with corresponding udid' do
-          sim_details = sim_control.instance_eval { sim_details(:udid) }
+          sim_details = sim_control.send(:sim_details, :udid)
           udid = sim_details.keys.sample
-          expect( sim_control.instance_eval { simctl_reset(udid) } ).to be == true
+          expect( sim_control.send(:simctl_reset, udid)).to be == true
           containers_dir = Resources.shared.core_simulator_device_containers_dir(udid)
           expect(File.exist? containers_dir).to be == false
         end
@@ -184,36 +184,63 @@ describe RunLoop::SimControl do
     end
   end
 
-  describe 'plist munging' do
-    let (:sim_control) { RunLoop::SimControl.new }
+  if Resources.shared.core_simulator_env?
+    describe 'plist munging' do
+      let (:sim_control) { RunLoop::SimControl.new }
 
-    let (:sdk8_device) {
-      test = lambda { |device|
-        device.version >= RunLoop::Version.new('8.0')
+      let (:sdk9_device) {
+        test = lambda { |device|
+          device.version >= RunLoop::Version.new('9.0')
+        }
+        Resources.shared.simulator_with_sdk_test(test, sim_control)
       }
-      Resources.shared.simulator_with_sdk_test(test, sim_control)
-    }
 
-    let (:sdk7_device) {
-      test = lambda { |device|
-        device.version < RunLoop::Version.new('8.0')
+      let (:sdk8_device) {
+        test = lambda { |device|
+          device.version >= RunLoop::Version.new('8.0') &&
+                device.version < RunLoop::Version.new('9.0')
+        }
+        Resources.shared.simulator_with_sdk_test(test, sim_control)
       }
+
+      let (:sdk7_device) {
+        test = lambda { |device|
+          device.version < RunLoop::Version.new('8.0')
+        }
       Resources.shared.simulator_with_sdk_test(test, sim_control)
-    }
+      }
 
-    describe 'enable accessibility on a device' do
+      describe 'enable accessibility on a device' do
 
-      it 'SDK < 8.0' do
-        expect(sim_control.enable_accessibility(sdk7_device)).to be_truthy
+        it 'SDK < 8.0' do
+          if sdk7_device
+            expect(sim_control.enable_accessibility(sdk7_device)).to be_truthy
+          else
+            Luffa.log_warn('Skipping test: could not find an iOS 7 simulator')
+          end
+        end
+
+        it '8.0 <= SDK < 9.0' do
+          if sdk8_device
+            expect(sim_control.enable_accessibility(sdk8_device)).to be_truthy
+          else
+            Luffa.log_warn('Skipping test: could not find an 8.0 <= iOS Simulator < 9.0')
+          end
+        end
+
+        it 'SDK >= 9.0' do
+          if sdk8_device
+            expect(sim_control.enable_accessibility(sdk9_device)).to be_truthy
+          else
+            Luffa.log_warn('Skipping test: could not find an iOS Simulator >= 9.0')
+          end
+        end
       end
 
-      it 'SDK >= 8.0' do
-        expect(sim_control.enable_accessibility(sdk8_device)).to be_truthy
+      it 'enable software keyboard on device' do
+        expect(sim_control.enable_software_keyboard(sdk8_device)).to be_truthy
       end
-    end
-
-    it 'enable software keyboard on device' do
-      expect(sim_control.enable_software_keyboard(sdk8_device)).to be_truthy
     end
   end
 end
+

--- a/spec/integration/simctl/bridge_spec.rb
+++ b/spec/integration/simctl/bridge_spec.rb
@@ -1,6 +1,10 @@
-unless Luffa::Environment.travis_ci?
+if Resources.shared.core_simulator_env?
 
   describe RunLoop::Simctl::Bridge do
+
+    before do
+      RunLoop::SimControl.terminate_all_sims
+    end
 
     let (:abp) { Resources.shared.cal_app_bundle_path }
 
@@ -11,10 +15,10 @@ unless Luffa::Environment.travis_ci?
     }
 
     let (:device) {
-      sim_control.simulators.shuffle.detect do |device|
-        [device.state == 'Shutdown',
-         device.name != 'rspec-0test-device',
-         !device.name[/Resizable/,0]].all?
+      sim_control.simulators.find do |device|
+        device.version > RunLoop::Version.new('7.1') &&
+              !device.name[/Resizable/, 0] &&
+              device.name != 'rspec-test-device'
       end
     }
 
@@ -55,5 +59,4 @@ unless Luffa::Environment.travis_ci?
       bridge.reset_app_sandbox
     end
   end
-
 end

--- a/spec/integration/simulator_compatibility_spec.rb
+++ b/spec/integration/simulator_compatibility_spec.rb
@@ -37,7 +37,7 @@ if Resources.shared.core_simulator_env?
         options =
               {
                     :app => Resources.shared.app_bundle_path_i386,
-                    :device_target => air.instruments_identifier,
+                    :device_target => air.instruments_identifier(sim_control.xcode),
                     :sim_control => sim_control
               }
 
@@ -74,7 +74,7 @@ if Resources.shared.core_simulator_env?
           options =
                 {
                       :app => Resources.shared.app_bundle_path_x86_64,
-                      :device_target => ipad2.instruments_identifier,
+                      :device_target => ipad2.instruments_identifier(sim_control.xcode),
                       :sim_control => sim_control
                 }
 

--- a/spec/integration/simulator_compatibility_spec.rb
+++ b/spec/integration/simulator_compatibility_spec.rb
@@ -1,77 +1,85 @@
-describe 'Simulator/Binary Compatibility Check' do
+if Resources.shared.core_simulator_env?
+  describe 'Simulator/Binary Compatibility Check' do
 
-  describe 'can launch if library is FAT' do
-
-    let(:sim_control) {
-      obj = RunLoop::SimControl.new
-      obj.reset_sim_content_and_settings
-      obj
-    }
-
-    it 'can launch if libraries are compatible' do
-      options =
-            {
-                  :app => Resources.shared.cal_app_bundle_path,
-                  :device_target => 'simulator',
-                  :sim_control => sim_control
-            }
-
-      Resources.shared.launch_sim_with_options(options) do |hash|
-        expect(hash).not_to be nil
-      end
+    before do
+      RunLoop::SimControl.terminate_all_sims
     end
 
-    it 'targeting x86_64 simulator with binary that contains only a i386 slice' do
-      # The latest iPad Air
-      air = sim_control.simulators.select do |device|
-        device.name == 'iPad Air'
-      end[-1]
+    describe 'can launch if library is FAT' do
 
-      expect(air).not_to be == nil
-      options =
-            {
-                  :app => Resources.shared.app_bundle_path_i386,
-                  :device_target => air.instruments_identifier,
-                  :sim_control => sim_control
-            }
+      let(:sim_control) {
+        obj = RunLoop::SimControl.new
+        obj.reset_sim_content_and_settings
+        obj
+      }
 
-      Resources.shared.launch_sim_with_options(options) do |hash|
-        expect(hash).not_to be nil
-      end
-    end
-  end
-
-  describe 'raises an error if libraries are not compatible' do
-
-    let(:sim_control) { RunLoop::SimControl.new }
-
-    it 'target only has arm slices' do
-      options =
-            {
-                  :app => Resources.shared.app_bundle_path_arm_FAT,
-                  :device_target => 'simulator',
-                  :sim_control => sim_control
-            }
-
-      expect {  RunLoop.run(options) }.to raise_error RunLoop::IncompatibleArchitecture
-    end
-
-    if Resources.shared.core_simulator_env?
-      it 'targeting i386 simulator with binary that contains only a x86_64 slice' do
-        # The latest iPad 2; will eventually fail when the iPad 2 is no longer supported. :(
-         ipad2 = sim_control.simulators.select do |device|
-          device.name == 'iPad 2'
-        end[-1]
-
-        expect(ipad2).not_to be == nil
+      it 'can launch if libraries are compatible' do
         options =
               {
-                    :app => Resources.shared.app_bundle_path_x86_64,
-                    :device_target => ipad2.instruments_identifier,
+                    :app => Resources.shared.cal_app_bundle_path,
+                    :device_target => 'simulator',
                     :sim_control => sim_control
               }
 
-        expect {  RunLoop.run(options) }.to raise_error RunLoop::IncompatibleArchitecture
+        Resources.shared.launch_sim_with_options(options) do |hash|
+          expect(hash).not_to be nil
+        end
+      end
+
+      it 'targeting x86_64 simulator with binary that contains only a i386 slice' do
+        # The latest iPad Air
+        air = sim_control.simulators.find do |device|
+          device.name == 'iPad Air' &&
+                device.version > RunLoop::Version.new('7.1')
+        end
+
+        expect(air).not_to be == nil
+        options =
+              {
+                    :app => Resources.shared.app_bundle_path_i386,
+                    :device_target => air.instruments_identifier,
+                    :sim_control => sim_control
+              }
+
+        Resources.shared.launch_sim_with_options(options) do |hash|
+          expect(hash).not_to be nil
+        end
+      end
+    end
+
+    describe 'raises an error if libraries are not compatible' do
+
+      let(:sim_control) { RunLoop::SimControl.new }
+
+      it 'target only has arm slices' do
+        options =
+              {
+                    :app => Resources.shared.app_bundle_path_arm_FAT,
+                    :device_target => 'simulator',
+                    :sim_control => sim_control
+              }
+
+        expect { RunLoop.run(options) }.to raise_error RunLoop::IncompatibleArchitecture
+      end
+
+      if Resources.shared.core_simulator_env?
+        it 'targeting i386 simulator with binary that contains only a x86_64 slice' do
+          # The latest iPad 2; will eventually fail when the iPad 2 is no longer supported. :(
+          ipad2 = sim_control.simulators.find do |device|
+            device.name == 'iPad 2' &&
+                  device.version > RunLoop::Version.new('7.1')
+          end
+
+          expect(ipad2).not_to be == nil
+          options =
+                {
+                      :app => Resources.shared.app_bundle_path_x86_64,
+                      :device_target => ipad2.instruments_identifier,
+                      :sim_control => sim_control
+                }
+
+          expect { RunLoop.run(options) }.to raise_error RunLoop::IncompatibleArchitecture
+        end
       end
     end
   end

--- a/spec/lib/cli/cli_spec.rb
+++ b/spec/lib/cli/cli_spec.rb
@@ -1,19 +1,21 @@
-require 'run_loop/cli/cli'
+if Resources.shared.core_simulator_env?
+  require 'run_loop/cli/cli'
 
-describe RunLoop::CLI do
-  context 'version' do
-    subject { capture_stdout { RunLoop::CLI::Tool.new.version }.string.strip }
-    it { is_expected.to be == RunLoop::VERSION }
-  end
-
-  context 'instruments' do
-    subject { capture_stdout { RunLoop::CLI::Tool.new.instruments }.string }
-    it 'has help for the launch command' do
-      expect(subject[/launch/,0]).to be_truthy
+  describe RunLoop::CLI do
+    context 'version' do
+      subject { capture_stdout { RunLoop::CLI::Tool.new.version }.string.strip }
+      it { is_expected.to be == RunLoop::VERSION }
     end
 
-    it 'has help for the quit command' do
-      expect(subject[/quit/,0]).to be_truthy
+    context 'instruments' do
+      subject { capture_stdout { RunLoop::CLI::Tool.new.instruments }.string }
+      it 'has help for the launch command' do
+        expect(subject[/launch/,0]).to be_truthy
+      end
+
+      it 'has help for the quit command' do
+        expect(subject[/quit/,0]).to be_truthy
+      end
     end
   end
 end

--- a/spec/lib/cli/simctl_spec.rb
+++ b/spec/lib/cli/simctl_spec.rb
@@ -1,126 +1,129 @@
-require 'run_loop/cli/simctl'
+if Resources.shared.core_simulator_env?
 
-describe RunLoop::CLI::Simctl do
+  require 'run_loop/cli/simctl'
 
-  let(:simctl) { RunLoop::CLI::Simctl.new }
-  let(:device) {
-    RunLoop::Device.new('name', '8.1', '134AECE8-0DDB-4A70-AA83-1CB3BC21ACD4', 'Booted')
-  }
-  it '#sim_control' do
-    expect(simctl.sim_control).to be_an_instance_of RunLoop::SimControl
-  end
+  describe RunLoop::CLI::Simctl do
 
-  describe '#booted_device' do
-    it 'returns nil if there are no booted devices' do
-      expect(simctl.sim_control).to receive(:simulators).and_return([])
-      expect(simctl.booted_device).to be == nil
-    end
-
-    it 'returns the first booted device' do
-      expect(simctl.sim_control).to receive(:simulators).and_return([device])
-      expect(simctl.booted_device).to be == device
-    end
-  end
-
-  describe '#expect_device' do
-    describe 'default simulator' do
-      it 'raises error if device cannot be created from default simulator' do
-        expect(simctl.sim_control).to receive(:simulators).and_return([])
-        expect {
-          simctl.expect_device({})
-        }.to raise_error RunLoop::CLI::ValidationError
-
-      end
-
-      it 'can create a device from default simulator' do
-        expect(simctl.sim_control).to receive(:simulators).and_return([device])
-        expect(RunLoop::Core).to receive(:default_simulator).and_return(device.instruments_identifier)
-        expect(simctl.expect_device({})).to be_a_kind_of( RunLoop::Device)
-      end
-    end
-
-    describe 'when passed a UDID or instruments-ready simulator name' do
-      it 'UUID' do
-        expect(simctl.sim_control).to receive(:simulators).and_return([device])
-        options = { :device => device.udid }
-        expect(simctl.expect_device(options).udid).to be == device.udid
-      end
-
-      it 'name' do
-        expect(simctl.sim_control).to receive(:simulators).and_return([device])
-        options = { :device => device.instruments_identifier }
-        expect(simctl.expect_device(options).udid).to be == device.udid
-      end
-
-      it 'raises error error if no match can be found' do
-        expect(simctl.sim_control).to receive(:simulators).and_return([device])
-        options = { :device => 'foobar' }
-        expect {
-          simctl.expect_device(options).udid
-        }.to raise_error RunLoop::CLI::ValidationError
-      end
-    end
-  end
-
-  describe '#expect_app' do
-    let(:options) {
-      options = { :app => Resources.shared.cal_app_bundle_path }
+    let(:simctl) { RunLoop::CLI::Simctl.new }
+    let(:device) {
+      RunLoop::Device.new('name', '8.1', '134AECE8-0DDB-4A70-AA83-1CB3BC21ACD4', 'Booted')
     }
-
-    it 'returns an app' do
-      expect(simctl.expect_app(options, device)).to be_a_kind_of(RunLoop::App)
+    it '#sim_control' do
+      expect(simctl.sim_control).to be_an_instance_of RunLoop::SimControl
     end
 
-    describe 'raises error when' do
-      describe 'app bundle path' do
-        it 'does not exist' do
-          options = { :app => '/some/path/that/does/not/exist' }
+    describe '#booted_device' do
+      it 'returns nil if there are no booted devices' do
+        expect(simctl.sim_control).to receive(:simulators).and_return([])
+        expect(simctl.booted_device).to be == nil
+      end
+
+      it 'returns the first booted device' do
+        expect(simctl.sim_control).to receive(:simulators).and_return([device])
+        expect(simctl.booted_device).to be == device
+      end
+    end
+
+    describe '#expect_device' do
+      describe 'default simulator' do
+        it 'raises error if device cannot be created from default simulator' do
+          expect(simctl.sim_control).to receive(:simulators).and_return([])
           expect {
-            simctl.expect_app(options, device)
+            simctl.expect_device({})
           }.to raise_error RunLoop::CLI::ValidationError
+
         end
 
-        it 'is not a directory' do
-          options = {
-                :app => FileUtils.touch(File.join(Dir.mktmpdir(), 'foo.txt')).first }
-          expect {
-            simctl.expect_app(options, device)
-          }.to raise_error RunLoop::CLI::ValidationError
-        end
-
-        it 'does not have .app extension' do
-          options = {
-                :app => FileUtils.mkdir_p(File.join(Dir.mktmpdir(), 'foo.txt')).first }
-          expect {
-            simctl.expect_app(options, device)
-          }.to raise_error RunLoop::CLI::ValidationError
+        it 'can create a device from default simulator' do
+          expect(simctl.sim_control).to receive(:simulators).and_return([device])
+          expect(RunLoop::Core).to receive(:default_simulator).and_return(device.instruments_identifier)
+          expect(simctl.expect_device({})).to be_a_kind_of( RunLoop::Device)
         end
       end
 
-      describe 'not a valid app' do
-        it 'cannot find the bundle identifier' do
-          expect_any_instance_of(RunLoop::App).to receive(:bundle_identifier).and_raise(RuntimeError)
-          expect {
-            simctl.expect_app(options, device)
-          }.to raise_error RunLoop::CLI::ValidationError
+      describe 'when passed a UDID or instruments-ready simulator name' do
+        it 'UUID' do
+          expect(simctl.sim_control).to receive(:simulators).and_return([device])
+          options = { :device => device.udid }
+          expect(simctl.expect_device(options).udid).to be == device.udid
         end
 
-        it 'cannot find the executable name' do
-          expect_any_instance_of(RunLoop::App).to receive(:executable_name).and_raise(RuntimeError)
-          expect {
-            simctl.expect_app(options, device)
-          }.to raise_error RunLoop::CLI::ValidationError
+        it 'name' do
+          expect(simctl.sim_control).to receive(:simulators).and_return([device])
+          options = { :device => device.instruments_identifier }
+          expect(simctl.expect_device(options).udid).to be == device.udid
         end
 
-        it 'app has incompatible arch' do
-          expect_any_instance_of(RunLoop::Lipo).to(
-                receive(
-                      :expect_compatible_arch
-                ).with(device).and_raise(RunLoop::IncompatibleArchitecture)
-          )
+        it 'raises error error if no match can be found' do
+          expect(simctl.sim_control).to receive(:simulators).and_return([device])
+          options = { :device => 'foobar' }
           expect {
-            simctl.expect_app(options, device)
+            simctl.expect_device(options).udid
           }.to raise_error RunLoop::CLI::ValidationError
+        end
+      end
+    end
+
+    describe '#expect_app' do
+      let(:options) {
+        options = { :app => Resources.shared.cal_app_bundle_path }
+      }
+
+      it 'returns an app' do
+        expect(simctl.expect_app(options, device)).to be_a_kind_of(RunLoop::App)
+      end
+
+      describe 'raises error when' do
+        describe 'app bundle path' do
+          it 'does not exist' do
+            options = { :app => '/some/path/that/does/not/exist' }
+            expect {
+              simctl.expect_app(options, device)
+            }.to raise_error RunLoop::CLI::ValidationError
+          end
+
+          it 'is not a directory' do
+            options = {
+                  :app => FileUtils.touch(File.join(Dir.mktmpdir(), 'foo.txt')).first }
+            expect {
+              simctl.expect_app(options, device)
+            }.to raise_error RunLoop::CLI::ValidationError
+          end
+
+          it 'does not have .app extension' do
+            options = {
+                  :app => FileUtils.mkdir_p(File.join(Dir.mktmpdir(), 'foo.txt')).first }
+            expect {
+              simctl.expect_app(options, device)
+            }.to raise_error RunLoop::CLI::ValidationError
+          end
+        end
+
+        describe 'not a valid app' do
+          it 'cannot find the bundle identifier' do
+            expect_any_instance_of(RunLoop::App).to receive(:bundle_identifier).and_raise(RuntimeError)
+            expect {
+              simctl.expect_app(options, device)
+            }.to raise_error RunLoop::CLI::ValidationError
+          end
+
+          it 'cannot find the executable name' do
+            expect_any_instance_of(RunLoop::App).to receive(:executable_name).and_raise(RuntimeError)
+            expect {
+              simctl.expect_app(options, device)
+            }.to raise_error RunLoop::CLI::ValidationError
+          end
+
+          it 'app has incompatible arch' do
+            expect_any_instance_of(RunLoop::Lipo).to(
+                  receive(
+                        :expect_compatible_arch
+                  ).with(device).and_raise(RunLoop::IncompatibleArchitecture)
+            )
+            expect {
+              simctl.expect_app(options, device)
+            }.to raise_error RunLoop::CLI::ValidationError
+          end
         end
       end
     end

--- a/spec/lib/cli/simctl_spec.rb
+++ b/spec/lib/cli/simctl_spec.rb
@@ -36,8 +36,10 @@ if Resources.shared.core_simulator_env?
 
         it 'can create a device from default simulator' do
           expect(simctl.sim_control).to receive(:simulators).and_return([device])
-          expect(RunLoop::Core).to receive(:default_simulator).and_return(device.instruments_identifier)
-          expect(simctl.expect_device({})).to be_a_kind_of( RunLoop::Device)
+          identifier = device.instruments_identifier(simctl.sim_control.xcode)
+          expect(RunLoop::Core).to receive(:default_simulator).and_return(identifier)
+
+          expect(simctl.expect_device({})).to be_a_kind_of(RunLoop::Device)
         end
       end
 
@@ -50,7 +52,8 @@ if Resources.shared.core_simulator_env?
 
         it 'name' do
           expect(simctl.sim_control).to receive(:simulators).and_return([device])
-          options = { :device => device.instruments_identifier }
+          identifier = device.instruments_identifier(simctl.sim_control.xcode)
+          options = { :device => identifier }
           expect(simctl.expect_device(options).udid).to be == device.udid
         end
 

--- a/spec/lib/device_spec.rb
+++ b/spec/lib/device_spec.rb
@@ -50,6 +50,7 @@ describe RunLoop::Device do
   describe '.device_with_identifier' do
     let(:sim_control) { RunLoop::SimControl.new }
     let(:instruments) { RunLoop::Instruments.new }
+    let(:xcode) { sim_control.xcode }
     let(:options) do
       {
             :sim_control => sim_control,
@@ -99,9 +100,9 @@ describe RunLoop::Device do
 
       it 'find by name' do
         expect(sim_control).to receive(:simulators).and_return([device])
+        identifier = device.instruments_identifier(xcode)
 
-        actual = RunLoop::Device.device_with_identifier(device.instruments_identifier,
-                                                        options)
+        actual = RunLoop::Device.device_with_identifier(identifier, options)
         expect(actual).to be_a_kind_of RunLoop::Device
       end
 

--- a/spec/resources.rb
+++ b/spec/resources.rb
@@ -146,7 +146,7 @@ class Resources
   def random_simulator_device(sim_control)
     @random_simulator_device ||= sim_control.simulators.shuffle.detect do |device|
       [device.state == 'Shutdown',
-         device.name != 'rspec-0test-device',
+         device.name != 'rspec-test-device',
          !device.name[/Resizable/,0]].all?
     end
   end


### PR DESCRIPTION
### Motivation

The integration examples have been suffering from bit rot because they are not part of any CI build.

Took the time to see what is and what is not working on Xcode 7 beta 6.

* simctl is broken.
* instruments is broken for simulators.

I did not have time to run on-device tests for Xcode 7 vs. any iOS version.

Discovered/reproduced [**calabash-ios not working with iOS 7.1 Simulators**](http://stackoverflow.com/questions/32313999/calabash-ios-not-working-with-ios-7-1-simulators)