### PR TITLE
Improve Directory.directory_digest and Device#simulator_wait_for_stable_state interaction

### DIFF
--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -383,7 +383,11 @@ Please update your sources to pass an instance of RunLoop::Xcode))
         io.close if io && !io.closed?
       end
 
-      line
+      if line
+        line.chomp
+      else
+        line
+      end
     end
 
     # @!visibility private

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -314,13 +314,11 @@ Please update your sources to pass an instance of RunLoop::Xcode))
       current_sha = nil
       sha_fn = lambda do |data_dir|
         begin
-          # Directory.directory_digest has a blocking read.  Typically, it
-          # returns in < 0.3 seconds.
+          # Typically, this returns in < 0.3 seconds.
           Timeout.timeout(2, TimeoutError) do
             RunLoop::Directory.directory_digest(data_dir)
           end
-        rescue => e
-          RunLoop.log_error(e) if RunLoop::Environment.debug?
+        rescue => _
           SecureRandom.uuid
         end
       end

--- a/lib/run_loop/directory.rb
+++ b/lib/run_loop/directory.rb
@@ -44,7 +44,26 @@ module RunLoop
       sha = OpenSSL::Digest::SHA256.new
       entries.each do |file|
         unless self.skip_file?(file, 'SHA1', debug)
-          sha << File.read(file)
+          begin
+            sha << File.read(file)
+          rescue => e
+            if debug
+              RunLoop.log_warn(%Q{
+RunLoop::Directory.directory_digest raised an error:
+
+#{e}
+
+while trying to find the SHA of this file:
+
+#{file}
+
+Please report this here:
+
+https://github.com/calabash/run_loop/issues
+
+})
+            end
+          end
         end
       end
       sha.hexdigest


### PR DESCRIPTION
### Motivation

While doing some debugging on other issues, I discovered that Device was logging ignorable errors that should have been logged in Directory.directory_digest.