### PR TITLE
Privacy: automatically dismiss Dutch APNS alerts

### DIFF
--- a/scripts/run_loop_fast_uia.js
+++ b/scripts/run_loop_fast_uia.js
@@ -204,25 +204,26 @@ function isLocationPrompt(alert) {
             ["OK", /vil bruge din aktuelle placering/],
             ["OK", /Would Like to Use Your Current Location/],
             ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
-            ["OK", /Would Like to Send You Notifications/],
-            ["OK", /would like to send you Push Notifications/],
             ["Allow", /access your location/],
             ["OK", /Would Like to Access Your Photos/],
             ["OK", /Would Like to Access Your Contacts/],
             ["OK", /Location Accuracy/],
             ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/],
             ["OK", /Access the Microphone/],
-            ["OK", /enviarle notificaiones/],
             ["OK", /Would Like to Access Your Calendar/],
             ["OK", /Would Like to Access Your Reminders/],
             ["OK", /Would Like to Access Your Motion Activity/],
             ["OK", /Would Like to Access the Camera/],
-
-            //iOS 9 - English
             ["OK", /Would Like to Access Your Motion & Fitness Activity/],
             ["OK", /Would Like Access to Twitter Accounts/],
+            ["OK", /data available to nearby bluetooth devices/],
 
-            ["OK", /data available to nearby bluetooth devices/]
+            // APNS
+            ["OK", /enviarle notificaiones/],
+            ["OK", /wil u berichten stuern/],
+            ["OK", /Would Like to Send You Notifications/],
+            ["OK", /would like to send you Push Notifications/],
+
         ],
         ans, exp,
         txt;

--- a/scripts/run_loop_host.js
+++ b/scripts/run_loop_host.js
@@ -222,25 +222,25 @@ function isLocationPrompt(alert) {
             ["OK", /vil bruge din aktuelle placering/],
             ["OK", /Would Like to Use Your Current Location/],
             ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
-            ["OK", /Would Like to Send You Notifications/],
-            ["OK", /would like to send you Push Notifications/],
             ["Allow", /access your location/],
             ["OK", /Would Like to Access Your Photos/],
             ["OK", /Would Like to Access Your Contacts/],
             ["OK", /Location Accuracy/],
             ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/],
             ["OK", /Access the Microphone/],
-            ["OK", /enviarle notificaiones/],
             ["OK", /Would Like to Access Your Calendar/],
             ["OK", /Would Like to Access Your Reminders/],
             ["OK", /Would Like to Access Your Motion Activity/],
             ["OK", /Would Like to Access the Camera/],
-
-            //iOS 9 - English
             ["OK", /Would Like to Access Your Motion & Fitness Activity/],
             ["OK", /Would Like Access to Twitter Accounts/],
+            ["OK", /data available to nearby bluetooth devices/],
 
-            ["OK", /data available to nearby bluetooth devices/]
+            // APNS
+            ["OK", /enviarle notificaiones/],
+            ["OK", /wil u berichten stuern/],
+            ["OK", /Would Like to Send You Notifications/],
+            ["OK", /would like to send you Push Notifications/],
         ],
         ans, exp,
         txt;

--- a/scripts/run_loop_shared_element.js
+++ b/scripts/run_loop_shared_element.js
@@ -204,25 +204,25 @@ function isLocationPrompt(alert) {
             ["OK", /vil bruge din aktuelle placering/],
             ["OK", /Would Like to Use Your Current Location/],
             ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
-            ["OK", /Would Like to Send You Notifications/],
-            ["OK", /would like to send you Push Notifications/],
             ["Allow", /access your location/],
             ["OK", /Would Like to Access Your Photos/],
             ["OK", /Would Like to Access Your Contacts/],
             ["OK", /Location Accuracy/],
             ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/],
             ["OK", /Access the Microphone/],
-            ["OK", /enviarle notificaiones/],
             ["OK", /Would Like to Access Your Calendar/],
             ["OK", /Would Like to Access Your Reminders/],
             ["OK", /Would Like to Access Your Motion Activity/],
             ["OK", /Would Like to Access the Camera/],
-
-            //iOS 9 - English
             ["OK", /Would Like to Access Your Motion & Fitness Activity/],
             ["OK", /Would Like Access to Twitter Accounts/],
+            ["OK", /data available to nearby bluetooth devices/],
 
-            ["OK", /data available to nearby bluetooth devices/]
+            // APNS
+            ["OK", /enviarle notificaiones/],
+            ["OK", /wil u berichten stuern/],
+            ["OK", /Would Like to Send You Notifications/],
+            ["OK", /would like to send you Push Notifications/],
         ],
         ans, exp,
         txt;


### PR DESCRIPTION
### Motivation

Resolves **Dutch APNS dialog is not automatically dismissed** #337

Cannot add to Permissions app because the app is not configured for APNS.

* **Needs to generate Apple Push Notification Services alerts** [#9](https://github.com/calabash/Permissions/issues/9)

I did confirm visually that run-loop can dismiss English APNS alerts in iOS 9.