### PR TITLE
Core.prepare_simulator raises an error if app does not exist

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -68,6 +68,8 @@ module RunLoop
       nil
     end
 
+    # @deprecated 1.5.2 No public replacement.
+    #
     # Raise an error if the application binary is not compatible with the
     # target simulator.
     #
@@ -85,6 +87,7 @@ module RunLoop
     # @raise [RunLoop::IncompatibleArchitecture] Raises an error if the
     #  application binary is not compatible with the target simulator.
     def self.expect_compatible_simulator_architecture(launch_options, sim_control)
+      RunLoop.deprecated('1.5.2', 'No public replacement.')
       logger = launch_options[:logger]
       if sim_control.xcode_version_gte_6?
         sim_identifier = launch_options[:udid]

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -135,6 +135,18 @@ module RunLoop
 
         # CoreSimulator
 
+        app_bundle_path = launch_options[:bundle_dir_or_bundle_id]
+        app = RunLoop::App.new(app_bundle_path)
+
+        unless app.valid?
+          if File.exist?(app)
+            message = "App '#{app_bundle_path}' does not exist."
+          else
+            message = "App '#{app_bundle_path}' is not a valid .app bundle"
+          end
+          raise RuntimeError, message
+        end
+
         udid = launch_options[:udid]
         xcode = sim_control.xcode
 
@@ -143,10 +155,10 @@ module RunLoop
         end
 
         if device.nil?
-          raise "Could not find simulator with name or UDID that matches: '#{udid}'"
+          raise RuntimeError,
+                "Could not find simulator with name or UDID that matches: '#{udid}'"
         end
 
-        app_bundle_path = launch_options[:bundle_dir_or_bundle_id]
         bridge = RunLoop::Simctl::Bridge.new(device, app_bundle_path)
 
         if bridge.app_is_installed?


### PR DESCRIPTION
### Motivation

**Core.prepare_simulator should raise an error if the app does not exist.** #233

* Moved the arch compatibility check into Core.prepare_simulator
* Deprecated (public) Core.expect_simulator_compatible_arch
* Added (private) Core.expect_simulator_compatible_arch

