### PR TITLE
Release/1.5.4

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -61,7 +61,12 @@ def simcontrol
 end
 
 def default_sim
-  @default_sim ||= RunLoop::Core.default_simulator
+  @default_sim ||= lambda do
+    name = RunLoop::Core.default_simulator(xcode)
+    simcontrol.simulators.find do |sim|
+      sim.instruments_identifier(xcode) == name
+    end
+  end.call
 end
 
 motd=["Let's get this done!", 'Ready to rumble.', 'Enjoy.', 'Remember to breathe.',

--- a/.irbrc
+++ b/.irbrc
@@ -46,6 +46,8 @@ puts '> xcode       => Xcode instance'
 puts '> instruments => Instruments instance'
 puts '> simcontrol  => SimControl instance'
 puts '> default_sim => Default simulator'
+puts '> verbose     => turn on DEBUG logging'
+puts '> quiet       => turn off DEBUG logging'
 puts ''
 
 def xcode
@@ -67,6 +69,14 @@ def default_sim
       sim.instruments_identifier(xcode) == name
     end
   end.call
+end
+
+def verbose
+  ENV['DEBUG'] = '1'
+end
+
+def quiet
+  ENV['DEBUG'] = '1'
 end
 
 motd=["Let's get this done!", 'Ready to rumble.', 'Enjoy.', 'Remember to breathe.',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Change Log
 
+### 1.5.2
+
+* Use CoreSimulator to ensure target app is the same as installed app #244
+* Core.prepare_simulator raises an error if app does not exist #236
+* Fixup Core#simulator_target? for Xcode 7 #232
+* Force UTF-8 encoding when reading the output of `instruments` Thanks to Magnús Magnússon
+* Xcode 7.1 beta support
+* CLI: simctl doctor [--device=DEVICE] - tool to prepare CoreSimulator environment EXPERIMENTAL
+* CoreSimulator#launch_simulator waits for the simulator to install
+* CoreSimulator App Life Cycle with direct file IO vs simctl
+* Simulator devices can update their state
+* Xcrun class for safely executing 'xcrun' commands
+
 ### 1.5.1
 
 * Core.simulator\_target? - fixup for Xcode 7 #216
@@ -16,7 +29,7 @@
 * Add Xcode class
 * Deprecate XCTools class
 * Add more privacy alert auto-dismiss regular expressions #199
-* uikit localization lookups in runloop #197 @svevang
+* UIKit localization lookups in runloop #197 @svevang
 
 ### 1.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Change Log
 
+### 1.5.4
+
+* Xcode 7: launch instruments with simulator UDID to avoid ambiguous
+  matches #253 @sapieneptus
+* Remove CoreSimulator LaunchServices csstore before during simulator
+  preparation #252 @sapieneptus
+* iOS9: dismiss Motion/Activity and Twitter permissions alerts #251
+  @sapieneptus
+* HOTFIX: backward compatibility for Calabash < 0.16.1 #248
+  @ark-konopacki
+
 ### 1.5.3
 
 * HOTFIX: backward compatibility for Calabash < 0.16.1 @ark-konopacki

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Change Log
 
+### 1.5.3
+
+* HOTFIX: backward compatibility for Calabash < 0.16.1 @ark-konopacki
+
 ### 1.5.2
 
 * Use CoreSimulator to ensure target app is the same as installed app #244

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,9 @@ The Calabash iOS Toolchain uses git-flow.
 
 See these links for information about git-flow and git best practices.
 
+Please see this [post](http://chris.beams.io/posts/git-commit/) for tips
+on how to make a good commit message.
+
 ##### Git Flow Step-by-Step guide
 
 * https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow

--- a/lib/run_loop/cli/simctl.rb
+++ b/lib/run_loop/cli/simctl.rb
@@ -129,7 +129,10 @@ module RunLoop
         # TODO this is duplicated code; extract!
         # https://github.com/calabash/run_loop/issues/225
         def terminate_core_simulator_processes
-          RunLoop::LifeCycle::CoreSimulator::MANAGED_PROCESSES.each do |pair|
+          to_manage = RunLoop::LifeCycle::CoreSimulator::MANAGED_PROCESSES
+          to_manage << ['com.apple.CoreSimulator.CoreSimulatorService', false]
+
+          to_manage.each do |pair|
             name = pair[0]
             send_term = pair[1]
             pids = RunLoop::ProcessWaiter.new(name).pids

--- a/lib/run_loop/cli/simctl.rb
+++ b/lib/run_loop/cli/simctl.rb
@@ -196,6 +196,17 @@ module RunLoop
 
         bridge = RunLoop::Simctl::Bridge.new(device, app.path)
 
+        xcode = bridge.sim_control.xcode
+        if xcode.version >= RunLoop::Version.new('7.0')
+          puts "ERROR: Xcode #{xcode.version.to_s} detected."
+          puts "ERROR: Apple's simctl install/uninstall is broken for this version of Xcode."
+          puts "ERROR: See the following links for details:"
+          puts "ERROR: https://forums.developer.apple.com/message/51922"
+          puts "ERROR: https://github.com/calabash/run_loop/issues/235"
+          puts "ERROR: exiting 1"
+          exit 1
+        end
+
         force_reinstall = options[:force]
 
         before = Time.now

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -68,6 +68,8 @@ module RunLoop
       nil
     end
 
+    # @deprecated 1.5.2 No public replacement.
+    #
     # Raise an error if the application binary is not compatible with the
     # target simulator.
     #
@@ -85,6 +87,7 @@ module RunLoop
     # @raise [RunLoop::IncompatibleArchitecture] Raises an error if the
     #  application binary is not compatible with the target simulator.
     def self.expect_compatible_simulator_architecture(launch_options, sim_control)
+      RunLoop.deprecated('1.5.2', 'No public replacement.')
       logger = launch_options[:logger]
       if sim_control.xcode_version_gte_6?
         sim_identifier = launch_options[:udid]
@@ -105,6 +108,30 @@ module RunLoop
         RunLoop::Logging.log_debug(logger, "Xcode #{sim_control.xcode_version} detected; skipping simulator architecture check.")
         false
       end
+    end
+
+    # Raise an error if the application binary is not compatible with the
+    # target simulator.
+    #
+    # @note This method is implemented for CoreSimulator environments only;
+    #  for Xcode < 6.0 this method does nothing.
+    #
+    # @param [RunLoop::Device] device The device to install on.
+    # @param [RunLoop::App] app The app to install.
+    # @param [RunLoop::Xcode] xcode The active Xcode.
+    #
+    # @raise [RunLoop::IncompatibleArchitecture] Raises an error if the
+    #  application binary is not compatible with the target simulator.
+    def self.expect_simulator_compatible_arch(device, app, xcode)
+      if !xcode.version_gte_6?
+        RunLoop.log_warn("Checking for compatible arches is only available in CoreSimulator environments")
+        return
+      end
+
+      lipo = RunLoop::Lipo.new(app.path)
+      lipo.expect_compatible_arch(device)
+
+      RunLoop.log_debug("Simulator instruction set '#{device.instruction_set}' is compatible with '#{lipo.info}'")
     end
 
     # Prepares the simulator for running.
@@ -135,6 +162,18 @@ module RunLoop
 
         # CoreSimulator
 
+        app_bundle_path = launch_options[:bundle_dir_or_bundle_id]
+        app = RunLoop::App.new(app_bundle_path)
+
+        unless app.valid?
+          if !File.exist?(app.path)
+            message = "App '#{app_bundle_path}' does not exist."
+          else
+            message = "App '#{app_bundle_path}' is not a valid .app bundle"
+          end
+          raise RuntimeError, message
+        end
+
         udid = launch_options[:udid]
         xcode = sim_control.xcode
 
@@ -143,10 +182,10 @@ module RunLoop
         end
 
         if device.nil?
-          raise "Could not find simulator with name or UDID that matches: '#{udid}'"
+          raise RuntimeError,
+                "Could not find simulator with name or UDID that matches: '#{udid}'"
         end
 
-        app_bundle_path = launch_options[:bundle_dir_or_bundle_id]
         bridge = RunLoop::Simctl::Bridge.new(device, app_bundle_path)
 
         if bridge.app_is_installed?
@@ -170,6 +209,9 @@ before you start cucumber.
 )
           end
         end
+
+        # Validate the architecture.
+        self.expect_simulator_compatible_arch(device, app, xcode)
 
         # Will quit the simulator if it is running.
         # @todo fix accessibility_enabled? so we don't have to quit the sim
@@ -283,7 +325,6 @@ Please update your sources to pass an instance of RunLoop::Xcode))
       merged_options = options.merge(discovered_options)
 
       if self.simulator_target?(merged_options)
-        self.expect_compatible_simulator_architecture(merged_options, sim_control)
         self.prepare_simulator(merged_options, sim_control)
       end
 

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -224,10 +224,12 @@ module RunLoop
       sim_control ||= options[:sim_control] || RunLoop::SimControl.new
 
       if options[:xctools]
-        RunLoop.deprecated('1.5.0', %q(
+        if RunLoop::Environment.debug?
+          RunLoop.deprecated('1.5.0', %q(
 RunLoop::XCTools has been replaced with RunLoop::Xcode.
 The :xctools key will be ignored.  It has been replaced by the :xcode key.
 Please update your sources to pass an instance of RunLoop::Xcode))
+        end
       end
 
       xcode ||= options[:xcode] || sim_control.xcode
@@ -476,29 +478,34 @@ Logfile: #{log_file}
   #
   # For historical reasons, the most recent non-64b SDK should be used.
   #
-  # @param [RunLoop::XCTools, RunLoop::XCode] xcode Used to detect the current xcode
+  # @param [RunLoop::XCTools, RunLoop::Xcode] xcode Used to detect the current xcode
   #  version.
   def self.default_simulator(xcode=RunLoop::Xcode.new)
     if xcode.is_a?(RunLoop::XCTools)
-      RunLoop.deprecated('1.5.0',
-                         %q(
+      if RunLoop::Environment.debug?
+        RunLoop.deprecated('1.5.0',
+                           %q(
 RunLoop::XCTools has been replaced with RunLoop::Xcode.
 Please update your sources to pass an instance of RunLoop::Xcode))
+      end
+      ensured_xcode = RunLoop::Xcode.new
+    else
+      ensured_xcode = xcode
     end
 
-    if xcode.version_gte_71?
+    if ensured_xcode.version_gte_71?
       'iPhone 6s (9.1)'
-    elsif xcode.version_gte_7?
+    elsif ensured_xcode.version_gte_7?
       'iPhone 5s (9.0)'
-    elsif xcode.version_gte_64?
+    elsif ensured_xcode.version_gte_64?
       'iPhone 5s (8.4 Simulator)'
-    elsif xcode.version_gte_63?
+    elsif ensured_xcode.version_gte_63?
       'iPhone 5s (8.3 Simulator)'
-    elsif xcode.version_gte_62?
+    elsif ensured_xcode.version_gte_62?
       'iPhone 5s (8.2 Simulator)'
-    elsif xcode.version_gte_61?
+    elsif ensured_xcode.version_gte_61?
       'iPhone 5s (8.1 Simulator)'
-    elsif xcode.version_gte_6?
+    elsif ensured_xcode.version_gte_6?
       'iPhone 5s (8.0 Simulator)'
     else
       'iPhone Retina (4-inch) - Simulator - iOS 7.1'
@@ -728,10 +735,12 @@ Please update your sources to pass an instance of RunLoop::Xcode))
 
     def self.default_tracetemplate(instruments_arg=RunLoop::Instruments.new)
       if instruments_arg.is_a?(RunLoop::XCTools)
-        RunLoop.deprecated('1.5.0',
-                           %q(
+        if RunLoop::Environment.debug?
+          RunLoop.deprecated('1.5.0',
+                             %q(
 RunLoop::XCTools has been replaced with RunLoop::Xcode.
 Please update your sources to pass an instance of RunLoop::Instruments))
+        end
         instruments = RunLoop::Instruments.new
       else
         instruments = instruments_arg

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -331,10 +331,9 @@ Please update your sources to pass an instance of RunLoop::Xcode))
 
       uia_timeout = options[:uia_timeout] || RunLoop::Environment.uia_timeout || 10
 
-      after = Time.now
-      RunLoop::Logging.log_debug(logger, "Preparation took #{after-before} seconds")
+      RunLoop::Logging.log_debug(logger, "Preparation took #{Time.now-before} seconds")
 
-      before = Time.now
+      before_instruments_launch = Time.now
       begin
 
         if options[:validate_channel]
@@ -358,7 +357,7 @@ Please update your sources to pass an instance of RunLoop::Xcode))
         raise RunLoop::TimeoutError, "Time out waiting for UIAutomation run-loop #{e}. \n Logfile #{log_file} \n\n #{File.read(log_file)}\n"
       end
 
-      RunLoop::Logging.log_debug(logger, "Launching took #{Time.now-before} seconds")
+      RunLoop::Logging.log_debug(logger, "Launching took #{Time.now-before_instruments_launch} seconds")
 
       dylib_path = self.dylib_path_from_options(merged_options)
 
@@ -369,6 +368,7 @@ Please update your sources to pass an instance of RunLoop::Xcode))
         lldb.retriable_inject_dylib
       end
 
+      RunLoop.log_debug("It took #{Time.now - before} seconds to launch the app")
       run_loop
     end
 

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -186,32 +186,12 @@ module RunLoop
                 "Could not find simulator with name or UDID that matches: '#{udid}'"
         end
 
-        bridge = RunLoop::Simctl::Bridge.new(device, app_bundle_path)
-
-        if bridge.app_is_installed?
-          installed_sha = bridge.installed_app_sha1
-          new_sha = bridge.app.sha1
-
-          if installed_sha != new_sha
-            raise RuntimeError, %Q(
-
-The app you are trying to launch is not the same as the app that is installed.
-
-  Installed app SHA: #{installed_sha}
-  App to launch SHA: #{new_sha}
-
-You can ensure that you are testing the correct .app by running:
-
-  $ run-loop simctl install --app "#{bridge.app.path}" --device "#{device.instruments_identifier(xcode)}"
-
-before you start cucumber.
-
-)
-          end
-        end
-
         # Validate the architecture.
         self.expect_simulator_compatible_arch(device, app, xcode)
+
+        bridge = RunLoop::LifeCycle::CoreSimulator.new(app, device, sim_control)
+
+        bridge.ensure_app_same
 
         # Will quit the simulator if it is running.
         # @todo fix accessibility_enabled? so we don't have to quit the sim

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -177,7 +177,7 @@ module RunLoop
         udid = launch_options[:udid]
         xcode = sim_control.xcode
 
-        device = sim_control.simulators.detect do |sim|
+        device = sim_control.simulators.find do |sim|
           sim.udid == udid || sim.instruments_identifier(xcode) == udid
         end
 

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -350,7 +350,7 @@ Please update your sources to pass an instance of RunLoop::Xcode))
         elapsed = Time.now - now
         stabilized = elapsed - quiet_time
         RunLoop.log_debug("Simulator stable after #{stabilized} seconds")
-        RunLoop.log_debug("Waited a total of #{elapsed} seconds to stabilize")
+        RunLoop.log_debug("Waited a total of #{elapsed} seconds for simulator to stabilize")
       else
         RunLoop.log_debug("Timed out: simulator not stable after #{timeout} seconds")
       end

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -370,13 +370,15 @@ Please update your sources to pass an instance of RunLoop::Xcode))
 
       return nil if !File.exist?(file)
 
+      debug = RunLoop::Environment.debug?
+
       begin
         io = File.open(file, 'r')
         io.seek(-100, IO::SEEK_END)
 
         line = io.readline
       rescue StandardError => e
-        RunLoop.log_debug("Caught #{e} while reading simulator log file")
+        RunLoop.log_error("Caught #{e} while reading simulator log file") if debug
       ensure
         io.close if io && !io.closed?
       end

--- a/lib/run_loop/life_cycle/core_simulator.rb
+++ b/lib/run_loop/life_cycle/core_simulator.rb
@@ -99,7 +99,7 @@ module RunLoop
         device.simulator_wait_for_stable_state
 
         elapsed = Time.now - start_time
-        RunLoop.log_debug("Took #{elapsed} seconds to launch")
+        RunLoop.log_debug("Took #{elapsed} seconds to launch the simulator")
 
         true
       end

--- a/lib/run_loop/life_cycle/core_simulator.rb
+++ b/lib/run_loop/life_cycle/core_simulator.rb
@@ -291,6 +291,8 @@ module RunLoop
 
         RunLoop.log_debug("Installed #{app} on CoreSimulator #{device.udid}")
 
+        clear_device_launch_csstore
+
         true
       end
 
@@ -450,6 +452,19 @@ module RunLoop
           raise "Expected '#{target_state} but found '#{device.state}' after waiting."
         end
         in_state
+      end
+
+      # @!visibility private
+      def device_caches_dir
+        @device_caches_dir ||= File.join(device_data_dir, 'Library', 'Caches')
+      end
+
+      # @!visibility private
+      def clear_device_launch_csstore
+        glob = File.join(device_caches_dir, "com.apple.LaunchServices-*.csstore")
+        Dir.glob(glob) do | ccstore |
+          FileUtils.rm_f ccstore
+        end
       end
 
       # @!visibility private

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -18,7 +18,7 @@ module RunLoop
 
     # @deprecated 1.5.0 - replaced by #xcode
     def xctools
-      RunLoop.deprecated('1.5.0', 'Replaced by RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced by RunLoop::Xcode') if RunLoop::Environment.debug?
       @xctools ||= RunLoop::XCTools.new
     end
 

--- a/lib/run_loop/simctl/bridge.rb
+++ b/lib/run_loop/simctl/bridge.rb
@@ -47,6 +47,21 @@ module RunLoop::Simctl
       terminate_core_simulator_processes
     end
 
+    # The sha1 of the installed app.
+    def installed_app_sha1
+      installed_bundle = fetch_app_dir
+      if installed_bundle
+        RunLoop::Directory.directory_digest(installed_bundle)
+      else
+        nil
+      end
+    end
+
+    # Is the app that is install the same as the one we have in hand?
+    def same_sha1_as_installed?
+      app.sha1 == installed_app_sha1
+    end
+
     # @!visibility private
     def is_sdk_8?
       @is_sdk_8 ||= device.version >= RunLoop::Version.new('8.0')

--- a/lib/run_loop/version.rb
+++ b/lib/run_loop/version.rb
@@ -1,5 +1,5 @@
 module RunLoop
-  VERSION = '1.5.1'
+  VERSION = '1.5.2'
 
   # A model of a software release version that can be used to compare two versions.
   #

--- a/lib/run_loop/version.rb
+++ b/lib/run_loop/version.rb
@@ -1,5 +1,5 @@
 module RunLoop
-  VERSION = '1.5.3'
+  VERSION = '1.5.4'
 
   # A model of a software release version that can be used to compare two versions.
   #

--- a/lib/run_loop/version.rb
+++ b/lib/run_loop/version.rb
@@ -1,5 +1,5 @@
 module RunLoop
-  VERSION = '1.5.2'
+  VERSION = '1.5.3'
 
   # A model of a software release version that can be used to compare two versions.
   #

--- a/lib/run_loop/xcrun.rb
+++ b/lib/run_loop/xcrun.rb
@@ -28,7 +28,9 @@ module RunLoop
 
       cmd = "xcrun #{args.join(' ')}"
 
-      RunLoop.log_unix_cmd(cmd) if merged_options
+      # Don't see your log?
+      # Commands are only logged when debugging.
+      RunLoop.log_unix_cmd(cmd) if merged_options[:log_cmd]
 
       begin
         Timeout.timeout(timeout, TimeoutError) do

--- a/lib/run_loop/xctools.rb
+++ b/lib/run_loop/xctools.rb
@@ -28,7 +28,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 7.1
     def v71
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v71
     end
 
@@ -38,7 +38,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 7.0
     def v70
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v70
     end
 
@@ -48,7 +48,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 6.4
     def v64
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v64
     end
 
@@ -58,7 +58,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 6.3
     def v63
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v63
     end
 
@@ -68,7 +68,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 6.2
     def v62
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v62
     end
 
@@ -78,7 +78,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 6.1
     def v61
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v61
     end
 
@@ -88,7 +88,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 6.0
     def v60
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v60
     end
 
@@ -98,7 +98,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 5.1
     def v51
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v51
     end
 
@@ -108,7 +108,7 @@ module RunLoop
     #
     # @return [RunLoop::Version] 5.0
     def v50
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.v50
     end
 
@@ -117,7 +117,7 @@ module RunLoop
     #
     # @return [Boolean] `true` if the current Xcode version is >= 6.4
     def xcode_version_gte_64?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version_gte_64?
     end
 
@@ -126,7 +126,7 @@ module RunLoop
     #
     # @return [Boolean] `true` if the current Xcode version is >= 6.3
     def xcode_version_gte_63?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version_gte_63?
     end
 
@@ -135,7 +135,7 @@ module RunLoop
     #
     # @return [Boolean] `true` if the current Xcode version is >= 6.2
     def xcode_version_gte_62?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version_gte_62?
     end
 
@@ -144,7 +144,7 @@ module RunLoop
     #
     # @return [Boolean] `true` if the current Xcode version is >= 6.1
     def xcode_version_gte_61?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version_gte_61?
     end
 
@@ -153,7 +153,7 @@ module RunLoop
     #
     # @return [Boolean] `true` if the current Xcode version is >= 6.0
     def xcode_version_gte_6?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version_gte_6?
     end
 
@@ -162,7 +162,7 @@ module RunLoop
     #
     # @return [Boolean] `true` if the current Xcode version is >= 7.1
     def xcode_version_gte_71?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version_gte_71?
     end
 
@@ -171,7 +171,7 @@ module RunLoop
     #
     # @return [Boolean] `true` if the current Xcode version is >= 7.0
     def xcode_version_gte_7?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version_gte_7?
     end
 
@@ -180,7 +180,7 @@ module RunLoop
     #
     # @return [Boolean] `true` if the current Xcode version is >= 5.1
     def xcode_version_gte_51?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version_gte_51?
     end
 
@@ -190,7 +190,7 @@ module RunLoop
     # @return [RunLoop::Version] The current version of Xcode as reported by
     #  `xcrun xcodebuild -version`.
     def xcode_version
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.version
     end
 
@@ -209,7 +209,7 @@ module RunLoop
     #
     # @return [String] path to current developer directory
     def xcode_developer_dir
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.developer_dir
     end
 
@@ -219,7 +219,7 @@ module RunLoop
     # @note Relies on Xcode beta versions having and app bundle named Xcode-Beta.app
     # @return [Boolean] True if the Xcode version is beta.
     def xcode_is_beta?
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Xcode') if RunLoop::Environment.debug?
       xcode.beta?
     end
 
@@ -262,7 +262,7 @@ module RunLoop
     #   instruments binary.
     # @raise [ArgumentError] if invalid `cmd` is passed
     def instruments(cmd=nil)
-      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Instruments')
+      RunLoop.deprecated('1.5.0', 'Replaced with RunLoop::Instruments') if RunLoop::Environment.debug?
       instruments = 'xcrun instruments'
       return instruments if cmd == nil
 
@@ -297,7 +297,7 @@ module RunLoop
     #
     # @return [Boolean] true if the version is >= 5.*
     def instruments_supports_hyphen_s?(version=instruments(:version))
-      RunLoop.deprecated('1.5.0', 'Not replaced.')
+      RunLoop.deprecated('1.5.0', 'Not replaced.') if RunLoop::Environment.debug?
       @instruments_supports_hyphen_s ||= lambda {
         if version.is_a? String
           _version = RunLoop::Version.new(version)

--- a/scripts/run_loop_fast_uia.js
+++ b/scripts/run_loop_fast_uia.js
@@ -213,7 +213,11 @@ function isLocationPrompt(alert) {
             ["OK", /Would Like to Access Your Calendar/],
             ["OK", /Would Like to Access Your Reminders/],
             ["OK", /Would Like to Access Your Motion Activity/],
-            ["OK", /Would Like to Access the Camera/]
+            ["OK", /Would Like to Access the Camera/],
+
+            //iOS 9 - English
+            ["OK", /Would Like to Access Your Motion & Fitness Activity/],
+            ["OK", /Would Like Access to Twitter Accounts/]
         ],
         ans, exp,
         txt;

--- a/scripts/run_loop_host.js
+++ b/scripts/run_loop_host.js
@@ -218,10 +218,10 @@ function isLocationPrompt(alert) {
     var exps = [
             ["OK", /vil bruge din aktuelle placering/],
             ["OK", /Would Like to Use Your Current Location/],
+            ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
             ["OK", /Would Like to Send You Notifications/],
             ["OK", /would like to send you Push Notifications/],
             ["Allow", /access your location/],
-            ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
             ["OK", /Would Like to Access Your Photos/],
             ["OK", /Would Like to Access Your Contacts/],
             ["OK", /Location Accuracy/],
@@ -231,7 +231,11 @@ function isLocationPrompt(alert) {
             ["OK", /Would Like to Access Your Calendar/],
             ["OK", /Would Like to Access Your Reminders/],
             ["OK", /Would Like to Access Your Motion Activity/],
-            ["OK", /Would Like to Access the Camera/]
+            ["OK", /Would Like to Access the Camera/],
+
+            //iOS 9 - English
+            ["OK", /Would Like to Access Your Motion & Fitness Activity/],
+            ["OK", /Would Like Access to Twitter Accounts/]
         ],
         ans, exp,
         txt;

--- a/scripts/run_loop_shared_element.js
+++ b/scripts/run_loop_shared_element.js
@@ -213,7 +213,11 @@ function isLocationPrompt(alert) {
             ["OK", /Would Like to Access Your Calendar/],
             ["OK", /Would Like to Access Your Reminders/],
             ["OK", /Would Like to Access Your Motion Activity/],
-            ["OK", /Would Like to Access the Camera/]
+            ["OK", /Would Like to Access the Camera/],
+
+            //iOS 9 - English
+            ["OK", /Would Like to Access Your Motion & Fitness Activity/],
+            ["OK", /Would Like Access to Twitter Accounts/]
         ],
         ans, exp,
         txt;

--- a/spec/lib/device_spec.rb
+++ b/spec/lib/device_spec.rb
@@ -31,7 +31,7 @@ describe RunLoop::Device do
     end
   end
 
-  describe '#to_str' do
+  describe '#to_s' do
     it 'physical device' do
       device = RunLoop::Device.new('denis',
                                    '8.3',
@@ -155,12 +155,12 @@ describe RunLoop::Device do
       describe 'Xcode > 7.0' do
         before { expect(xcode).to receive(:version_gte_7?).and_return true }
         context 'with Major.Minor SDK version' do
-          let(:device) { RunLoop::Device.new('Form Factor', '8.1.1', 'not a device udid', 'Shutdown') }
+          let(:device) { RunLoop::Device.new('Form Factor', '8.1.1', '14A15E35-C568-4775-9480-4FC0C2648236', 'Shutdown') }
           it { is_expected.to be == 'Form Factor (8.1)' }
         end
 
         context 'with Major.Minor.Patch SDK version' do
-          let(:device) { RunLoop::Device.new('Form Factor', '7.0.3', 'not a device udid', 'Shutdown') }
+          let(:device) { RunLoop::Device.new('Form Factor', '7.0.3', '14A15E35-C568-4775-9480-4FC0C2648236', 'Shutdown') }
           it { is_expected.to be == 'Form Factor (7.0.3)' }
         end
       end


### PR DESCRIPTION
### 1.5.4

* Xcode 7: launch instruments with simulator UDID to avoid ambiguous
  matches #253 @sapieneptus
* Remove CoreSimulator LaunchServices csstore before during simulator
  preparation #252 @sapieneptus
* iOS9: dismiss Motion/Activity and Twitter permissions alerts #251
  @sapieneptus
* HOTFIX: backward compatibility for Calabash < 0.16.1 #248
  @ark-konopacki

ATTN: @krukow @sapieneptus 