### PR TITLE
Increase simctl and sim stable timeouts in CI environments and expose options to users

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -1,22 +1,24 @@
 # A class to manage interactions with CoreSimulators.
 class RunLoop::CoreSimulator
 
-  # Starting in Xcode 7, the time for simctl to install a simulator on a
-  # device has increased. The situation on resource constrained devices is
-  # especially bad.
+  # These options control various aspects of an app's life cycle on the iOS
+  # Simulator.
   #
-  # If the default values do not work in your environment, you can override
-  # them.  For cucumber users, the best place to override would be in your
-  # features/support/env.rb
+  # You can override these values if they do not work in your environment.
   #
-  # RunLoop::CoreSimulator::OPTIONS[:install_app_timeout] = 60
-  OPTIONS = {
-
-    # How long to wait for an app to install.
-    :install_app_timeout => RunLoop::Environment.ci? ? 60 : 30,
-
-    # How long to wait for an app to launch.
-    :app_launch_timeout => RunLoop::Environment.ci? ? 60 : 30
+  # For cucumber users, the best place to override would be in your
+  # features/support/env.rb.
+  #
+  # For example:
+  #
+  # RunLoop::CoreSimulator::DEFAULT_OPTIONS[:install_app_timeout] = 60
+  DEFAULT_OPTIONS = {
+    # In most cases 30 seconds is a reasonable amount of time to wait for an
+    # install.  When testing larger apps, on slow machines, or in CI, this
+    # value may need to be higher.  120 is the default for CI.
+    :install_app_timeout => RunLoop::Environment.ci? ? 120 : 30,
+    :uninstall_app_timeout => RunLoop::Environment.ci? ? 120 : 30,
+    :launch_app_timeout => RunLoop::Environment.ci? ? 120 : 30
   }
 
   # @!visibility private
@@ -233,7 +235,7 @@ class RunLoop::CoreSimulator
     launch_simulator
 
     args = ['simctl', 'launch', device.udid, app.bundle_identifier]
-    timeout = OPTIONS[:app_launch_timeout]
+    timeout = DEFAULT_OPTIONS[:launch_app_timeout]
     hash = xcrun.exec(args, log_cmd: true, timeout: timeout)
 
     exit_status = hash[:exit_status]
@@ -297,7 +299,9 @@ class RunLoop::CoreSimulator
     launch_simulator
 
     args = ['simctl', 'uninstall', device.udid, app.bundle_identifier]
-    xcrun.exec(args, log_cmd: true, timeout: 20)
+
+    timeout = DEFAULT_OPTIONS[:uninstall_app_timeout]
+    xcrun.exec(args, log_cmd: true, timeout: timeout)
 
     device.simulator_wait_for_stable_state
     true
@@ -423,7 +427,7 @@ Command had no output
     launch_simulator
 
     args = ['simctl', 'install', device.udid, app.path]
-    timeout = OPTIONS[:install_app_timeout]
+    timeout = DEFAULT_OPTIONS[:install_app_timeout]
     xcrun.exec(args, log_cmd: true, timeout: timeout)
 
     device.simulator_wait_for_stable_state

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -122,9 +122,10 @@ describe RunLoop::CoreSimulator do
       it 'launches the simulator and installs the app with simctl' do
         expect(core_sim).to receive(:app_is_installed?).and_return true
         expect(core_sim).to receive(:launch_simulator).and_return true
-
         args = ['simctl', 'uninstall', device.udid, app.bundle_identifier]
-        options = { log_cmd: true, timeout: 20 }
+
+        timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:uninstall_app_timeout]
+        options = { log_cmd: true, timeout: timeout }
         expect(core_sim.xcrun).to receive(:exec).with(args, options).and_return true
 
         expect(core_sim.device).to receive(:simulator_wait_for_stable_state).and_return true
@@ -560,8 +561,9 @@ describe RunLoop::CoreSimulator do
       it '#install_app_with_simctl' do
         expect(core_sim).to receive(:launch_simulator).and_return true
         args = ['simctl', 'install', device.udid, app.path]
-        timeout = RunLoop::CoreSimulator::OPTIONS[:install_app_timeout]
-        options = { :log_cmd => true, :timeout => timeout}
+        timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:install_app_timeout]
+        options = { :log_cmd => true, :timeout => timeout }
+
         expect(core_sim.xcrun).to receive(:exec).with(args, options).and_return({})
         expect(core_sim.device).to receive(:simulator_wait_for_stable_state).and_return true
 

--- a/spec/lib/device_spec.rb
+++ b/spec/lib/device_spec.rb
@@ -1,5 +1,18 @@
 describe RunLoop::Device do
 
+  describe "SIM_STABLE_STATE_OPTIONS" do
+    it ":timeout" do
+      if RunLoop::Environment.ci?
+        expected = 120
+      else
+        expected = 30
+      end
+
+      actual = RunLoop::Device::SIM_STABLE_STATE_OPTIONS[:timeout]
+      expect(actual).to be == expected
+    end
+  end
+
   context 'creating a new instance' do
     subject!(:version) { RunLoop::Version.new('7.1.2') }
     subject(:device) { RunLoop::Device.new('name', version , 'udid', 'Shutdown') }
@@ -370,3 +383,4 @@ describe RunLoop::Device do
     end
   end
 end
+


### PR DESCRIPTION
### Motivation

Expands upon **Increase simctl install/launch app and simulator stable timeouts in CI environments** #329 by:

* applying uniform naming for default keys
* adding uninstall

Users can override these values in there features/support/env.rb

```
RunLoop::Device::SIM_STABLE_STATE_OPTIONS[:timeout] = 60
RunLoop::CoreSimulator::DEFAULT_OPTIONS[:install_app_timeout] = 30
RunLoop::CoreSimulator::DEFAULT_OPTIONS[:uninstall_app_timeout] = 30
RunLoop::CoreSimulator::DEFAULT_OPTIONS[:launch_app_timeout] = 30
```

RunLoop will try to detect CI environments and automatically increase the timeouts.


Progress on:

* **Collect information about Calabash sessions** [#908](https://github.com/calabash/calabash-ios/issues/908) - detecting CI environments is a requirement.
* **Integration examples need attention** #243