### PR TITLE
HostCache can be used by `console_attach` for all strategies

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -254,12 +254,14 @@ module RunLoop
       FileUtils.rm_f(repl_path)
 
       uia_strategy = options[:uia_strategy]
+
       if uia_strategy == :host
         create_uia_pipe(repl_path)
-        RunLoop::HostCache.default.clear unless RunLoop::Environment.xtc?
       else
         FileUtils.touch repl_path
       end
+
+      RunLoop::HostCache.default.clear unless RunLoop::Environment.xtc?
 
       cal_script = File.join(SCRIPTS_PATH, 'calabash_script_uia.js')
       File.open(script, 'w') do |file|


### PR DESCRIPTION
### Motivation

Progress on **`console_attach` needs some love; run-loop should cache runtime info for all strategies** [#828](https://github.com/calabash/calabash-ios/issues/828)

It turns out that we can use this cache for _all_ strategies.

At some point we will need to clarify the name:

* Rename HostCache to RunLoop::Cache #356