### PR TITLE
CoreSimulator#launch launches simulator even if app is installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_script:
 script:
   - scripts/ci/travis/install-gem-ci.rb
   - scripts/ci/travis/rspec-ci.rb
-  - bundle exec rspec spec/integration/core_simulator_spec.rb
 
 rvm:
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_script:
 script:
   - scripts/ci/travis/install-gem-ci.rb
   - scripts/ci/travis/rspec-ci.rb
+  - bundle exec rspec spec/integration/core_simulator_spec.rb
 
 rvm:
   - 2.0.0

--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -109,6 +109,8 @@ class RunLoop::CoreSimulator
       send_term_first = process_details[1]
       self.term_or_kill(process_name, send_term_first)
     end
+
+    self.simulator_pid = nil
   end
 
   # @!visibility private

--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -351,12 +351,25 @@ class RunLoop::CoreSimulator
   #
   # @note Will only search for the current Xcode simulator.
   #
-  # @return [String, nil] The pid as a String or nil if no process is found.
+  # @return [Integer, nil] The pid as a String or nil if no process is found.
   #
   # @todo Convert this to force UTF8
   def running_simulator_pid
     process_name = "MacOS/#{sim_name}"
-    `xcrun ps x -o pid,command | grep "#{process_name}" | grep -v grep`.strip.split(' ').first
+
+    hash = xcrun.exec(["xcrun", "ps", "x", "-o" "pid,command"])
+
+    return nil if hash.nil? || hash[:out].nil?
+
+    lines = hash[:out].split("\n")
+
+    match = lines.detect do |line|
+      line[/#{process_name}/, 0]
+    end
+
+    return nil if match.nil?
+
+    match.split(" ").first.to_i
   end
 
   # @!visibility private

--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -363,9 +363,30 @@ class RunLoop::CoreSimulator
   def running_simulator_pid
     process_name = "MacOS/#{sim_name}"
 
-    hash = xcrun.exec(["xcrun", "ps", "x", "-o" "pid,command"])
+    args = ["xcrun", "ps", "x", "-o", "pid,command"]
+    hash = xcrun.exec(args)
 
-    return nil if hash.nil? || hash[:out].nil?
+    exit_status = hash[:exit_status]
+    if exit_status != 0
+      raise RuntimeError,
+%Q{Could not find the pid of #{sim_name} with:
+
+#{args.join(" ")}
+
+Command exited with status #{exit_status}
+Message: '#{hash[:out]}'
+}
+    end
+
+    if hash[:out].nil? || hash[:out] == ""
+       raise RuntimeError,
+%Q{Could not find the pid of #{sim_name} with:
+
+#{args.join(" ")}
+
+Command had no output
+}
+    end
 
     lines = hash[:out].split("\n")
 

--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -215,7 +215,7 @@ class RunLoop::CoreSimulator
     launch_simulator
 
     args = ['simctl', 'launch', device.udid, app.bundle_identifier]
-    hash = xcrun.exec(args, log_cmd: true, timeout: 20)
+    hash = xcrun.exec(args, log_cmd: true, timeout: 30)
 
     exit_status = hash[:exit_status]
 

--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -164,11 +164,11 @@ class RunLoop::CoreSimulator
   # Launch the simulator indicated by device.
   def launch_simulator
 
-    if sim_pid != nil
+    if running_simulator_pid != nil
       # There is a running simulator.
 
       # Did we launch it?
-      if sim_pid == simulator_pid
+      if running_simulator_pid == self.simulator_pid
         # Nothing to do, we already launched the simulator.
         return
       else
@@ -354,7 +354,7 @@ class RunLoop::CoreSimulator
   # @return [String, nil] The pid as a String or nil if no process is found.
   #
   # @todo Convert this to force UTF8
-  def sim_pid
+  def running_simulator_pid
     process_name = "MacOS/#{sim_name}"
     `xcrun ps x -o pid,command | grep "#{process_name}" | grep -v grep`.strip.split(' ').first
   end

--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -2,6 +2,9 @@
 class RunLoop::CoreSimulator
 
   # @!visibility private
+  @@simulator_pid = nil
+
+  # @!visibility private
   attr_reader :app
 
   # @!visibility private
@@ -15,9 +18,6 @@ class RunLoop::CoreSimulator
 
   # @!visibility private
   attr_reader :xcrun
-
-  # @!visibility private
-  attr_reader :simulator_pid
 
   # @!visibility private
   METADATA_PLIST = '.com.apple.mobile_container_manager.metadata.plist'
@@ -111,6 +111,16 @@ class RunLoop::CoreSimulator
     end
   end
 
+  # @!visibility private
+  def self.simulator_pid
+    @@simulator_pid
+  end
+
+  # @!visibility private
+  def self.simulator_pid=(pid)
+    @@simulator_pid = pid
+  end
+
   # @param [RunLoop::Device] device The device.
   # @param [RunLoop::App] app The application.
   # @param [Hash] options Controls the behavior of this class.
@@ -149,11 +159,6 @@ class RunLoop::CoreSimulator
     @xcrun ||= RunLoop::Xcrun.new
   end
 
-  # @!visibility private
-  def simulator_pid
-    @simulator_pid
-  end
-
   # Launch the simulator indicated by device.
   def launch_simulator
 
@@ -181,7 +186,7 @@ class RunLoop::CoreSimulator
     Process.detach(pid)
 
     # Keep track of the pid so we can know if we have already launched this sim.
-    @simulator_pid = pid
+    self.simulator_pid = pid
 
     options = { :timeout => 5, :raise_on_timeout => true }
     RunLoop::ProcessWaiter.new(sim_name, options).wait_for_any

--- a/scripts/ci/jenkins/rspec-unit.sh
+++ b/scripts/ci/jenkins/rspec-unit.sh
@@ -7,5 +7,6 @@ rm -rf spec/reports
 rbenv exec \
   bundle exec \
   rspec \
-  spec/lib
+  spec/lib \
+  spec/integration/core_simulator_spec.rb
 

--- a/spec/integration/core_simulator_spec.rb
+++ b/spec/integration/core_simulator_spec.rb
@@ -19,6 +19,11 @@ describe RunLoop::CoreSimulator do
   describe '#launch_simulator' do
     it 'can launch the simulator' do
       expect(core_sim.launch_simulator).to be_truthy
+
+      pid = RunLoop::CoreSimulator.simulator_pid
+      running = core_sim.send(:running_simulator_pid)
+
+      expect(pid).to be == running
     end
 
     it 'it does not relaunch if the simulator is already running' do
@@ -27,15 +32,51 @@ describe RunLoop::CoreSimulator do
       expect(Process).not_to receive(:spawn)
 
       core_sim.launch_simulator
+
+      pid = RunLoop::CoreSimulator.simulator_pid
+      running = core_sim.send(:running_simulator_pid)
+
+      expect(pid).to be == running
     end
 
     it 'quits the simulator if it is not the same' do
+      core_sim.launch_simulator
 
+      running = core_sim.send(:running_simulator_pid)
+      RunLoop::CoreSimulator.class_variable_set(:@@simulator_pid, running - 1)
+
+      expect(Process).to receive(:spawn).and_call_original
+
+      core_sim.launch_simulator
+
+      pid = RunLoop::CoreSimulator.simulator_pid
+      running = core_sim.send(:running_simulator_pid)
+      expect(pid).to be == running
     end
   end
 
-  it '#launch' do
-    expect(core_sim.launch).to be_truthy
+  describe "#launch" do
+    before do
+      args = ['simctl', 'erase', simulator.udid]
+      xcrun.exec(args, {:log_cmd => true })
+      simulator.simulator_wait_for_stable_state
+    end
+
+    it "launches the app" do
+      expect(core_sim.launch).to be_truthy
+    end
+
+    it "launches the app even if it is already installed" do
+      expect(core_sim.launch).to be_truthy
+
+      RunLoop::CoreSimulator.quit_simulator
+
+      expect(core_sim.launch).to be_truthy
+
+      pid = RunLoop::CoreSimulator.simulator_pid
+      running = core_sim.send(:running_simulator_pid)
+      expect(pid).to be == running
+    end
   end
 
   it 'install with simctl' do
@@ -53,3 +94,4 @@ describe RunLoop::CoreSimulator do
     expect(core_sim.app_is_installed?).to be_falsey
   end
 end
+

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -4,6 +4,19 @@ describe RunLoop::CoreSimulator do
     allow(RunLoop::Environment).to receive(:debug?).and_return true
   end
 
+  describe ".simulator_pid" do
+
+    after do
+      RunLoop::CoreSimulator.class_variable_set(:@@simulator_pid, nil)
+    end
+
+    it "sets the class variable" do
+      RunLoop::CoreSimulator.simulator_pid = :foo
+      expect(RunLoop::CoreSimulator.class_variable_get(:@@simulator_pid)).to be == :foo
+      expect(RunLoop::CoreSimulator.simulator_pid).to be == :foo
+    end
+  end
+
   it '.quit_simulator' do
     expect(RunLoop::CoreSimulator).to receive(:term_or_kill).at_least(:once).and_return true
 

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -21,6 +21,7 @@ describe RunLoop::CoreSimulator do
     expect(RunLoop::CoreSimulator).to receive(:term_or_kill).at_least(:once).and_return true
 
     RunLoop::CoreSimulator.quit_simulator
+    expect(RunLoop::CoreSimulator.class_variable_get(:@@simulator_pid)).to be == nil
   end
 
   it '.terminate_core_simulator_processes' do

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -133,6 +133,55 @@ describe RunLoop::CoreSimulator do
       end
     end
 
+    describe "#running_simulator_pid" do
+      let(:xcrun) { RunLoop::Xcrun.new }
+
+      before do
+        allow(core_sim).to receive(:xcrun).and_return xcrun
+      end
+
+      it "xcrun returns a nil hash" do
+        expect(xcrun).to receive(:exec).and_return nil
+
+        expect(core_sim.send(:running_simulator_pid)).to be == nil
+      end
+
+      it "xcrun returns no :out" do
+        expect(xcrun).to receive(:exec).and_return({:out => nil})
+
+        expect(core_sim.send(:running_simulator_pid)).to be == nil
+      end
+
+      it "no matching process is found" do
+        out =
+%Q{
+27247 login -pf moody
+46238 tmate
+31098 less run_loop.out
+32976 vim lib/run_loop/xcrun.rb
+7656 /bin/ps x -o pid,command
+}
+        expect(xcrun).to receive(:exec).and_return({:out => out})
+
+        expect(core_sim.send(:running_simulator_pid)).to be == nil
+      end
+
+      it "returns integer pid" do
+        out =
+%Q{
+27247 login -pf moody
+46238 tmate
+31098 less run_loop.out
+32976 MacOS/Simulator
+7656 /MacOS/SillySim
+}
+        expect(core_sim).to receive(:sim_name).and_return("SillySim")
+        expect(xcrun).to receive(:exec).and_return({:out => out})
+
+        expect(core_sim.send(:running_simulator_pid)).to be == 7656
+      end
+    end
+
     describe 'Mocked file system' do
 
       describe '#sdk_gte_8?' do


### PR DESCRIPTION
### Motivation

If an an app is already installed (the SHAs match) CoreSimulator#install will not launch the simulator.

In that case, CoreSimulator#launch was not launching the simulator before trying to install which cased install errors.

CoreSimulator#launch_simulator and the CoreSimulator class now manage launching using a class variable `@@simulator_pid` - this might fix the double-launching issues some users have reported.
