### PR TITLE
Instruments#version extracts version from Instruments.app Info.plist

### DIFF
--- a/lib/run_loop/instruments.rb
+++ b/lib/run_loop/instruments.rb
@@ -9,6 +9,10 @@ module RunLoop
 
     attr_reader :xcode
 
+    def pbuddy
+      @pbuddy ||= RunLoop::PlistBuddy.new
+    end
+
     def xcode
       @xcode ||= RunLoop::Xcode.new
     end
@@ -110,10 +114,9 @@ Please update your sources to pass an instance of RunLoop::Xcode))
     # @return [RunLoop::Version] A version object.
     def version
       @instruments_version ||= lambda do
-        args = ['instruments']
-        hash = xcrun.exec(args, log_cmd: true)
-        version_str = hash[:err][VERSION_REGEX, 0]
-        RunLoop::Version.new(version_str)
+        version_string = pbuddy.plist_read('CFBundleShortVersionString',
+                                           path_to_instruments_app_plist)
+        RunLoop::Version.new(version_string)
       end.call
     end
 

--- a/lib/run_loop/instruments.rb
+++ b/lib/run_loop/instruments.rb
@@ -398,5 +398,16 @@ Please update your sources to pass an instance of RunLoop::Xcode))
     def line_is_simulator_paired_with_watch?(line)
       line[CORE_SIMULATOR_UDID_REGEX, 0] && line[/Apple Watch/, 0]
     end
+
+    # @!visibility private
+    def path_to_instruments_app_plist
+      @path_to_instruments_app_plist ||=
+            File.expand_path(File.join(xcode.developer_dir,
+                                 '..',
+                                 'Applications',
+                                 'Instruments.app',
+                                 'Contents',
+                                 'Info.plist'))
+    end
   end
 end

--- a/spec/lib/instruments_spec.rb
+++ b/spec/lib/instruments_spec.rb
@@ -239,16 +239,9 @@ describe RunLoop::Instruments do
   end
 
   it '#version' do
-    xcrun = RunLoop::Xcrun.new
-    expect(instruments).to receive(:xcrun).and_return xcrun
-    output = %q(
-instruments, version 7.0 (58143.1)
-usage: instruments [-t template] [-D document] [-l timeLimit] [-i #] [-w device] [[-p pid] | [application [-e variable value] [argument ...]]]
-)
-    hash = { :err => output }
-    args = { log_cmd: true }
-
-    expect(xcrun).to receive(:exec).with(['instruments'], args).and_return hash
+    path = instruments.send(:path_to_instruments_app_plist)
+    key = 'CFBundleShortVersionString'
+    expect(instruments.pbuddy).to receive(:plist_read).with(key, path).and_return '7.0'
 
     expected = RunLoop::Version.new('7.0')
     expect(instruments.version).to be == RunLoop::Version.new('7.0')

--- a/spec/lib/instruments_spec.rb
+++ b/spec/lib/instruments_spec.rb
@@ -524,4 +524,27 @@ usage: instruments [-t template] [-D document] [-l timeLimit] [-i #] [-w device]
       it { is_expected.to be_truthy }
     end
   end
+
+  describe '#path_to_instruments_app_plist' do
+    it 'active Xcode' do
+      path = instruments.send(:path_to_instruments_app_plist)
+
+      expect(File.exist?(path)).to be_truthy
+      memoized = instruments.instance_variable_get(:@path_to_instruments_app_plist)
+      expect(memoized).to be == path
+    end
+
+    describe 'regression' do
+      Resources.shared.alt_xcode_install_paths.each do |developer_dir|
+        Resources.shared.with_developer_dir(developer_dir) do
+          it "#{developer_dir}" do
+            instruments = RunLoop::Instruments.new
+            path = instruments.send(:path_to_instruments_app_plist)
+
+            expect(File.exist?(path)).to be_truthy
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Motivation

**Default timeout in instruments.rb causes failure on slow hardware** #259

It is not necessary to call `instruments` to get its version.

```
def timeit
  Benchmark.realtime do
    10.times do
      RunLoop::Instruments.new.version
    end
  end
end

# Before
> timeit => ~5.0s

# After
> timeit => ~0.1s
```
