### PR TITLE
Simulator: should manage the 'iproxy' process

### DIFF
--- a/lib/run_loop/life_cycle/simulator.rb
+++ b/lib/run_loop/life_cycle/simulator.rb
@@ -38,6 +38,10 @@ module RunLoop
                   # killed when quiting the simulator.
                   ['assetsd', true],
 
+                  # iproxy is started by UITest.  It is not necessary to send
+                  # TERM first.
+                  ['iproxy', false],
+
                   # Xcode 7
                   ['ids_simd', true]
             ]


### PR DESCRIPTION
### Motivation

Generated by iproxy, this can bind port 37265 and prevent the server from starting.

**run-loop needs to manage iproxy process** #277