### PR TITLE
Core.simulator_target? - fixup for Xcode 7

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -10,6 +10,8 @@ module RunLoop
 
   module Core
 
+    include RunLoop::Regex
+
     START_DELIMITER = "OUTPUT_JSON:\n"
     END_DELIMITER="\nEND_OUTPUT"
 
@@ -362,15 +364,7 @@ Please update your sources to pass an instance of RunLoop::Xcode))
       # support for 'simulator' and Xcode >= 5.1 device targets
       return true if value.downcase.include?('simulator')
 
-      # if Xcode < 6.0, we are done
-      return false if not sim_control.xcode_version_gte_6?
-
-      # support for Xcode >= 6 simulator udids
-      return true if sim_control.sim_udid? value
-
-      # support for Xcode >= 6 'named simulators'
-      sims = sim_control.simulators.each
-      sims.find_index { |device| device.name == value } != nil
+      value[DEVICE_UDID_REGEX, 0] == nil
     end
 
     # Extracts the value of :inject_dylib from options Hash.

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -243,10 +243,14 @@ describe RunLoop::Core do
         end
       end
 
-      it ":device_target => Xcode 6 simulator UDID" do
-        expect(sim_control).to receive(:xcode_version_gte_6?).and_return true
+      it ":device_target => CoreSimulator UDID" do
         options = { :device_target => '0BF52B67-F8BB-4246-A668-1880237DD17B' }
-        expect(RunLoop::Core.simulator_target?(options, sim_control)).to be == true
+        expect(RunLoop::Core.simulator_target?(options)).to be == true
+      end
+
+      it 'returns false when target is a physical device' do
+        options = { :device_target => '49b59706a3ac25e997770a91577ef4e6ad0ab7bb' }
+        expect(RunLoop::Core.simulator_target?(options)).to be == false
       end
     end
   end


### PR DESCRIPTION
### Motivation

Xcode 7 simulators do not include the word 'Simulator'.