### PR TITLE
Use CoreSimulator to ensure target app is the same as installed app

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -186,32 +186,12 @@ module RunLoop
                 "Could not find simulator with name or UDID that matches: '#{udid}'"
         end
 
-        bridge = RunLoop::Simctl::Bridge.new(device, app_bundle_path)
-
-        if bridge.app_is_installed?
-          installed_sha = bridge.installed_app_sha1
-          new_sha = bridge.app.sha1
-
-          if installed_sha != new_sha
-            raise RuntimeError, %Q(
-
-The app you are trying to launch is not the same as the app that is installed.
-
-  Installed app SHA: #{installed_sha}
-  App to launch SHA: #{new_sha}
-
-You can ensure that you are testing the correct .app by running:
-
-  $ run-loop simctl install --app "#{bridge.app.path}" --device "#{device.instruments_identifier(xcode)}"
-
-before you start cucumber.
-
-)
-          end
-        end
-
         # Validate the architecture.
         self.expect_simulator_compatible_arch(device, app, xcode)
+
+        bridge = RunLoop::LifeCycle::CoreSimulator.new(app, device, sim_control)
+
+        bridge.ensure_app_same
 
         # Will quit the simulator if it is running.
         # @todo fix accessibility_enabled? so we don't have to quit the sim


### PR DESCRIPTION
### Motivation

Fixes **Install new app if installed app SHA is different** #241

1. Does nothing if the app is not installed.
2. Does nothing if the app the same as the app that is installed
3. Installs app if it is different from the installed app

Only the app is uninstalled; the app sandbox is preserved.

This strategy respects the user's wishes by _not resetting the app sandbox unless they ask us to_.

Finally.

Big thanks to @rasmuskl for finding the magic plist.

### Related

* **In CoreSimulator environments RESET_BETWEEN_SCENARIOS=1 resets the simulator contents and settings; should only reset the app sandbox** [#597](https://github.com/calabash/calabash-ios/issues/597)
* **Fix reset btw scenarios xcode 6** [#526](https://github.com/calabash/calabash-ios/pull/526)


