### PR TITLE
Version can be used as hash key

### DIFF
--- a/lib/run_loop/version.rb
+++ b/lib/run_loop/version.rb
@@ -44,7 +44,7 @@ module RunLoop
     #  version.minor       => 10
     #  version.patch       => 1
     #  version.pre         => false
-    #  version.pre_release => nil
+    #  version.pre_version => nil
     #
     # @example
     #  version = Version.new(1.6.3.pre5)
@@ -52,7 +52,7 @@ module RunLoop
     #  version.minor       => 6
     #  version.patch       => 3
     #  version.pre         => true
-    #  version.pre_release => 5
+    #  version.pre_version => 5
     #
     # @param [String] version the version string to parse.
     # @raise [ArgumentError] if version is not in the form 5, 6.1, 7.1.2, 8.2.3.pre1

--- a/lib/run_loop/version.rb
+++ b/lib/run_loop/version.rb
@@ -88,6 +88,18 @@ module RunLoop
       "#<Version #{to_s}>"
     end
 
+    # Compare this version to another for _object_ equality.  This allows
+    # Version instances to be used as Hash keys.
+    # @param [Version] other the version to compare against.
+    def eql?(other)
+      hash == other.hash
+    end
+
+    # The hash method for this instance.
+    def hash
+      to_s.hash
+    end
+
     # Compare this version to another for equality.
     # @param [Version] other the version to compare against
     # @return [Boolean] true if this Version is the same as `other`

--- a/spec/lib/version_spec.rb
+++ b/spec/lib/version_spec.rb
@@ -30,6 +30,90 @@ describe RunLoop::Version do
     end
   end
 
+  describe '#hash' do
+    it '0.9.5.pre1' do
+      str = '0.9.5.pre1'
+      version = RunLoop::Version.new(str)
+      expect(str.hash).to be == version.hash
+    end
+
+    it '0.9.5.pre' do
+      str = '0.9.5.pre'
+      version = RunLoop::Version.new(str)
+      expect(str.hash).to be == version.hash
+    end
+
+    it '0.9.5' do
+      str = '0.9.5'
+      version = RunLoop::Version.new(str)
+      expect(str.hash).to be == version.hash
+    end
+
+    it '0.9' do
+      str = '0.9'
+      version = RunLoop::Version.new(str)
+      expect(str.hash).to be == version.hash
+    end
+
+    it '0' do
+      str = '0'
+      version = RunLoop::Version.new(str)
+      expect(str.hash).to be == version.hash
+    end
+  end
+
+  describe '#eql?' do
+    it 'mocked' do
+      a = RunLoop::Version.new('9.9.9')
+      b = RunLoop::Version.new('0.0.0')
+
+      expect(a).to receive(:hash).and_return(-1, -1)
+      expect(b).to receive(:hash).and_return(-1, 0)
+
+      expect(a.eql?(b)).to be == true
+      expect(a.eql?(b)).to be == false
+    end
+
+    it 'are equal' do
+
+      a = RunLoop::Version.new('0.0.0')
+      b = RunLoop::Version.new('0.0.0')
+
+      expect(a.eql?(b)).to be == true
+    end
+
+    it 'are not equal' do
+
+      a = RunLoop::Version.new('9.9.9')
+      b = RunLoop::Version.new('0.0.0')
+
+      expect(a.eql?(b)).to be == false
+    end
+  end
+
+  describe 'instance as a hash key' do
+    it 'keys match' do
+      a = RunLoop::Version.new('0.0.0')
+      b = RunLoop::Version.new('0.0.0')
+
+      hash = { a => 'before!' }
+
+      hash[b] = 'after!'
+      expect(hash[a]) == 'after!'
+    end
+
+    it 'keys do not match' do
+      a = RunLoop::Version.new('0.0.0')
+      b = RunLoop::Version.new('9.9.9')
+
+      hash = { a => 'before!' }
+
+      hash[b] = 'after!'
+      expect(hash[a]) == 'before!'
+      expect(hash[b]) == 'after!'
+    end
+  end
+
   describe '==' do
     it 'tests equality' do
       a = RunLoop::Version.new('0.9.5')


### PR DESCRIPTION
### Motivation

**Xcode 7.1 beta 2: instruments and simctl need to filter out Apple TV from known simulators** #283

Might have some downstream consequences, but I doubt it.  We'll run this through CI a bunch before a release.