### PR TITLE
DotDir: remove unnecessary code

### DIFF
--- a/lib/run_loop/dot_dir.rb
+++ b/lib/run_loop/dot_dir.rb
@@ -22,26 +22,6 @@ module RunLoop::DotDir
     next_results_dir
   end
 
-  def self.logs_dir
-   log_dir = File.join(self.directory, 'logs')
-
-   if !File.exist?(log_dir)
-     FileUtils.mkdir_p(log_dir)
-   end
-
-   log_dir
-  end
-
-  def self.logfile_for_rotate_results
-    logfile = File.join(self.logs_dir, 'rotate-results.log')
-
-    if !File.exist?(logfile)
-      FileUtils.touch(logfile)
-    end
-
-    logfile
-  end
-
   def self.rotate_result_directories
     return :xtc if RunLoop::Environment.xtc?
 
@@ -98,21 +78,6 @@ module RunLoop::DotDir
       dir = File.join(base_dir, SecureRandom.uuid)
     end
     dir
-  end
-
-  def self.log_to_file(file, message)
-
-    timestamp = Time.now
-    dated = "#{timestamp} #{message}"
-
-    File.open(file, "a") do |log|
-      begin
-        log.write("#{dated}\n")
-        log.flush
-      rescue StandardError => e
-        RunLoop.log_error("Writing to #{file} generated this error: #{e}")
-      end
-    end
   end
 end
 

--- a/spec/lib/dot_dir_spec.rb
+++ b/spec/lib/dot_dir_spec.rb
@@ -103,35 +103,6 @@ describe RunLoop::DotDir do
    end
  end
 
- it ".logs_dir" do
-   expected = File.join(dot_dir, 'logs')
-   actual = RunLoop::DotDir.logs_dir
-
-   expect(actual).to be == expected
-   expect(File.exist?(actual)).to be_truthy
- end
-
- it ".logfile_for_rotate_results" do
-   log = RunLoop::DotDir.logfile_for_rotate_results
-
-   expect(File.exist?(log)).to be_truthy
- end
-
- it ".log_to_file" do
-   file = File.join(RunLoop::DotDir.logs_dir, "some.log")
-   message = "Hey!"
-
-   timestamp = "2015-10-09 15:04:06 +0200"
-   expect(Time).to receive(:now).and_return(timestamp)
-
-   expected = "#{timestamp} #{message}\n"
-
-   RunLoop::DotDir.log_to_file(file, message)
-
-   actual = File.open(file, "r") { |log| log.read }
-   expect(actual).to be == expected
- end
-
  describe ".rotate_result_directories" do
    let(:generator) do
      Class.new do


### PR DESCRIPTION
### Motivation

There was some unused code left over from an attempt at rotating instruments caches.
