### PR TITLE
Fix 'simctl manage processes'

### DIFF
--- a/lib/run_loop/cli/simctl.rb
+++ b/lib/run_loop/cli/simctl.rb
@@ -98,6 +98,11 @@ module RunLoop
 
         begin
           RunLoop::CoreSimulator.terminate_core_simulator_processes
+          process_name = "com.apple.CoreSimulator.CoreSimulatorService"
+          RunLoop::ProcessWaiter.new(process_name).pids.each do |pid|
+            kill_options = { :timeout => 0.5 }
+            RunLoop::ProcessTerminator.new(pid, 'KILL', process_name, kill_options)
+          end
         ensure
           ENV['DEBUG'] = original_value if debug
         end

--- a/lib/run_loop/cli/simctl.rb
+++ b/lib/run_loop/cli/simctl.rb
@@ -97,8 +97,7 @@ module RunLoop
         ENV['DEBUG'] = '1' if debug
 
         begin
-          RunLoop::SimControl.terminate_all_sims
-          RunLoop::LifeCycle::Simulator.new.terminate_core_simulator_processes
+          RunLoop::CoreSimulator.terminate_core_simulator_processes
         ensure
           ENV['DEBUG'] = original_value if debug
         end

--- a/scripts/ci/jenkins/cli.sh
+++ b/scripts/ci/jenkins/cli.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Fail if any command exits non-zero
+set -e
+
+function execute {
+  echo "$(tput setaf 6)EXEC: $1 $(tput sgr0)"
+  $1
+}
+
+execute "bundle exec run-loop simctl manage-processes"
+

--- a/scripts/ci/jenkins/run.sh
+++ b/scripts/ci/jenkins/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+scripts/ci/jenkins/rspec-unit.sh
+scripts/ci/jenkins/cli.sh
+


### PR DESCRIPTION
### Motivation

Fixes **command line tool has a reference to Lifecycle module** #332 

On El Capitan, it has been demonstrated that the CoreSimulatorService daemon can become unstable after it has been running for a long time.  This PR improves the:

```
$ bundle exec run-loop simctl manage-processes
```

tool by directing it to KILL the CoreSimulatorService daemon.

If you are seeing FIFO errors in CI (or even locally), try integrating this command into your workflow.

Please note that the service takes a long time (seconds) to restart so don't call this obsessively.