### PR TITLE
Core.prepare_simulator raise an error if the installed app is stale

### DIFF
--- a/lib/run_loop/simctl/bridge.rb
+++ b/lib/run_loop/simctl/bridge.rb
@@ -47,6 +47,21 @@ module RunLoop::Simctl
       terminate_core_simulator_processes
     end
 
+    # The sha1 of the installed app.
+    def installed_app_sha1
+      installed_bundle = fetch_app_dir
+      if installed_bundle
+        RunLoop::Directory.directory_digest(installed_bundle)
+      else
+        nil
+      end
+    end
+
+    # Is the app that is install the same as the one we have in hand?
+    def same_sha1_as_installed?
+      app.sha1 == installed_app_sha1
+    end
+
     # @!visibility private
     def is_sdk_8?
       @is_sdk_8 ||= device.version >= RunLoop::Version.new('8.0')


### PR DESCRIPTION
### Motivation

Xcode 6 instruments will not install an app that is already installed.

This has been a thorn in my side.

```ruby
$ be run-loop instruments launch --app $APP --device $DEVICE --debug
2015-09-11 08:17:02 +0200 [RunLoop:debug]: Simulator instruction set 'x86_64' is compatible with ["i386", "x86_64"]
/Users/moody/git/calabash/run-loop/lib/run_loop/core.rb:157:in `prepare_simulator':  (RuntimeError)

The app you are trying to launch is not the same as the app that is installed.

  Installed app SHA: 61fe407c4a6b334d88753c4dc148f24e54b21c8d3b7c02961cc7c2257698a2fb
  App to launch SHA: 2472f284d401664a69fa6804e409cc2ed3214c887e23cf8e4a83741868f2a367

You can ensure that you are testing the correct .app by running:

  $ run-loop simctl --app "/Users/moody/git/calabash/ios-smoke-test-app/CalSmokeApp/CalSmoke-cal.app" --device "iPhone 6 (8.4)"

before you start cucumber.
```

**Fail if the SHA of the app is different than that of the installed app** #215