### PR TITLE
Increase simctl install/launch app and simulator stable timeouts in CI environments

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -1,6 +1,24 @@
 # A class to manage interactions with CoreSimulators.
 class RunLoop::CoreSimulator
 
+  # Starting in Xcode 7, the time for simctl to install a simulator on a
+  # device has increased. The situation on resource constrained devices is
+  # especially bad.
+  #
+  # If the default values do not work in your environment, you can override
+  # them.  For cucumber users, the best place to override would be in your
+  # features/support/env.rb
+  #
+  # RunLoop::CoreSimulator::OPTIONS[:install_app_timeout] = 60
+  OPTIONS = {
+
+    # How long to wait for an app to install.
+    :install_app_timeout => RunLoop::Environment.ci? ? 60 : 30,
+
+    # How long to wait for an app to launch.
+    :app_launch_timeout => RunLoop::Environment.ci? ? 60 : 30
+  }
+
   # @!visibility private
   @@simulator_pid = nil
 
@@ -215,7 +233,8 @@ class RunLoop::CoreSimulator
     launch_simulator
 
     args = ['simctl', 'launch', device.udid, app.bundle_identifier]
-    hash = xcrun.exec(args, log_cmd: true, timeout: 30)
+    timeout = OPTIONS[:app_launch_timeout]
+    hash = xcrun.exec(args, log_cmd: true, timeout: timeout)
 
     exit_status = hash[:exit_status]
 
@@ -404,7 +423,8 @@ Command had no output
     launch_simulator
 
     args = ['simctl', 'install', device.udid, app.path]
-    xcrun.exec(args, log_cmd: true, timeout: 20)
+    timeout = OPTIONS[:install_app_timeout]
+    xcrun.exec(args, log_cmd: true, timeout: timeout)
 
     device.simulator_wait_for_stable_state
     installed_app_bundle_dir

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -3,7 +3,15 @@ module RunLoop
 
     include RunLoop::Regex
 
-    # Controls the behavior of Device#simulator_wait_for_stable_state.
+    # Starting in Xcode 7, iOS 9 simulators have a new "booting" state.
+    #
+    # The simulator must completely boot before run-loop tries to do things
+    # like installing an app or clearing an app sandbox.  Run-loop tries to
+    # wait for a the simulator stabilize by watching the checksum of the
+    # simulator directory and the simulator log.
+    #
+    # On resource constrained devices or CI systems, the default settings may
+    # not work.
     #
     # You can override these values if they do not work in your environment.
     #
@@ -17,8 +25,9 @@ module RunLoop
       # The maximum amount of time to wait for the simulator
       # to stabilize.  No errors are raised if this timeout is
       # exceeded - if the default 30 seconds has passed, the
-      # simulator is probably stable.
-      :timeout => 30
+      # simulator is probably stable enough for subsequent
+      # operations.
+      :timeout => RunLoop::Environment.ci? ? 120 : 30
     }
 
     attr_reader :name

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -104,6 +104,14 @@ module RunLoop
       return value && value != ''
     end
 
+    # Returns true if running in Teamcity
+    #
+    # Checks the value of TEAMCITY_PROJECT_NAME
+    def self.teamcity?
+      value = ENV["TEAMCITY_PROJECT_NAME"]
+      return value && value != ''
+    end
+
     # !@visibility private
     def self.with_debugging(debug, &block)
       if debug

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -88,6 +88,14 @@ module RunLoop
       return value && value != ''
     end
 
+    # Returns true if running in Travis CI
+    #
+    # Checks the value of TRAVIS
+    def self.travis?
+      value = ENV["TRAVIS"]
+      return value && value != ''
+    end
+
     # !@visibility private
     def self.with_debugging(debug, &block)
       if debug

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -96,6 +96,14 @@ module RunLoop
       return value && value != ''
     end
 
+    # Returns true if running in Circle CI
+    #
+    # Checks the value of CIRCLECI
+    def self.circle_ci?
+      value = ENV["CIRCLECI"]
+      return value && value != ''
+    end
+
     # !@visibility private
     def self.with_debugging(debug, &block)
       if debug

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -80,6 +80,14 @@ module RunLoop
       end
     end
 
+    # Returns true if running in Jenkins CI
+    #
+    # Checks the value of JENKINS_HOME
+    def self.jenkins?
+      value = ENV["JENKINS_HOME"]
+      return value && value != ''
+    end
+
     # !@visibility private
     def self.with_debugging(debug, &block)
       if debug

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -112,6 +112,17 @@ module RunLoop
       return value && value != ''
     end
 
+    # Returns true if running in a CI environment
+    def self.ci?
+      [
+        self.ci_var_defined?,
+        self.travis?,
+        self.jenkins?,
+        self.circle_ci?,
+        self.teamcity?
+      ].any?
+    end
+
     # !@visibility private
     def self.with_debugging(debug, &block)
       if debug
@@ -128,5 +139,14 @@ module RunLoop
         block.call
       end
     end
+
+    private
+
+    # !@visibility private
+    def self.ci_var_defined?
+      value = ENV["CI"]
+      return value && value != ''
+    end
   end
 end
+

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -560,7 +560,8 @@ describe RunLoop::CoreSimulator do
       it '#install_app_with_simctl' do
         expect(core_sim).to receive(:launch_simulator).and_return true
         args = ['simctl', 'install', device.udid, app.path]
-        options = { :log_cmd => true, :timeout => 20 }
+        timeout = RunLoop::CoreSimulator::OPTIONS[:install_app_timeout]
+        options = { :log_cmd => true, :timeout => timeout}
         expect(core_sim.xcrun).to receive(:exec).with(args, options).and_return({})
         expect(core_sim.device).to receive(:simulator_wait_for_stable_state).and_return true
 

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -197,4 +197,26 @@ describe RunLoop::Environment do
       end
     end
   end
+
+  describe ".circle_ci?" do
+    it "returns true if CIRCLECI defined" do
+      stub_env({"CIRCLECI" => true})
+
+      expect(RunLoop::Environment.circle_ci?).to be_truthy
+    end
+
+    describe "returns false if CIRCLECI" do
+      it "is nil" do
+        stub_env({"CIRCLECI" => nil})
+
+        expect(RunLoop::Environment.circle_ci?).to be_falsey
+      end
+
+      it "is empty string" do
+        stub_env({"CIRCLECI" => ""})
+
+        expect(RunLoop::Environment.circle_ci?).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -153,4 +153,27 @@ describe RunLoop::Environment do
       expect(RunLoop::Environment.developer_dir).to be == nil
     end
   end
+
+  describe ".jenkins?" do
+    it "returns true if JENKINS_HOME defined" do
+      stub_env({"JENKINS_HOME" => "/Users/Shared/Jenkins"})
+
+      expect(RunLoop::Environment.jenkins?).to be_truthy
+    end
+
+    describe "returns false if JENKINS_HOME" do
+      it "is nil" do
+        stub_env({"JENKINS_HOME" => nil})
+
+        expect(RunLoop::Environment.jenkins?).to be_falsey
+      end
+
+      it "is empty string" do
+        stub_env({"JENKINS_HOME" => ""})
+
+        expect(RunLoop::Environment.jenkins?).to be_falsey
+      end
+
+    end
+  end
 end

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -219,4 +219,26 @@ describe RunLoop::Environment do
       end
     end
   end
+
+  describe ".teamcity?" do
+    it "returns true if TEAMCITY_PROJECT_NAME defined" do
+      stub_env({"TEAMCITY_PROJECT_NAME" => "project name"})
+
+      expect(RunLoop::Environment.teamcity?).to be_truthy
+    end
+
+    describe "returns false if TEAMCITY_PROJECT_NAME" do
+      it "is nil" do
+        stub_env({"TEAMCITY_PROJECT_NAME" => nil})
+
+        expect(RunLoop::Environment.teamcity?).to be_falsey
+      end
+
+      it "is empty string" do
+        stub_env({"TEAMCITY_PROJECT_NAME" => ""})
+
+        expect(RunLoop::Environment.teamcity?).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -173,7 +173,28 @@ describe RunLoop::Environment do
 
         expect(RunLoop::Environment.jenkins?).to be_falsey
       end
+    end
+  end
 
+  describe ".travis?" do
+    it "returns true if TRAVIS defined" do
+      stub_env({"TRAVIS" => "some truthy value"})
+
+      expect(RunLoop::Environment.travis?).to be_truthy
+    end
+
+    describe "returns false if TRAVIS" do
+      it "is nil" do
+        stub_env({"TRAVIS" => nil})
+
+        expect(RunLoop::Environment.travis?).to be_falsey
+      end
+
+      it "is empty string" do
+        stub_env({"TRAVIS" => ""})
+
+        expect(RunLoop::Environment.travis?).to be_falsey
+      end
     end
   end
 end

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -241,4 +241,93 @@ describe RunLoop::Environment do
       end
     end
   end
+
+  describe ".ci?" do
+    describe "truthy" do
+      it "CI" do
+        expect(RunLoop::Environment).to receive(:jenkins?).and_return false
+        expect(RunLoop::Environment).to receive(:travis?).and_return false
+        expect(RunLoop::Environment).to receive(:circle_ci?).and_return false
+        expect(RunLoop::Environment).to receive(:teamcity?).and_return false
+        expect(RunLoop::Environment).to receive(:ci_var_defined?).and_return true
+
+        expect(RunLoop::Environment.ci?).to be_truthy
+      end
+
+      it "Jenkins" do
+        expect(RunLoop::Environment).to receive(:jenkins?).and_return true
+        expect(RunLoop::Environment).to receive(:travis?).and_return false
+        expect(RunLoop::Environment).to receive(:circle_ci?).and_return false
+        expect(RunLoop::Environment).to receive(:teamcity?).and_return false
+        expect(RunLoop::Environment).to receive(:ci_var_defined?).and_return false
+
+        expect(RunLoop::Environment.ci?).to be_truthy
+      end
+
+      it "Travis" do
+        expect(RunLoop::Environment).to receive(:jenkins?).and_return false
+        expect(RunLoop::Environment).to receive(:travis?).and_return true
+        expect(RunLoop::Environment).to receive(:circle_ci?).and_return false
+        expect(RunLoop::Environment).to receive(:teamcity?).and_return false
+        expect(RunLoop::Environment).to receive(:ci_var_defined?).and_return false
+
+        expect(RunLoop::Environment.ci?).to be_truthy
+      end
+
+      it "Circle CI" do
+        expect(RunLoop::Environment).to receive(:jenkins?).and_return false
+        expect(RunLoop::Environment).to receive(:travis?).and_return false
+        expect(RunLoop::Environment).to receive(:circle_ci?).and_return true
+        expect(RunLoop::Environment).to receive(:teamcity?).and_return false
+        expect(RunLoop::Environment).to receive(:ci_var_defined?).and_return false
+
+        expect(RunLoop::Environment.ci?).to be_truthy
+      end
+
+      it "TeamCity" do
+        expect(RunLoop::Environment).to receive(:jenkins?).and_return false
+        expect(RunLoop::Environment).to receive(:travis?).and_return false
+        expect(RunLoop::Environment).to receive(:circle_ci?).and_return false
+        expect(RunLoop::Environment).to receive(:teamcity?).and_return true
+        expect(RunLoop::Environment).to receive(:ci_var_defined?).and_return false
+
+        expect(RunLoop::Environment.ci?).to be_truthy
+      end
+    end
+
+    it "falsey" do
+      expect(RunLoop::Environment).to receive(:jenkins?).and_return false
+      expect(RunLoop::Environment).to receive(:travis?).and_return false
+      expect(RunLoop::Environment).to receive(:circle_ci?).and_return false
+      expect(RunLoop::Environment).to receive(:teamcity?).and_return false
+      expect(RunLoop::Environment).to receive(:ci_var_defined?).and_return false
+
+      expect(RunLoop::Environment.ci?).to be_falsey
+    end
+  end
+
+  # private
+
+  describe ".ci_var_defined?" do
+    it "returns true if CI defined" do
+      stub_env({"CI" => true})
+
+      expect(RunLoop::Environment.send(:ci_var_defined?)).to be_truthy
+    end
+
+    describe "returns false if CI" do
+      it "is nil" do
+        stub_env({"CI" => nil})
+
+        expect(RunLoop::Environment.send(:ci_var_defined?)).to be_falsey
+      end
+
+      it "is empty string" do
+        stub_env({"CI" => ""})
+
+        expect(RunLoop::Environment.send(:ci_var_defined?)).to be_falsey
+      end
+    end
+  end
 end
+


### PR DESCRIPTION
### Motivation

Calabash Jenkins CI is up and running again.  It is now running on El Capitan.  I noticed that in CI environments the defaults for:

* simctl install app
* simctl launch app
* the simulator stable state

were too low; sometimes raising errors.

Run-loop now tries to detect CI environments.  When it does, it significantly increases the CoreSimulator related timeouts.

In addition, users can control the following RunLoop::CoreSimulator::OPTIONS:

```
# How long to wait for an app to install.
:install_app_timeout => RunLoop::Environment.ci? ? 60 : 30,

# How long to wait for an app to launch.
:app_launch_timeout => RunLoop::Environment.ci? ? 60 : 30
```

Progress on:

**Collect information about Calabash sessions** [#908](https://github.com/calabash/calabash-ios/issues/908) - detecting CI environments is a requirement.
