### PR TITLE
CLI: simctl doctor [--device=DEVICE] - tool to prepare CoreSimulator environment

### DIFF
--- a/lib/run_loop/cli/simctl.rb
+++ b/lib/run_loop/cli/simctl.rb
@@ -52,17 +52,9 @@ module RunLoop
 
         ENV['DEBUG'] = '1' if debug
 
-        RunLoop::SimControl.terminate_all_sims
-
         begin
-          process_name = 'com.apple.CoreSimulator.CoreSimulatorService'
-          pids = RunLoop::ProcessWaiter.new(process_name, {:timeout => 0.2}).pids
-          if debug && pids.empty?
-            puts 'There are no CoreSimulatorServices processes running'
-          end
-          pids.each do |pid|
-            RunLoop::ProcessTerminator.new(pid, 'KILL', process_name).kill_process
-          end
+          RunLoop::SimControl.terminate_all_sims
+          terminate_core_simulator_processes
         ensure
           ENV['DEBUG'] = original_value if debug
         end
@@ -76,6 +68,30 @@ module RunLoop
         def booted_device
           sim_control.simulators.detect(nil) do |device|
             device.state == 'Booted'
+          end
+        end
+
+        # TODO this is duplicated code; extract!
+        # https://github.com/calabash/run_loop/issues/225
+        def terminate_core_simulator_processes
+          RunLoop::LifeCycle::CoreSimulator::MANAGED_PROCESSES.each do |pair|
+            name = pair[0]
+            send_term = pair[1]
+            pids = RunLoop::ProcessWaiter.new(name).pids
+            pids.each do |pid|
+
+              if send_term
+                term = RunLoop::ProcessTerminator.new(pid, 'TERM', name)
+                killed = term.kill_process
+              else
+                killed = false
+              end
+
+              unless killed
+                term = RunLoop::ProcessTerminator.new(pid, 'KILL', name)
+                term.kill_process
+              end
+            end
           end
         end
       end

--- a/lib/run_loop/cli/simctl.rb
+++ b/lib/run_loop/cli/simctl.rb
@@ -37,6 +37,41 @@ module RunLoop
         end
       end
 
+      desc 'doctor', 'EXPERIMENTAL: Prepare the CoreSimulator environment for testing'
+
+      method_option 'debug',
+                    :desc => 'Enable debug logging.',
+                    :aliases => '-v',
+                    :required => false,
+                    :default => false,
+                    :type => :boolean
+
+      def doctor
+        debug = options[:debug]
+
+        if debug
+          RunLoop::Environment.with_debugging do
+            launch_each_simulator
+          end
+        else
+           launch_each_simulator
+        end
+      end
+
+      no_commands do
+        def launch_each_simulator
+          sim_control = RunLoop::SimControl.new
+          sim_control.simulators.each do |simulator|
+            #if simulator.version >= RunLoop::Version.new('9.0')
+              core_sim = RunLoop::LifeCycle::CoreSimulator.new(nil,
+                                                               simulator,
+                                                               sim_control)
+              core_sim.launch_simulator
+            #end
+          end
+        end
+      end
+
       desc 'manage-processes', 'Manage CoreSimulator processes by quiting stale processes'
 
       method_option 'debug',

--- a/lib/run_loop/cli/simctl.rb
+++ b/lib/run_loop/cli/simctl.rb
@@ -37,7 +37,7 @@ module RunLoop
         end
       end
 
-      desc 'refresh', 'EXPERIMENTAL: Terminate CoreSimulatorService daemons'
+      desc 'manage-processes', 'Manage CoreSimulator processes by quiting stale processes'
 
       method_option 'debug',
                     :desc => 'Enable debug logging.',
@@ -46,7 +46,7 @@ module RunLoop
                     :default => false,
                     :type => :boolean
 
-      def refresh
+      def manage_processes
         debug = options[:debug]
         original_value = ENV['DEBUG']
 

--- a/lib/run_loop/cli/simctl.rb
+++ b/lib/run_loop/cli/simctl.rb
@@ -46,15 +46,33 @@ module RunLoop
                     :default => false,
                     :type => :boolean
 
+      method_option 'device',
+                    :desc => 'The simulator UDID or name.',
+                    :aliases => '-d',
+                    :required => false,
+                    :type => :string
+
       def doctor
         debug = options[:debug]
+        device = options[:device]
 
-        if debug
-          RunLoop::Environment.with_debugging do
-            launch_each_simulator
+        if device
+          device = expect_device(options)
+          if debug
+            RunLoop::Environment.with_debugging do
+              launch_simulator(device)
+            end
+          else
+            launch_simulator(device)
           end
         else
-           launch_each_simulator
+          if debug
+            RunLoop::Environment.with_debugging do
+              launch_each_simulator
+            end
+          else
+            launch_each_simulator
+          end
         end
       end
 
@@ -62,13 +80,15 @@ module RunLoop
         def launch_each_simulator
           sim_control = RunLoop::SimControl.new
           sim_control.simulators.each do |simulator|
-            #if simulator.version >= RunLoop::Version.new('9.0')
-              core_sim = RunLoop::LifeCycle::CoreSimulator.new(nil,
-                                                               simulator,
-                                                               sim_control)
-              core_sim.launch_simulator
-            #end
+            launch_simulator(simulator, sim_control)
           end
+        end
+
+        def launch_simulator(simulator, sim_control=RunLoop::SimControl.new)
+          core_sim = RunLoop::LifeCycle::CoreSimulator.new(nil,
+                                                           simulator,
+                                                           sim_control)
+          core_sim.launch_simulator
         end
       end
 
@@ -140,7 +160,7 @@ module RunLoop
                     :type => :string
 
       method_option 'device',
-                    :desc => 'The device UDID or simulator identifier.',
+                    :desc => 'The simulator UDID or name.',
                     :aliases => '-d',
                     :required => false,
                     :type => :string

--- a/lib/run_loop/directory.rb
+++ b/lib/run_loop/directory.rb
@@ -1,10 +1,10 @@
-require 'digest'
-require 'openssl'
-
 module RunLoop
 
   # Class for performing operations on directories.
   class Directory
+    require 'digest'
+    require 'openssl'
+    require 'pathname'
 
     # Dir.glob ignores files that start with '.', but we often need to find
     # dotted files and directories.
@@ -41,7 +41,11 @@ module RunLoop
 
       sha = OpenSSL::Digest::SHA256.new
       self.recursive_glob_for_entries(path).each do |file|
-        unless File.directory?(file)
+        if File.directory?(file)
+          # skip directories
+        elsif !Pathname.new(file).exist?
+          # skip broken symlinks
+        else
           sha << File.read(file)
         end
       end

--- a/lib/run_loop/life_cycle/core_simulator.rb
+++ b/lib/run_loop/life_cycle/core_simulator.rb
@@ -84,6 +84,7 @@ module RunLoop
         sim_path = sim_control.send(:sim_app_path)
         args = ['open', '-g', '-a', sim_path, '--args', '-CurrentDeviceUDID', device.udid]
 
+        RunLoop.log_debug("Launching #{device} with:")
         RunLoop.log_unix_cmd("xcrun #{args.join(' ')}")
 
         start_time = Time.now
@@ -94,15 +95,12 @@ module RunLoop
         sim_name = sim_control.send(:sim_name)
 
         RunLoop::ProcessWaiter.new(sim_name, WAIT_FOR_SIMULATOR_PROCESSES_OPTS).wait_for_any
-        RunLoop::ProcessWaiter.new('SimulatorBridge', WAIT_FOR_SIMULATOR_PROCESSES_OPTS).wait_for_any
 
-        device.wait_for_simulator_to_install
-        device.wait_for_simulator_log_to_stop_updating(5, 1)
-
-        sleep(SIM_POST_LAUNCH_WAIT)
+        device.simulator_wait_for_stable_state
 
         elapsed = Time.now - start_time
-        RunLoop.log_debug("Took #{elapsed} seconds to launch simulator")
+        RunLoop.log_debug("Took #{elapsed} seconds to launch")
+
         true
       end
 


### PR DESCRIPTION
### Motivation

I need a way to ensure that any given CoreSimulator is installed.

Fixes: https://github.com/calabash/run_loop/issues/224 and https://github.com/calabash/run_loop/issues/223

```
$ be run-loop simctl help doctor
Usage:
  run-loop doctor

Options:
  -v, [--debug], [--no-debug]  # Enable debug logging.
  -d, [--device=DEVICE]        # The simulator UDID or name.

EXPERIMENTAL: Prepare the CoreSimulator environment for testing

# Launch every simulator and wait for it to install.
$ be run-loop simctl doctor

# Launch a particular simulator and wait for it to install.
$ be run-loop simctl doctor --device DCFE6D89-C91A-4420-A2C7-CD65E923ACDD
```
