### PR TITLE
Directory: better logging of digest read errors

### DIFF
--- a/lib/run_loop/directory.rb
+++ b/lib/run_loop/directory.rb
@@ -47,21 +47,14 @@ module RunLoop
           begin
             sha << File.read(file)
           rescue => e
-            if debug
-              RunLoop.log_warn(%Q{
-RunLoop::Directory.directory_digest raised an error:
-
-#{e}
-
-while trying to find the SHA of this file:
-
-#{file}
-
-Please report this here:
-
-https://github.com/calabash/run_loop/issues
-
-})
+            [
+                 "RunLoop::Directory.directory_digest raised an error:",
+                 e,
+                 "while trying to find the SHA of this file:",
+                 file,
+                 "This is not a fatal error; it can be ignored."
+            ].each do |line|
+              RunLoop.log_debug(line)
             end
           end
         end

--- a/spec/lib/directory_spec.rb
+++ b/spec/lib/directory_spec.rb
@@ -59,6 +59,26 @@ describe RunLoop::Directory do
         }.to raise_error ArgumentError
       end
     end
+
+    it "logs read errors" do
+      tmp_dir = Dir.mktmpdir
+      path = File.join(tmp_dir, "foo.txt")
+      FileUtils.touch(path)
+
+      error = RuntimeError.new("My runtime error")
+      expect(File).to receive(:read).with(path).and_raise error
+
+      out = Kernel.capture_stdout do
+        RunLoop::Directory.directory_digest(tmp_dir)
+      end.string
+
+      puts out
+
+      expect(out[/directory_digest raised an error:/, 0]).to be_truthy
+      expect(out[/My runtime error/, 0]).to be_truthy
+      expect(out[/#{path}/, 0]).to be_truthy
+      expect(out[/This is not a fatal error; it can be ignored/, 0]).to be_truthy
+    end
   end
 
   describe '.size' do


### PR DESCRIPTION
### Motivation

The existing message looks like an error.  It is an error, but it is completely ignorable.

Resolved:

**RunLoop::Directory.directory_digest does not complete on slower machines** #307