### PR TITLE
Simplify the detection of iOS Simulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_script:
 script:
   - scripts/ci/travis/install-gem-ci.rb
   - scripts/ci/travis/rspec-ci.rb
+  - bundle exec rspec spec/integration/detect_simulators_spec.rb
 
 rvm:
   - 2.0.0

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -1143,34 +1143,23 @@ module RunLoop
 
       out.split("\n").each do |line|
 
-        possible_sdk = line[VERSION_REGEX,0]
-        if possible_sdk
-          current_sdk = possible_sdk
+        not_ios = [
+          line[/Unavailable/, 0], # Unavailable SDK
+          line[/Apple Watch/, 0],
+          line[/watchOS/, 0],
+          line[/Apple TV/, 0],
+          line[/tvOS/, 0]
+        ].any?
+
+        if not_ios
+          current_sdk = nil
+          next
+        end
+
+        ios_sdk = line[VERSION_REGEX,0]
+        if ios_sdk
+          current_sdk = ios_sdk
           simulators[current_sdk] = []
-          next
-        end
-
-        unavailable_sdk = line[/Unavailable/, 0]
-        if unavailable_sdk
-          current_sdk = nil
-          next
-        end
-
-        watch_os = line[/watchOS/, 0]
-        if watch_os
-          current_sdk = nil
-          next
-        end
-
-        watch = line[/Apple Watch/, 0]
-        if watch
-          current_sdk = nil
-          next
-        end
-
-        tv = line[/Apple TV/, 0]
-        if tv
-          current_sdk = nil
           next
         end
 
@@ -1180,9 +1169,9 @@ module RunLoop
             udid = line[CORE_SIMULATOR_UDID_REGEX,0]
             state = line[/(Booted|Shutdown)/,0]
             simulators[current_sdk] << {
-                  :name => name,
-                  :udid => udid,
-                  :state => state
+              :name => name,
+              :udid => udid,
+              :state => state
             }
           end
         end

--- a/spec/integration/detect_simulators_spec.rb
+++ b/spec/integration/detect_simulators_spec.rb
@@ -1,0 +1,8 @@
+describe "Detect iOS Simulators" do
+  it "Instruments and SimControl agree on the simulator count" do
+    simcontrol = RunLoop::SimControl.new.simulators.count
+    instruments = RunLoop::Instruments.new.simulators.count
+    expect(instruments).to be == simcontrol
+  end
+end
+

--- a/spec/lib/sim_control_spec.rb
+++ b/spec/lib/sim_control_spec.rb
@@ -341,11 +341,11 @@ describe RunLoop::SimControl do
         actual = sim_control.send(:simctl_list, :devices)
 
         expect(actual).to be_a Hash
-        expect(actual.length).to be == 8
+        expect(actual.length).to be == 6
 
         expect(actual['7.1']).to be == []
-        expect(actual['9.0']).to be == []
-        expect(actual['2.0']).to be == []
+        expect(actual['9.0']).to be == nil
+        expect(actual['2.0']).to be == nil
 
         # Has an extra 'TEST' device
         expect(actual['8.1'].length).to be == 9


### PR DESCRIPTION
### Motivation

Resolves:

* Xcode 7.1 - SimControl is not finding iOS 9.0 simulators #318

Added an integration example to Travis.

Progress on:

* Integration examples need attention #243