### PR TITLE
OnAlert: divide regexes by language

### DIFF
--- a/scripts/lib/on_alert.js
+++ b/scripts/lib/on_alert.js
@@ -15,45 +15,89 @@ function findAlertViewText(alert) {
     return txt;
 }
 
+function englishLocalizations() {
+  return [
+    ["OK", /Would Like to Use Your Current Location/],
+    ["OK", /Location Accuracy/],
+    ["Allow", /access your location/],
+    ["OK", /Would Like to Access Your Photos/],
+    ["OK", /Would Like to Access Your Contacts/],
+    ["OK", /Access the Microphone/],
+    ["OK", /Would Like to Access Your Calendar/],
+    ["OK", /Would Like to Access Your Reminders/],
+    ["OK", /Would Like to Access Your Motion Activity/],
+    ["OK", /Would Like to Access the Camera/],
+    ["OK", /Would Like to Access Your Motion & Fitness Activity/],
+    ["OK", /Would Like Access to Twitter Accounts/],
+    ["OK", /data available to nearby bluetooth devices/],
+    ["OK", /Would Like to Send You Notifications/],
+    ["OK", /would like to send you Push Notifications/]
+  ];
+}
+
+function danishLocalizations() {
+  return [
+    // Location
+    ["Tillad", /bruge din lokalitet, når du bruger appen/],
+    ["Tillad", /også når du ikke bruger appen/],
+    ["OK", /vil bruge din aktuelle placering/]
+  ];
+}
+
+function spanishLocalizations() {
+  return [
+    // APNS
+    ["OK", /enviarle notificaiones/]
+  ];
+}
+
+function germanLocalizations() {
+  return [
+    // Location
+    ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/]
+  ];
+}
+
+function dutchLocalizations() {
+  return [
+    // APNS
+    ["OK", /wil u berichten stuern/]
+  ];
+}
+
+function russianLocalizations() {
+  return [
+    // Location
+    ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/]
+  ];
+}
+
+function localizations() {
+  return [].concat(
+     danishLocalizations(),
+     dutchLocalizations(),
+     englishLocalizations(),
+     germanLocalizations(),
+     russianLocalizations(),
+     spanishLocalizations()
+  );
+}
+
 function isPrivacyAlert(alert) {
 
-    var exps = [
-      ["Tillad", /bruge din lokalitet, når du bruger appen/],
-      ["Tillad", /også når du ikke bruger appen/],
-      ["OK", /vil bruge din aktuelle placering/],
-      ["OK", /Would Like to Use Your Current Location/],
-      ["Ja", /Darf (?:.)+ Ihren aktuellen Ort verwenden/],
-      ["Allow", /access your location/],
-      ["OK", /Would Like to Access Your Photos/],
-      ["OK", /Would Like to Access Your Contacts/],
-      ["OK", /Location Accuracy/],
-      ["OK", /запрашивает разрешение на использование Ващей текущей пгеопозиции/],
-      ["OK", /Access the Microphone/],
-      ["OK", /Would Like to Access Your Calendar/],
-      ["OK", /Would Like to Access Your Reminders/],
-      ["OK", /Would Like to Access Your Motion Activity/],
-      ["OK", /Would Like to Access the Camera/],
-      ["OK", /Would Like to Access Your Motion & Fitness Activity/],
-      ["OK", /Would Like Access to Twitter Accounts/],
-      ["OK", /data available to nearby bluetooth devices/],
+  var ans, exp, txt;
 
-      // APNS
-      ["OK", /enviarle notificaiones/],
-      ["OK", /wil u berichten stuern/],
-      ["OK", /Would Like to Send You Notifications/],
-      ["OK", /would like to send you Push Notifications/]
-    ],
-    ans, exp,
-    txt;
+  var exps = localizations();
 
-    txt = findAlertViewText(alert);
-    Log.output({"output":"alert: "+txt}, true);
-    for (var i = 0; i < exps.length; i++) {
-        ans = exps[i][0];
-        exp = exps[i][1];
-        if (exp.test(txt)) {
-            return ans;
-        }
+  txt = findAlertViewText(alert);
+  Log.output({"output":"alert: "+txt}, true);
+  for (var i = 0; i < exps.length; i++) {
+    ans = exps[i][0];
+    exp = exps[i][1];
+    if (exp.test(txt)) {
+      return ans;
     }
-    return false;
+  }
+  return false;
 }
+


### PR DESCRIPTION
### Motivation

Progress on:

* **Ideas for dismissing Privacy alerts** #350
* run-loop 2.0.2

This will allow us to quickly see where we have support gaps.

### Testing

* Locally with the Permission.app on iOS simulators
* [XTC against iOS 9 devices](https://testcloud.xamarin.com/test/permissions_506622d0-c117-477c-9148-4d3edd9ab550/)
* [XTC against iOS 7 - 9 devices](https://testcloud.xamarin.com/test/permissions_73baf599-8e84-44eb-893e-9900faf8b855/)

ATTN: @krukow No regexes were added.

Thanks @BAJ- for the JavaScript help.

