### PR TITLE
Environment: user home on XTC is ./tmp/home

### DIFF
--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -3,8 +3,14 @@ module RunLoop
 
     # Returns the user home directory
     def self.user_home_directory
-      require 'etc'
-      Etc.getpwuid.dir
+      if self.xtc?
+         home = File.join("./", "tmp", "home")
+         FileUtils.mkdir_p(home)
+         home
+      else
+        require 'etc'
+        Etc.getpwuid.dir
+      end
     end
 
     # Returns true if debugging is enabled.

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -2,8 +2,18 @@ describe RunLoop::Environment do
 
   let(:environment) { RunLoop::Environment.new }
 
-  it '.user_home_directory' do
-    expect(File.exist?(RunLoop::Environment.user_home_directory)).to be_truthy
+  describe ".user_home_directory" do
+    it "always returns a directory that exists" do
+      expect(File.exist?(RunLoop::Environment.user_home_directory)).to be_truthy
+    end
+
+    it "returns local ./tmp/home on the XTC" do
+      expect(RunLoop::Environment).to receive(:xtc?).and_return true
+
+      expected = File.join("./", "tmp", "home")
+      expect(RunLoop::Environment.user_home_directory).to be == expected
+      expect(File.exist?(expected)).to be_truthy
+    end
   end
 
   describe '.debug?' do


### PR DESCRIPTION
### Motivation

On the XTC we don't want to be writing to a home directory which might be shared.

