### PR TITLE
Expose important timeouts as constant mutable variables

### DIFF
--- a/lib/run_loop/xcrun.rb
+++ b/lib/run_loop/xcrun.rb
@@ -3,11 +3,20 @@ module RunLoop
 
     require 'command_runner'
 
-    DEFAULT_OPTIONS =
-          {
-                :timeout => 30,
-                :log_cmd => false
-          }
+    # Controls the behavior of Xcrun#exec.
+    #
+    # You can override these values if they do not work in your environment.
+    #
+    # For cucumber users, the best place to override would be in your
+    # features/support/env.rb.
+    #
+    # For example:
+    #
+    # RunLoop::Xcrun::DEFAULT_OPTIONS[:timeout] = 60
+    DEFAULT_OPTIONS = {
+      :timeout => 30,
+      :log_cmd => false
+    }
 
     # Raised when Xcrun fails.
     class Error < RuntimeError; end


### PR DESCRIPTION
### Motivation

Progress on:

**RunLoop::Directory.directory_digest does not complete on slower machines** #307

Some users are reporting Xcrun is timing out.

@xinsight is reporting that Directory.directory_digest is _logging a warning_ - no error is raised.

This PR exposes the options that control `Xcrun#exec` and `Device#simulator_wait_for_stable_state` to users.

For cucumber users, the best place to override would be in your features/support/env.rb.

```
RunLoop::Xcrun::DEFAULT_OPTIONS[:timeout] = 60
RunLoop::Device::SIM_STABLE_STATE_OPTIONS[:timeout] = 60
```
