### PR TITLE
Install the app to the simulator, with simctl, without launching the simulator.

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -401,12 +401,9 @@ Command had no output
 
   # @!visibility private
   def install_app_with_simctl
-    launch_simulator
-
     args = ['simctl', 'install', device.udid, app.path]
     xcrun.exec(args, log_cmd: true, timeout: 20)
 
-    device.simulator_wait_for_stable_state
     installed_app_bundle_dir
   end
 

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -558,11 +558,9 @@ describe RunLoop::CoreSimulator do
       end
 
       it '#install_app_with_simctl' do
-        expect(core_sim).to receive(:launch_simulator).and_return true
         args = ['simctl', 'install', device.udid, app.path]
         options = { :log_cmd => true, :timeout => 20 }
         expect(core_sim.xcrun).to receive(:exec).with(args, options).and_return({})
-        expect(core_sim.device).to receive(:simulator_wait_for_stable_state).and_return true
 
         expect(core_sim).to receive(:installed_app_bundle_dir).and_return('/new/path')
 


### PR DESCRIPTION
We've been trying to trim down the time our acceptance tests take. Our profiling found that launching the simulator twice during the "Before" block contributed ~10s per scenario. Cutting the launch on app installation sped up our build significantly.

What is the reasoning behind launching the simulator before installing the app? We haven't run into any issues in our preliminary testing, but I'm no expert here so it's entirely possible I've missed something.

Thanks!