### PR TITLE
Rotate /Library/Cache/com.app.dt.instruments directories

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -820,6 +820,8 @@ Please update your sources to pass an instance of RunLoop::Instruments))
 
     def self.prepare(run_options)
       RunLoop::DotDir.rotate_result_directories
+      RunLoop::Instruments.rotate_cache_directories
+      true
     end
   end
 end

--- a/lib/run_loop/instruments.rb
+++ b/lib/run_loop/instruments.rb
@@ -420,6 +420,7 @@ Please update your sources to pass an instance of RunLoop::Xcode))
     end
 
     # @!visibility private
+    #
     # Instruments caches files in this directory and it can become quite large
     # over time; particularly on CI system.
     def self.library_cache_dir
@@ -445,5 +446,17 @@ Please update your sources to pass an instance of RunLoop::Xcode))
         nil
       end
     end
+
+    # @!visibility private
+    #
+    # We don't want to run more than 1 time per-day.
+    def self.instruments_cache_rotate_lock_stale?
+      lock = self.instruments_cache_rotate_lock
+      return true if !lock
+
+      mtime = File.mtime(lock)
+      mtime < (DateTime.now - 1).to_time
+    end
   end
 end
+

--- a/lib/run_loop/instruments.rb
+++ b/lib/run_loop/instruments.rb
@@ -431,5 +431,19 @@ Please update your sources to pass an instance of RunLoop::Xcode))
         nil
       end
     end
+
+    # @!visibility private
+    #
+    # Cleaning the instruments cache file is an async operation.  Whether
+    # or not a new operation is forked is controlled by a lock file.
+    def self.instruments_cache_rotate_lock
+      lock = File.join(RunLoop::DotDir.locks_dir, "instruments_cache_rotate.lock")
+
+      if File.exist?(lock)
+        lock
+      else
+        nil
+      end
+    end
   end
 end

--- a/lib/run_loop/instruments.rb
+++ b/lib/run_loop/instruments.rb
@@ -33,8 +33,9 @@ module RunLoop
 
       log_progress = false
       if directories.count > 25
-        RunLoop.log_info2("Found #{directories.count} instruments caches")
+        RunLoop.log_info2("Found #{directories.count} instruments caches: ~#{20 * directories.count} Mb")
         RunLoop.log_info2("Deleting them could take a long time.")
+        RunLoop.log_info2("This delay will only happen once!")
         RunLoop.log_info2("Please be patient and allow the directories to be deleted")
         log_progress = true
       else

--- a/lib/run_loop/instruments.rb
+++ b/lib/run_loop/instruments.rb
@@ -418,5 +418,18 @@ Please update your sources to pass an instance of RunLoop::Xcode))
                                  'Contents',
                                  'Info.plist'))
     end
+
+    # @!visibility private
+    # Instruments caches files in this directory and it can become quite large
+    # over time; particularly on CI system.
+    def self.library_cache_dir
+      path = "/Library/Caches/com.apple.dt.instruments"
+
+      if File.exist?(path)
+        path
+      else
+        nil
+      end
+    end
   end
 end

--- a/lib/run_loop/logging.rb
+++ b/lib/run_loop/logging.rb
@@ -59,6 +59,12 @@ module RunLoop
     end
   end
 
+  # .log_info is already taken by the XTC logger. (>_O)
+  # green
+  def self.log_info2(msg)
+    puts self.green(" INFO: #{msg}") if msg
+  end
+
   # red
   def self.log_error(msg)
     puts self.red("ERROR: #{msg}") if msg
@@ -100,5 +106,10 @@ module RunLoop
   # @!visibility private
   def self.cyan(string)
     colorize(string, 36)
+  end
+
+  # @!visibility private
+  def self.green(string)
+    colorize(string, 32)
   end
 end

--- a/spec/lib/instruments_spec.rb
+++ b/spec/lib/instruments_spec.rb
@@ -574,4 +574,28 @@ describe RunLoop::Instruments do
       end
     end
   end
+
+  describe "clearing the /Library cache" do
+    let(:path) { "/Library/Caches/com.apple.dt.instruments" }
+
+    describe ".library_cache_dir" do
+      it "returns the dir path if it exist" do
+        expect(File).to receive(:exist?).with(path).and_return true
+
+        actual = RunLoop::Instruments.send(:library_cache_dir)
+        expect(actual).to be == path
+      end
+
+      it "returns nil otherwise" do
+        expect(File).to receive(:exist?).with(path).and_return false
+
+        actual = RunLoop::Instruments.send(:library_cache_dir)
+        expect(actual).to be_falsey
+      end
+    end
+
+    describe ".instrument_cache_cleanup_lock" do
+
+    end
+  end
 end

--- a/spec/lib/instruments_spec.rb
+++ b/spec/lib/instruments_spec.rb
@@ -11,6 +11,103 @@ describe RunLoop::Instruments do
     Resources.shared.kill_fake_instruments_process
   }
 
+  describe ".rotate_cache_directories" do
+    let(:cache_dir) { "./tmp/cache" }
+
+    let(:generator) do
+      Class.new do
+        def initialize(cache_dir)
+          @cache_dir = cache_dir
+        end
+
+        def generate(n)
+          FileUtils.rm_rf(@cache_dir)
+          FileUtils.mkdir_p(@cache_dir)
+          generated = []
+
+          n.times do
+            file = File.join(@cache_dir, "xrtmp__#{SecureRandom.uuid}")
+            FileUtils.mkdir_p(file)
+            generated << file
+
+            # Make some other directories because we only match on xrtmp__
+            file = File.join(@cache_dir, SecureRandom.uuid)
+            FileUtils.mkdir_p(file)
+          end
+          generated
+        end
+      end.new(cache_dir)
+    end
+
+    let(:options) { { :forked => false } }
+
+    let(:pid) { nil }
+
+    after do
+     if pid
+       begin
+         Process.kill("TERM", pid)
+       rescue Errno::ESRCH => _
+         # No pid found
+       rescue Errno::EPERM => _
+         # Don't have permission
+       rescue SignalException => _
+         # Anything else?
+       end
+     end
+    end
+
+    it "does nothing on the XTC" do
+      expect(RunLoop::Environment).to receive(:xtc?).and_return true
+
+      expect(RunLoop::Instruments.rotate_cache_directories(options)).to be == :xtc
+    end
+
+    it "does nothing if the lock file is not stale" do
+      method = :instruments_cache_rotate_lock_stale?
+      expect(RunLoop::Instruments).to receive(method).and_return false
+
+      expect(RunLoop::Instruments.rotate_cache_directories(options)).to be == :locked
+    end
+
+    it "leaves 5 most recent results" do
+      expect(RunLoop::Instruments).to receive(:library_cache_dir).and_return cache_dir
+      generated = generator.generate(10)
+
+      counter = 1
+      generated.each do |dir|
+        new_time =  Time.now + counter
+        expect(File).to receive(:mtime).with(dir).at_least(:once).and_return(new_time)
+        counter = counter + 1
+      end
+
+      generated.shift(5)
+
+      actual = RunLoop::Instruments.rotate_cache_directories(options)
+      expect(actual).to be == :not_forked
+
+      actual = Dir.glob("#{cache_dir}/xrtmp__*").select do |entry|
+        !(entry.end_with?('..') || entry.end_with?('.'))
+      end.sort_by { |f| File.mtime(f) }
+
+      expect(actual).to be == generated
+
+      actual = Dir.entries(cache_dir).select do |entry|
+        !(entry.end_with?('..') || entry.end_with?('.'))
+      end
+
+      expect(actual.count).to be == 15
+    end
+
+    it "forks by default" do
+      expect(RunLoop::Instruments).to receive(:library_cache_dir).and_return cache_dir
+      generator.generate(10)
+
+      pid = RunLoop::Instruments.rotate_cache_directories
+      expect(pid).to be_truthy
+    end
+  end
+
   describe '.new' do
     it 'creates a new RunLoop::Instruments instance' do
       expect(RunLoop::Instruments.new).to be_a RunLoop::Instruments

--- a/spec/lib/instruments_spec.rb
+++ b/spec/lib/instruments_spec.rb
@@ -576,9 +576,10 @@ describe RunLoop::Instruments do
   end
 
   describe "clearing the /Library cache" do
-    let(:path) { "/Library/Caches/com.apple.dt.instruments" }
 
     describe ".library_cache_dir" do
+      let(:path) { "/Library/Caches/com.apple.dt.instruments" }
+
       it "returns the dir path if it exist" do
         expect(File).to receive(:exist?).with(path).and_return true
 
@@ -594,8 +595,28 @@ describe RunLoop::Instruments do
       end
     end
 
-    describe ".instrument_cache_cleanup_lock" do
+    describe ".instruments_cache_rotate_lock" do
 
+      let(:dir) { "tmp/.run-loop/locks" }
+      let(:path) { File.join(dir, "instruments_cache_rotate.lock") }
+
+      before do
+        expect(RunLoop::DotDir).to receive(:locks_dir).and_return(dir)
+      end
+
+      it "returns path to the lock file" do
+        expect(File).to receive(:exist?).with(path).and_return true
+
+        actual = RunLoop::Instruments.send(:instruments_cache_rotate_lock)
+        expect(actual).to be_truthy
+      end
+
+      it "returns nil otherwise" do
+        expect(File).to receive(:exist?).with(path).and_return false
+
+        actual = RunLoop::Instruments.send(:instruments_cache_rotate_lock)
+        expect(actual).to be_falsey
+      end
     end
   end
 end

--- a/spec/lib/logging_spec.rb
+++ b/spec/lib/logging_spec.rb
@@ -45,5 +45,10 @@ describe RunLoop do
     it '.log_error' do
       RunLoop.log_error('error')
     end
+
+    # .log_info is already taken by the XTC logger. (>_O)
+    it '.log_info2' do
+      RunLoop.log_info2("info")
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Each Calabash generates a >= 25 M directory in /Library/Cache/com.app.dt.instruments.

Run loop will now rotate these directories keeping only the 5 most recent.  On the XTC the rotate step does nothing.

Fixes **Running out of disk space because of cached instruments files** #276

Initially, I implemented the rotate in a forked process because the first run will take a long time to complete - it will possibly have to delete hundreds of _gigabytes_ of files. Subsequent runs will be fast; any delays will be lost in the noise of launching the simulator. Instead of the async solution, I added non-optional logging if a large number of directories is discovered.  This logging explains what is happening, asks the user to be patient, and shows progress.  I kept the commits for the async solution because there is some decent code in there - I had the async solution working and tested locally. 