### PR TITLE
Environment: expand the APP bundle path

### DIFF
--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -63,7 +63,7 @@ module RunLoop
       if !value || value == ''
         nil
       else
-        value
+        File.expand_path(value)
       end
     end
 

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -118,10 +118,10 @@ describe RunLoop::Environment do
       end
 
       it 'APP' do
+        expect(RunLoop::Environment.path_to_app_bundle).to be == nil
         allow(ENV).to receive(:[]).and_call_original
         allow(ENV).to receive(:[]).with('APP_BUNDLE_PATH').and_return(nil)
         allow(ENV).to receive(:[]).with('APP').and_return('')
-        expect(RunLoop::Environment.path_to_app_bundle).to be == nil
       end
 
       it 'both' do
@@ -130,6 +130,15 @@ describe RunLoop::Environment do
         allow(ENV).to receive(:[]).with('APP').and_return('')
         expect(RunLoop::Environment.path_to_app_bundle).to be == nil
       end
+    end
+
+    it "expands relative paths" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('APP_BUNDLE_PATH').and_return("./CalSmoke-cal.app")
+
+      dirname = File.dirname(__FILE__)
+      expected = File.expand_path(File.join(dirname, '..', '..', "CalSmoke-cal.app"))
+      expect(RunLoop::Environment.path_to_app_bundle).to be == expected
     end
   end
 


### PR DESCRIPTION
### Motivation

Fixes **Expand APP (and APP_BUNDLE_PATH) path before launching instruments** #255

Instruments cannot handle relative paths or paths with "~/"