### PR TITLE
Force UTF-8 encoding when reading the output of `instruments`

### DIFF
--- a/lib/run_loop/instruments.rb
+++ b/lib/run_loop/instruments.rb
@@ -134,7 +134,7 @@ Please update your sources to pass an instance of RunLoop::Xcode))
     def templates
       @instruments_templates ||= lambda do
         args = ['instruments', '-s', 'templates']
-        hash = xcrun.exec(args, log_unix_cmd: true)
+        hash = xcrun.exec(args, log_cmd: true)
         if xcode.version_gte_6?
           hash[:out].chomp.split("\n").map do |elm|
             stripped = elm.strip.tr('"', '')
@@ -215,7 +215,7 @@ Please update your sources to pass an instance of RunLoop::Xcode))
     def fetch_devices
       @device_hash ||= lambda do
         args = ['instruments', '-s', 'devices']
-        xcrun.exec(args, log_unix_cmd: true)
+        xcrun.exec(args, log_cmd: true)
       end.call
     end
 

--- a/lib/run_loop/instruments.rb
+++ b/lib/run_loop/instruments.rb
@@ -110,10 +110,10 @@ Please update your sources to pass an instance of RunLoop::Xcode))
     # @return [RunLoop::Version] A version object.
     def version
       @instruments_version ||= lambda do
-        execute_command([]) do |_, stderr, _|
-          version_str = stderr.read[VERSION_REGEX, 0]
-          RunLoop::Version.new(version_str)
-        end
+        args = ['instruments']
+        hash = xcrun.exec(args, log_cmd: true)
+        version_str = hash[:err][VERSION_REGEX, 0]
+        RunLoop::Version.new(version_str)
       end.call
     end
 
@@ -346,18 +346,6 @@ Please update your sources to pass an instance of RunLoop::Xcode))
     def execute_command(args)
       Open3.popen3('xcrun', 'instruments', *args) do |_, stdout, stderr, process_status|
         yield stdout, stderr, process_status
-      end
-    end
-
-    # @!visibility private
-    #
-    # Filters `instruments` spam.
-    def filter_stderr_spam(stderr)
-      # Xcode 6 GM is spamming "WebKit Threading Violations"
-      stderr.read.strip.split("\n").each do |line|
-        unless line[/WebKit Threading Violation/, 0]
-          $stderr.puts line
-        end
       end
     end
 

--- a/lib/run_loop/life_cycle/core_simulator.rb
+++ b/lib/run_loop/life_cycle/core_simulator.rb
@@ -300,7 +300,7 @@ module RunLoop
         target = File.join(directory, bundle_name)
 
         args = ['ditto', app.path, target]
-        RunLoop::Xcrun.new.exec(args)
+        RunLoop::Xcrun.new.exec(args, log_unix_cmd: true)
         target
       end
 
@@ -319,7 +319,7 @@ module RunLoop
         target = File.join(directory, bundle_name)
 
         args = ['ditto', app.path, target]
-        RunLoop::Xcrun.new.exec(args)
+        RunLoop::Xcrun.new.exec(args, log_unix_cmd: true)
         installed_app_bundle
       end
 
@@ -482,7 +482,7 @@ module RunLoop
         launch_simulator
 
         args = ['simctl', 'launch', device.udid, app.bundle_identifier]
-        hash = RunLoop::Xcrun.new.exec(args, 20)
+        hash = RunLoop::Xcrun.new.exec(args, log_unix_cmd: true, timeout: 20)
 
         exit_status = hash[:exit_status]
 

--- a/lib/run_loop/life_cycle/core_simulator.rb
+++ b/lib/run_loop/life_cycle/core_simulator.rb
@@ -300,7 +300,7 @@ module RunLoop
         target = File.join(directory, bundle_name)
 
         args = ['ditto', app.path, target]
-        RunLoop::Xcrun.new.exec(args, log_unix_cmd: true)
+        RunLoop::Xcrun.new.exec(args, log_cmd: true)
         target
       end
 
@@ -319,7 +319,7 @@ module RunLoop
         target = File.join(directory, bundle_name)
 
         args = ['ditto', app.path, target]
-        RunLoop::Xcrun.new.exec(args, log_unix_cmd: true)
+        RunLoop::Xcrun.new.exec(args, log_cmd: true)
         installed_app_bundle
       end
 
@@ -482,7 +482,7 @@ module RunLoop
         launch_simulator
 
         args = ['simctl', 'launch', device.udid, app.bundle_identifier]
-        hash = RunLoop::Xcrun.new.exec(args, log_unix_cmd: true, timeout: 20)
+        hash = RunLoop::Xcrun.new.exec(args, log_cmd: true, timeout: 20)
 
         exit_status = hash[:exit_status]
 

--- a/lib/run_loop/xcrun.rb
+++ b/lib/run_loop/xcrun.rb
@@ -1,6 +1,12 @@
 module RunLoop
   class Xcrun
 
+    DEFAULT_OPTIONS =
+          {
+                :timeout => 10,
+                :log_cmd => false
+          }
+
     DEFAULT_TIMEOUT = 10
 
     # Raised when Xcrun fails.
@@ -8,7 +14,10 @@ module RunLoop
 
     attr_reader :stdin, :stdout, :stderr, :pid
 
-    def exec(args, timeout = DEFAULT_TIMEOUT)
+    def exec(args, options={})
+      merged_options = DEFAULT_OPTIONS.merge(options)
+
+      timeout = merged_options[:timeout]
 
       unless args.is_a?(Array)
         raise ArgumentError,
@@ -18,6 +27,8 @@ module RunLoop
       @stdin, @stdout, out, @stderr, err, process_status, @pid, exit_status = nil
 
       cmd = "xcrun #{args.join(' ')}"
+
+      RunLoop.log_unix_cmd(cmd) if merged_options
 
       begin
         Timeout.timeout(timeout, TimeoutError) do

--- a/lib/run_loop/xcrun.rb
+++ b/lib/run_loop/xcrun.rb
@@ -37,10 +37,10 @@ module RunLoop
           @pid = process_status.pid
           exit_status = process_status.value.exitstatus
 
-          err = @stderr.read.chomp
+          err = @stderr.read.force_encoding('utf-8').chomp
           err = nil if err == ''
 
-          out = @stdout.read.chomp
+          out = @stdout.read.force_encoding('utf-8').chomp
         end
 
         {

--- a/run_loop.gemspec
+++ b/run_loop.gemspec
@@ -58,7 +58,6 @@ tools like instruments and simctl.}
   s.add_development_dependency('guard-rspec', '~> 4.3')
   s.add_development_dependency('guard-bundler', '~> 2.0')
   s.add_development_dependency('growl', '~> 1.0')
-  s.add_development_dependency('rb-readline', '~> 0.5')
   s.add_development_dependency('stub_env', '>= 1.0.1', '< 2.0')
   s.add_development_dependency('pry')
   s.add_development_dependency('pry-nav')

--- a/spec/integration/instruments_spec.rb
+++ b/spec/integration/instruments_spec.rb
@@ -187,15 +187,8 @@ describe RunLoop::Instruments do
     end
   end
 
-  describe '#execute_command' do
-    it 'yields stdout, stderr, and process_status' do
-      # equivalent to getting the version
-      instruments.send(:execute_command, []) do |stdout, stderr, process_status|
-        expect(stdout.read.strip).to be == ''
-        expect(stderr.read.strip[/instruments, version/, 0]).not_to be == nil
-        expect(process_status).to be_a_kind_of(Process::Waiter)
-        expect(process_status.value.exitstatus).not_to be == 0
-      end
-    end
+  it 'UTF 8 encoding' do
+    stub_env('LC_ALL', 'C')
+    actual = instruments.simulators
   end
 end

--- a/spec/integration/instruments_spec.rb
+++ b/spec/integration/instruments_spec.rb
@@ -186,9 +186,4 @@ describe RunLoop::Instruments do
       end
     end
   end
-
-  it 'UTF 8 encoding' do
-    stub_env('LC_ALL', 'C')
-    actual = instruments.simulators
-  end
 end

--- a/spec/integration/xcrun_spec.rb
+++ b/spec/integration/xcrun_spec.rb
@@ -6,7 +6,7 @@ describe RunLoop::Xcrun do
     it 'can call simctl' do
       args = ['simctl', 'list', 'devices']
 
-      hash = xcrun.exec(args)
+      hash = xcrun.exec(args, log_unix_cmd: true, timeout: 2)
 
       expect(hash[:err]).to be == nil
       expect(hash[:out]).to be_truthy
@@ -19,7 +19,7 @@ describe RunLoop::Xcrun do
 
     args = ['xcodebuild', '-version']
 
-    hash = xcrun.exec(args)
+    hash = xcrun.exec(args, log_unix_cmd: true, timeout: 2)
 
     expect(hash[:err]).to be == nil
     expect(hash[:out]).to be_truthy

--- a/spec/integration/xcrun_spec.rb
+++ b/spec/integration/xcrun_spec.rb
@@ -6,7 +6,7 @@ describe RunLoop::Xcrun do
     it 'can call simctl' do
       args = ['simctl', 'list', 'devices']
 
-      hash = xcrun.exec(args, log_unix_cmd: true, timeout: 2)
+      hash = xcrun.exec(args, log_cmd: true, timeout: 2)
 
       expect(hash[:err]).to be == nil
       expect(hash[:out]).to be_truthy
@@ -19,7 +19,7 @@ describe RunLoop::Xcrun do
 
     args = ['xcodebuild', '-version']
 
-    hash = xcrun.exec(args, log_unix_cmd: true, timeout: 2)
+    hash = xcrun.exec(args, log_cmd: true, timeout: 2)
 
     expect(hash[:err]).to be == nil
     expect(hash[:out]).to be_truthy

--- a/spec/lib/instruments_spec.rb
+++ b/spec/lib/instruments_spec.rb
@@ -172,19 +172,20 @@ describe RunLoop::Instruments do
   end
 
   it '#version' do
-
+    xcrun = RunLoop::Xcrun.new
+    expect(instruments).to receive(:xcrun).and_return xcrun
     output = %q(
 instruments, version 7.0 (58143.1)
 usage: instruments [-t template] [-D document] [-l timeLimit] [-i #] [-w device] [[-p pid] | [application [-e variable value] [argument ...]]]
 )
-    stderr = StringIO.new(output)
-    yielded = ['', stderr, nil]
-    expect(instruments).to receive(:execute_command).with([]).and_yield(*yielded)
+    hash = { :err => output }
+    args = { log_cmd: true }
+
+    expect(xcrun).to receive(:exec).with(['instruments'], args).and_return hash
 
     expected = RunLoop::Version.new('7.0')
     expect(instruments.version).to be == RunLoop::Version.new('7.0')
     expect(instruments.instance_variable_get(:@instruments_version)).to be == expected
-    # Testing memoization
     expect(instruments.version).to be == expected
   end
 

--- a/spec/lib/instruments_spec.rb
+++ b/spec/lib/instruments_spec.rb
@@ -202,7 +202,7 @@ usage: instruments [-t template] [-D document] [-l timeLimit] [-i #] [-w device]
 
     let(:args) { ['instruments', '-s', 'templates'] }
 
-    let(:options) { {:log_unix_cmd => true } }
+    let(:options) { {:log_cmd => true } }
 
     let(:xcode) { RunLoop::Xcode.new }
 
@@ -246,7 +246,7 @@ usage: instruments [-t template] [-D document] [-l timeLimit] [-i #] [-w device]
   describe 'instruments -s devices' do
     let(:args) { ['instruments', '-s', 'devices'] }
 
-    let(:options) { {:log_unix_cmd => true } }
+    let(:options) { {:log_cmd => true } }
 
     let(:xcode_511_output) do
       {


### PR DESCRIPTION
### Motivation

- [x] **Device names with apostrophes cause invalid byte sequence in US-ASCII (ArgumentError)** #74  
- [x] **Handle UTF-8 characters in output of `instruments`** #219

Progress toward **Pass all `read` calls through utf-8 filter and come up with a way of testing** #230