### PR TITLE
Core: prepare simulator responds to :reset launch arg

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -185,6 +185,12 @@ module RunLoop
         # Quits the simulator.
         core_sim = RunLoop::CoreSimulator.new(device, app)
 
+        # :reset is a legacy variable; has been replaced with :reset_app_sandbox
+        if launch_options[:reset] || launch_options[:reset_app_sandbox]
+          core_sim.reset_app_sandbox
+        end
+
+        # Launches the simulator
         core_sim.install
 
         # Will quit the simulator if it is running.

--- a/scripts/ci/jenkins/run.sh
+++ b/scripts/ci/jenkins/run.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+bundle update
+bundle exec run-loop simctl manage-processes
 scripts/ci/jenkins/rspec-unit.sh
 scripts/ci/jenkins/cli.sh
 


### PR DESCRIPTION
### Motivation

**RESET_APP_BETWEEN_SCENARIOS is still resetting the simulator not just the app sandbox** [#878](https://github.com/calabash/calabash-ios/issues/878)

Calabash is responsible for sending :reset based on user input and environment variables.  :reset is supported because it is a legacy key.  :reset_app_sandbox is the preferred key.



