### PR TITLE
Increase the default timeout for Xcrun.exec

### DIFF
--- a/lib/run_loop/xcrun.rb
+++ b/lib/run_loop/xcrun.rb
@@ -31,7 +31,7 @@ module RunLoop
       RunLoop.log_unix_cmd(cmd) if merged_options[:log_cmd]
 
       begin
-        Timeout.timeout(timeout, TimeoutError) do
+        Timeout.timeout(timeout, Timeout::Error) do
           @stdin, @stdout, @stderr, process_status = Open3.popen3('xcrun', *args)
 
           @pid = process_status.pid
@@ -49,6 +49,8 @@ module RunLoop
               :pid => pid,
               :exit_status => exit_status
         }
+      rescue Timeout::Error => _
+        raise XcrunError, "Xcrun.exec timed out after #{timeout} running '#{cmd}'"
       rescue StandardError => e
         raise XcrunError, e
       ensure

--- a/lib/run_loop/xcrun.rb
+++ b/lib/run_loop/xcrun.rb
@@ -3,11 +3,9 @@ module RunLoop
 
     DEFAULT_OPTIONS =
           {
-                :timeout => 10,
+                :timeout => 30,
                 :log_cmd => false
           }
-
-    DEFAULT_TIMEOUT = 10
 
     # Raised when Xcrun fails.
     class XcrunError < RuntimeError; end

--- a/spec/lib/xcrun_spec.rb
+++ b/spec/lib/xcrun_spec.rb
@@ -8,5 +8,21 @@ describe RunLoop::Xcrun do
          xcrun.exec('simctl list devices')
        end.to raise_error ArgumentError, /Expected args/
     end
+
+    it 're-raises Timeout::Errors' do
+      expect(Open3).to receive(:popen3).with('xcrun', 'instruments').and_raise TimeoutError
+
+      expect do
+        xcrun.exec(['instruments'])
+      end.to raise_error RunLoop::Xcrun::XcrunError, /'xcrun instruments'/
+    end
+
+    it 're-raises StandardError' do
+      expect(Open3).to receive(:popen3).and_raise StandardError, 'Raised again!'
+
+      expect do
+        xcrun.exec([])
+      end.to raise_error RunLoop::Xcrun::XcrunError, /Raised again!/
+    end
   end
 end


### PR DESCRIPTION
### Motivation

The previous default of 10s was too short for older machines and CI environments.

**Default timeout in instruments.rb causes failure on slow hardware** #259