### PR TITLE
Core.simulator_target? should match simulators created by users

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -443,8 +443,11 @@ Logfile: #{log_file}
       xcode = sim_control.xcode
       if xcode.version_gte_6?
         simulator = sim_control.simulators.find do |sim|
-          sim.instruments_identifier(xcode) == value ||
-                sim.udid == value
+          [
+                sim.instruments_identifier(xcode) == value,
+                sim.udid == value,
+                sim.name == value
+          ].any?
         end
         !simulator.nil?
       else

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -267,6 +267,13 @@ describe RunLoop::Core do
         end
 
         it ':device_target => Named simulator' do
+          options[:device_target] = device.name
+          device.instance_variable_set(:@uuid, 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA')
+
+          expect(RunLoop::Core.simulator_target?(options)).to be == true
+        end
+
+        it ':device_target => Instruments identifier' do
           options[:device_target] = device.instruments_identifier(xcode)
           device.instance_variable_set(:@uuid, 'AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA')
 

--- a/spec/resources.rb
+++ b/spec/resources.rb
@@ -37,6 +37,10 @@ class Resources
     @instruments ||= RunLoop::Instruments.new
   end
 
+  def sim_control
+    @sim_control ||= RunLoop::SimControl.new
+  end
+
   def with_debugging(&block)
     original_value = ENV['DEBUG']
     ENV['DEBUG'] = '1'


### PR DESCRIPTION
### Motivation

`Core.simulator_target?` was not match simulators created with `xcrun simctl create`.