### PR TITLE
Gem: ruby_files glob should catch only ruby files

### DIFF
--- a/run_loop.gemspec
+++ b/run_loop.gemspec
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 
-ruby_files = Dir.glob('{lib}/**/*')
+ruby_files = Dir.glob('{lib}/**/*.rb')
 java_scripts = Dir.glob('scripts/*.js')
 bash_scripts = ['scripts/udidetect', 'scripts/read-cmd.sh', 'scripts/timeout3']
 plists = Dir.glob('plists/**/*.plist')


### PR DESCRIPTION
### Motivation

**Ruby files glob in gemspec should match **/*.rb not **/*** #260