### PR TITLE
Add ruby 1.9 support for Xcrun#exec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ script:
   - scripts/ci/travis/rspec-ci.rb
 
 rvm:
-  # Disable 1.9.3 tests pending CommandRunner 1.9 support
-  #- 1.9.3
+  - 1.9.3
   - 2.0.0
   - 2.2.1
 

--- a/lib/run_loop/xcrun.rb
+++ b/lib/run_loop/xcrun.rb
@@ -1,7 +1,7 @@
 module RunLoop
   class Xcrun
 
-    require 'command_runner'
+    require 'command_runner' if RUBY_VERSION >= '2.0'
 
     DEFAULT_OPTIONS =
           {
@@ -16,9 +16,8 @@ module RunLoop
     # Raised when Xcrun times out.
     class TimeoutError < RuntimeError; end
 
-    attr_reader :stdin, :stdout, :stderr, :pid
-
     def exec(args, options={})
+
       merged_options = DEFAULT_OPTIONS.merge(options)
 
       timeout = merged_options[:timeout]
@@ -42,9 +41,13 @@ module RunLoop
       # Commands are only logged when debugging.
       RunLoop.log_unix_cmd(cmd) if merged_options[:log_cmd]
 
+      # Ruby < 2.0 support
+      return exec_ruby19(args, merged_options) if RUBY_VERSION < '2.0'
+
       hash = {}
 
       begin
+
         start_time = Time.now
         command_output = CommandRunner.run(['xcrun'] + args, timeout: timeout)
 
@@ -75,6 +78,63 @@ module RunLoop
               "Xcrun timed out after #{elapsed} seconds executing '#{cmd}' with a timeout of #{timeout}"
       end
 
+      hash
+    end
+
+    private
+
+    attr_reader :stdin, :stdout, :stderr, :pid
+
+    def exec_ruby19(args, options)
+
+      timeout = options[:timeout]
+
+      cmd = "xcrun #{args.join(' ')}"
+
+      err, out, pid, exit_status, process_status = nil
+
+      hash = nil
+      begin
+        Timeout.timeout(timeout, Timeout::Error) do
+          @stdin, @stdout, @stderr, process_status = Open3.popen3('xcrun', *args)
+
+          @pid = process_status.pid
+          exit_status = process_status.value.exitstatus
+
+          err = @stderr.read.force_encoding('utf-8').chomp
+          err = nil if err == ''
+
+          out = @stdout.read.force_encoding('utf-8').chomp
+        end
+
+        hash =
+              {
+                    :err => err,
+                    :out => out,
+                    :pid => pid,
+                    :exit_status => exit_status
+              }
+      rescue Timeout::Error => _
+        raise TimeoutError, "Xcrun.exec timed out after #{timeout} running '#{cmd}'"
+      rescue StandardError => e
+        raise Error, e
+      ensure
+        stdin.close if stdin && !stdin.closed?
+        stdout.close if stdout && !stdout.closed?
+        stderr.close if stderr && !stderr.closed?
+
+        if pid
+          terminator = RunLoop::ProcessTerminator.new(pid, 'TERM', cmd)
+          unless terminator.kill_process
+            terminator = RunLoop::ProcessTerminator.new(pid, 'KILL', cmd)
+            terminator.kill_process
+          end
+        end
+
+        if process_status
+          process_status.join
+        end
+      end
       hash
     end
   end

--- a/run_loop.gemspec
+++ b/run_loop.gemspec
@@ -49,7 +49,10 @@ tools like instruments and simctl.}
   s.add_dependency('awesome_print', '~> 1.2')
   s.add_dependency('CFPropertyList','~> 2.2')
   s.add_dependency('thor', '>= 0.18.1', '< 1.0')
-  s.add_dependency('command_runner_ng', '>= 0.0.2')
+
+  if RUBY_VERSION >= '2.0'
+    s.add_dependency('command_runner_ng', '>= 0.0.2')
+  end
 
   s.add_development_dependency('luffa', '>= 1.1.0', '< 2.0')
   s.add_development_dependency('bundler', '~> 1.6')

--- a/spec/lib/xcrun_spec.rb
+++ b/spec/lib/xcrun_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 describe RunLoop::Xcrun do
 
   let(:xcrun) { RunLoop::Xcrun.new }
@@ -15,81 +17,109 @@ describe RunLoop::Xcrun do
     }
   end
 
-  describe '#exec' do
-    it 'raises an error if arg is not an Array' do
-       expect do
-         xcrun.exec('simctl list devices')
-       end.to raise_error ArgumentError, /Expected args/
-    end
+  if RUBY_VERSION >= '2.0'
+    describe '#exec' do
+      it 'raises an error if arg is not an Array' do
+        expect do
+          xcrun.exec('simctl list devices')
+        end.to raise_error ArgumentError, /Expected args/
+      end
 
-    it 'raises an error if any arg is not a string' do
-      expect do
-        xcrun.exec(['sleep', 5])
-      end.to raise_error ArgumentError,
-            /Expected arg '5' to be a String, but found 'Fixnum'/
-    end
+      it 'raises an error if any arg is not a string' do
+        expect do
+          xcrun.exec(['sleep', 5])
+        end.to raise_error ArgumentError,
+                           /Expected arg '5' to be a String, but found 'Fixnum'/
+      end
 
-    it 're-raises error thrown by CommandRunner' do
-      expect(CommandRunner).to receive(:run).and_raise RuntimeError, 'Some error'
-
-      expect do
-        xcrun.exec(['sleep', '0.5'])
-      end.to raise_error RunLoop::Xcrun::Error, /Some error/
-    end
-
-    describe 'raises timeout error if CommandRunner timed out' do
-      it 'mocked' do
-        expect(process_status).to receive(:exitstatus).and_return(nil)
-        expect(CommandRunner).to receive(:run).and_return(command_output)
+      it 're-raises error thrown by CommandRunner' do
+        expect(CommandRunner).to receive(:run).and_raise RuntimeError, 'Some error'
 
         expect do
           xcrun.exec(['sleep', '0.5'])
-        end.to raise_error RunLoop::Xcrun::TimeoutError, /Xcrun timed out after/
+        end.to raise_error RunLoop::Xcrun::Error, /Some error/
       end
 
-      it 'actual' do
+      describe 'raises timeout error if CommandRunner timed out' do
+        it 'mocked' do
+          expect(process_status).to receive(:exitstatus).and_return(nil)
+          expect(CommandRunner).to receive(:run).and_return(command_output)
+
+          expect do
+            xcrun.exec(['sleep', '0.5'])
+          end.to raise_error RunLoop::Xcrun::TimeoutError, /Xcrun timed out after/
+        end
+
+        it 'actual' do
+          expect do
+            xcrun.exec(['sleep', '0.5'], timeout: 0.05)
+          end.to raise_error RunLoop::Xcrun::TimeoutError, /Xcrun timed out after/
+        end
+      end
+
+      it 'forces UTF-8 encoding and chomps' do
+        # Force C (non UTF-8 encoding)
+        stub_env({'LC_ALL' => 'C'})
+        args = ['cat', 'spec/resources/encoding.txt']
+
+        # Confirm that the string is read as ASCII whatever
+        command_runner_hash = CommandRunner.run(args, timeout: 0.2)
+        command_runner_out = command_runner_hash[:out]
+        expect(command_runner_out.length).to be == 20
+
+        xcrun_hash = xcrun.exec(args, timout: 0.2)
+        xcrun_out = xcrun_hash[:out]
+
+        expect(xcrun_out).to be == 'ITZVÃ ●℆❡♡'
+      end
+
+      describe 'contents of returned hash' do
+        it 'mocked' do
+          expect(process_status).to receive(:exitstatus).and_return(256)
+          expect(process_status).to receive(:pid).and_return(3030)
+          command_output[:out] = 'mocked'
+          expect(CommandRunner).to receive(:run).and_return(command_output)
+
+          xcrun_hash = xcrun.exec(['sleep', '0.1'])
+
+          expect(xcrun_hash[:out]).to be == 'mocked'
+          expect(xcrun_hash[:pid]).to be == 3030
+          expect(xcrun_hash[:exit_status]).to be == 256
+        end
+
+        it 'actual' do
+          xcrun_hash = xcrun.exec(['echo', "\"actual\""], timeout: 0.5)
+
+          expect(xcrun_hash[:pid]).to be_truthy
+          expect(xcrun_hash[:exit_status]).to be == 0
+          expect(xcrun_hash[:out]).to be == "\"actual\""
+        end
+      end
+    end
+  else
+
+    # Ruby 1.9
+    describe '#exec' do
+      it 'raises an error if arg is not an Array' do
         expect do
-          xcrun.exec(['sleep', '0.5'], timeout: 0.05)
-        end.to raise_error RunLoop::Xcrun::TimeoutError, /Xcrun timed out after/
-      end
-    end
-
-    it 'forces UTF-8 encoding and chomps' do
-      # Force C (non UTF-8 encoding)
-      stub_env({'LC_ALL' => 'C'})
-      args = ['cat', 'spec/resources/encoding.txt']
-
-      # Confirm that the string is read as ASCII whatever
-      command_runner_hash = CommandRunner.run(args, timeout: 0.2)
-      command_runner_out = command_runner_hash[:out]
-      expect(command_runner_out.length).to be == 20
-
-      xcrun_hash = xcrun.exec(args, timout: 0.2)
-      xcrun_out = xcrun_hash[:out]
-
-      expect(xcrun_out).to be == 'ITZVÃ ●℆❡♡'
-    end
-
-    describe 'contents of returned hash' do
-      it 'mocked' do
-        expect(process_status).to receive(:exitstatus).and_return(256)
-        expect(process_status).to receive(:pid).and_return(3030)
-        command_output[:out] = 'mocked'
-        expect(CommandRunner).to receive(:run).and_return(command_output)
-
-        xcrun_hash = xcrun.exec(['sleep', '0.1'])
-
-        expect(xcrun_hash[:out]).to be == 'mocked'
-        expect(xcrun_hash[:pid]).to be == 3030
-        expect(xcrun_hash[:exit_status]).to be == 256
+          xcrun.exec('simctl list devices')
+        end.to raise_error ArgumentError, /Expected args/
       end
 
-      it 'actual' do
-        xcrun_hash = xcrun.exec(['echo', "\"actual\""], timeout: 0.5)
+      it 're-raises Timeout::Errors' do
+        expect(Open3).to receive(:popen3).with('xcrun', 'instruments').and_raise TimeoutError
 
-        expect(xcrun_hash[:pid]).to be_truthy
-        expect(xcrun_hash[:exit_status]).to be == 0
-        expect(xcrun_hash[:out]).to be == "\"actual\""
+        expect do
+          xcrun.exec(['instruments'])
+        end.to raise_error RunLoop::Xcrun::TimeoutError, /'xcrun instruments'/
+      end
+
+      it 're-raises StandardError' do
+        expect(Open3).to receive(:popen3).and_raise StandardError, 'Raised again!'
+
+        expect do
+          xcrun.exec([])
+        end.to raise_error RunLoop::Xcrun::Error, /Raised again!/
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ require 'tmpdir'
 require 'fileutils'
 require 'luffa'
 require 'digest/sha2'
-require 'command_runner'
+require 'command_runner' if RUBY_VERSION >= '2.0'
 
 require File.join(File.dirname(__FILE__), 'resources/instruments_output')
 


### PR DESCRIPTION
### Motivation

We want to use command_runner_ng, but it does not support ruby 1.9.3.

Pending support for ruby 1.9.3, this is a patch for Xcrun#exec.

**Add support for ruby 1.9** [#5](https://github.com/kamstrup/command_runner_ng/pull/5)