### PR TITLE
Send KILL to lldb directly and don't wait as long for lldb to die

### DIFF
--- a/lib/run_loop/lldb.rb
+++ b/lib/run_loop/lldb.rb
@@ -33,9 +33,7 @@ module RunLoop
     # Attempts to gracefully kill all running lldb processes.
     def self.kill_lldb_processes
       self.lldb_pids.each do |pid|
-        unless self.kill_with_signal(pid, 'TERM')
-          self.kill_with_signal(pid, 'KILL')
-        end
+        self.kill_with_signal(pid, 'KILL')
       end
     end
 

--- a/lib/run_loop/lldb.rb
+++ b/lib/run_loop/lldb.rb
@@ -44,7 +44,8 @@ module RunLoop
 
     # @!visibility private
     def self.kill_with_signal(pid, signal)
-      RunLoop::ProcessTerminator.new(pid, signal, 'lldb').kill_process
+      options = {:timeout => 1.0, :delay => 0.1}
+      RunLoop::ProcessTerminator.new(pid, signal, 'lldb', options).kill_process
     end
 
   end

--- a/spec/lib/lldb_spec.rb
+++ b/spec/lib/lldb_spec.rb
@@ -23,9 +23,7 @@ describe RunLoop::LLDB do
 
   it '.kill_lldb_processes' do
     expect(RunLoop::LLDB).to receive(:lldb_pids).and_return([1, 2])
-    expect(RunLoop::LLDB).to receive(:kill_with_signal).with(1, 'TERM').exactly(1).times.and_return(false)
     expect(RunLoop::LLDB).to receive(:kill_with_signal).with(1, 'KILL').exactly(1).times.and_return(true)
-    expect(RunLoop::LLDB).to receive(:kill_with_signal).with(2, 'TERM').exactly(1).times.and_return(false)
     expect(RunLoop::LLDB).to receive(:kill_with_signal).with(2, 'KILL').exactly(1).times.and_return(true)
     expect(RunLoop::LLDB.kill_lldb_processes).to be_truthy
   end


### PR DESCRIPTION
### Motivation

**Improve dylib injection for simulators** #311 improved our interactions with lldb.

I don't think the TERM is necessary anymore and we were waiting too long for lldb to die.