### PR TITLE
HOTFIX: backward compatibility for Calabash < 0.16.1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Change Log
 
+### 1.5.3
+
+* HOTFIX: backward compatibility for Calabash < 0.16.1 @ark-konopacki
+
 ### 1.5.2
 
 * Use CoreSimulator to ensure target app is the same as installed app #244

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -476,7 +476,7 @@ Logfile: #{log_file}
   #
   # For historical reasons, the most recent non-64b SDK should be used.
   #
-  # @param [RunLoop::XCTools, RunLoop::XCode] xcode Used to detect the current xcode
+  # @param [RunLoop::XCTools, RunLoop::Xcode] xcode Used to detect the current xcode
   #  version.
   def self.default_simulator(xcode=RunLoop::Xcode.new)
     if xcode.is_a?(RunLoop::XCTools)
@@ -484,21 +484,24 @@ Logfile: #{log_file}
                          %q(
 RunLoop::XCTools has been replaced with RunLoop::Xcode.
 Please update your sources to pass an instance of RunLoop::Xcode))
+      ensured_xcode = RunLoop::Xcode.new
+    else
+      ensured_xcode = xcode
     end
 
-    if xcode.version_gte_71?
+    if ensured_xcode.version_gte_71?
       'iPhone 6s (9.1)'
-    elsif xcode.version_gte_7?
+    elsif ensured_xcode.version_gte_7?
       'iPhone 5s (9.0)'
-    elsif xcode.version_gte_64?
+    elsif ensured_xcode.version_gte_64?
       'iPhone 5s (8.4 Simulator)'
-    elsif xcode.version_gte_63?
+    elsif ensured_xcode.version_gte_63?
       'iPhone 5s (8.3 Simulator)'
-    elsif xcode.version_gte_62?
+    elsif ensured_xcode.version_gte_62?
       'iPhone 5s (8.2 Simulator)'
-    elsif xcode.version_gte_61?
+    elsif ensured_xcode.version_gte_61?
       'iPhone 5s (8.1 Simulator)'
-    elsif xcode.version_gte_6?
+    elsif ensured_xcode.version_gte_6?
       'iPhone 5s (8.0 Simulator)'
     else
       'iPhone Retina (4-inch) - Simulator - iOS 7.1'

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -224,10 +224,12 @@ module RunLoop
       sim_control ||= options[:sim_control] || RunLoop::SimControl.new
 
       if options[:xctools]
-        RunLoop.deprecated('1.5.0', %q(
+        if RunLoop::Environment.debug?
+          RunLoop.deprecated('1.5.0', %q(
 RunLoop::XCTools has been replaced with RunLoop::Xcode.
 The :xctools key will be ignored.  It has been replaced by the :xcode key.
 Please update your sources to pass an instance of RunLoop::Xcode))
+        end
       end
 
       xcode ||= options[:xcode] || sim_control.xcode
@@ -480,10 +482,12 @@ Logfile: #{log_file}
   #  version.
   def self.default_simulator(xcode=RunLoop::Xcode.new)
     if xcode.is_a?(RunLoop::XCTools)
-      RunLoop.deprecated('1.5.0',
-                         %q(
+      if RunLoop::Environment.debug?
+        RunLoop.deprecated('1.5.0',
+                           %q(
 RunLoop::XCTools has been replaced with RunLoop::Xcode.
 Please update your sources to pass an instance of RunLoop::Xcode))
+      end
       ensured_xcode = RunLoop::Xcode.new
     else
       ensured_xcode = xcode
@@ -731,10 +735,12 @@ Please update your sources to pass an instance of RunLoop::Xcode))
 
     def self.default_tracetemplate(instruments_arg=RunLoop::Instruments.new)
       if instruments_arg.is_a?(RunLoop::XCTools)
-        RunLoop.deprecated('1.5.0',
-                           %q(
+        if RunLoop::Environment.debug?
+          RunLoop.deprecated('1.5.0',
+                             %q(
 RunLoop::XCTools has been replaced with RunLoop::Xcode.
 Please update your sources to pass an instance of RunLoop::Instruments))
+        end
         instruments = RunLoop::Instruments.new
       else
         instruments = instruments_arg

--- a/lib/run_loop/version.rb
+++ b/lib/run_loop/version.rb
@@ -1,5 +1,5 @@
 module RunLoop
-  VERSION = '1.5.2'
+  VERSION = '1.5.3'
 
   # A model of a software release version that can be used to compare two versions.
   #

--- a/lib/run_loop/xctools.rb
+++ b/lib/run_loop/xctools.rb
@@ -28,7 +28,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 7.1
     def v71
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v71
     end
 
@@ -38,7 +38,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 7.0
     def v70
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v70
     end
 
@@ -48,7 +48,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 6.4
     def v64
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v64
     end
 
@@ -58,7 +58,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 6.3
     def v63
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v63
     end
 
@@ -68,7 +68,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 6.2
     def v62
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v62
     end
 
@@ -78,7 +78,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 6.1
     def v61
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v61
     end
 
@@ -88,7 +88,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 6.0
     def v60
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v60
     end
 
@@ -98,7 +98,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 5.1
     def v51
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v51
     end
 
@@ -108,7 +108,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 5.0
     def v50
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v50
     end
 
@@ -117,7 +117,7 @@ module RunLoop
     #
     # @return [Boolean] `true` if the current Xcode version is >= 6.4
     def xcode_version_gte_64?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version_gte_64?
     end
 
@@ -126,7 +126,7 @@ module RunLoop
     #
     # @return [Boolean] `true` if the current Xcode version is >= 6.3
     def xcode_version_gte_63?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version_gte_63?
     end
 
@@ -135,7 +135,7 @@ module RunLoop
     #
     # @return [Boolean] `true` if the current Xcode version is >= 6.2
     def xcode_version_gte_62?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version_gte_62?
     end
 
@@ -144,7 +144,7 @@ module RunLoop
     #
     # @return [Boolean] `true` if the current Xcode version is >= 6.1
     def xcode_version_gte_61?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version_gte_61?
     end
 
@@ -153,7 +153,7 @@ module RunLoop
     #
     # @return [Boolean] `true` if the current Xcode version is >= 6.0
     def xcode_version_gte_6?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version_gte_6?
     end
 
@@ -162,7 +162,7 @@ module RunLoop
     #
     # @return [Boolean] `true` if the current Xcode version is >= 7.1
     def xcode_version_gte_71?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version_gte_71?
     end
 
@@ -171,7 +171,7 @@ module RunLoop
     #
     # @return [Boolean] `true` if the current Xcode version is >= 7.0
     def xcode_version_gte_7?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version_gte_7?
     end
 
@@ -180,7 +180,7 @@ module RunLoop
     #
     # @return [Boolean] `true` if the current Xcode version is >= 5.1
     def xcode_version_gte_51?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version_gte_51?
     end
 
@@ -190,7 +190,7 @@ module RunLoop
     # @return [RunLoop::Version] The current version of Xcode as reported by
     #  `xcrun xcodebuild -version`.
     def xcode_version
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version
     end
 
@@ -209,7 +209,7 @@ module RunLoop
     #
     # @return [String] path to current developer directory
     def xcode_developer_dir
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.developer_dir
     end
 
@@ -219,7 +219,7 @@ module RunLoop
     # @note Relies on Xcode beta versions having and app bundle named Xcode-Beta.app
     # @return [Boolean] True if the Xcode version is beta.
     def xcode_is_beta?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.beta?
     end
 
@@ -262,7 +262,7 @@ module RunLoop
     #   instruments binary.
     # @raise [ArgumentError] if invalid `cmd` is passed
     def instruments(cmd=nil)
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Instruments')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Instruments') if RunLoop::Environment.debug?
       instruments = 'xcrun instruments'
       return instruments if cmd == nil
 
@@ -297,7 +297,7 @@ module RunLoop
     #
     # @return [Boolean] true if the version is >= 5.*
     def instruments_supports_hyphen_s?(version=instruments(:version))
-      RunLoop.deprecated('1.5.0', 'Not replaced.')
+      RunLoop.deprecated('1.5.0', 'Not replaced.') if RunLoop::Environment.debug?
       @instruments_supports_hyphen_s ||= lambda {
         if version.is_a? String
           _version = RunLoop::Version.new(version)


### PR DESCRIPTION
### 1.5.3

Thanks to @ark-konopacki for reporting.

**Cannot run tests with Calabash 0.14.3 and run_loop 1.5.2** [#843](https://github.com/calabash/calabash-ios/issues/843)