### PR TITLE
Skip install step with xcode versions prior to 7

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -246,7 +246,7 @@ class RunLoop::CoreSimulator
     installed_app_bundle = installed_app_bundle_dir
 
     # App is not installed. Use simctl interface to install.
-    if !installed_app_bundle
+    if !installed_app_bundle && xcode.version_gte_7?
       installed_app_bundle = install_app_with_simctl
     else
       ensure_app_same


### PR DESCRIPTION
Earlier versions of XCRun Instruments will install the app when specified,
obviating the need to a separate install step.

This is a continuation of https://github.com/calabash/run_loop/pull/327; here's a PR in case you like the change suggested in my last comment.

Thanks!