### PR TITLE
Refactor auto dismiss JavaScript methods

### DIFF
--- a/lib/run_loop/cli/cli.rb
+++ b/lib/run_loop/cli/cli.rb
@@ -3,6 +3,7 @@ require 'run_loop'
 require 'run_loop/cli/errors'
 require 'run_loop/cli/instruments'
 require 'run_loop/cli/simctl'
+require "run_loop/cli/locale"
 
 trap 'SIGINT' do
   puts 'Trapped SIGINT - exiting'
@@ -30,6 +31,9 @@ module RunLoop
 
       desc 'simctl', "Interact with Xcode's command-line simctl"
       subcommand 'simctl', RunLoop::CLI::Simctl
+
+      desc "locale", "Tools for interacting with locales"
+      subcommand "locale", RunLoop::CLI::Locale
 
     end
   end

--- a/lib/run_loop/cli/locale.rb
+++ b/lib/run_loop/cli/locale.rb
@@ -1,0 +1,31 @@
+require "thor"
+require "run_loop"
+require "run_loop/cli/errors"
+
+module RunLoop
+  module CLI
+    class Locale < Thor
+
+      desc "print-alert-regexes", "Print privacy alert regular expressions"
+
+      def print_alert_regexes
+        dir = File.expand_path(File.dirname(__FILE__))
+        scripts_dir = File.join(dir, "..", "..", "..", "scripts")
+        on_alert = File.join(scripts_dir, "lib", "on_alert.js")
+
+        lines = []
+        File.read(on_alert).force_encoding("UTF-8").split($-0).each do |line|
+          if line[/\[\".+\", \/.+\/\]/, 0]
+            line.chomp!
+            if line[-1,1] == ","
+              line = line[0, line.length - 1]
+            end
+            lines << line
+          end
+        end
+
+        puts lines.join(",#{$-0}")
+      end
+    end
+  end
+end

--- a/scripts/lib/on_alert.js
+++ b/scripts/lib/on_alert.js
@@ -116,9 +116,11 @@ function isPrivacyAlert(alert) {
   var expressions = localizations();
 
   var title = findAlertTitle(alert);
-  var buttonNames = findAlertButtonNames(alert);
 
-  Log.output({"output":"alert: " + title + "," + buttonNames}, true);
+  // When debugging or trying to capture the regexes for a new
+  // localization, uncomment these lines.
+  // var buttonNames = findAlertButtonNames(alert);
+  // Log.output({"output":"alert: " + title + "," + buttonNames}, true);
 
   var answer;
   var expression;

--- a/scripts/lib/on_alert.js
+++ b/scripts/lib/on_alert.js
@@ -16,6 +16,16 @@ function findAlertTitle(alert) {
     return title;
 }
 
+function findAlertButtonNames(alert) {
+  if (!alert) {
+    return false;
+  }
+
+  var buttons = alert.buttons();
+  var leftButton = buttons[0].name();
+  var rightButton = buttons[1].name();
+
+  return leftButton + "," + rightButton;
 }
 
 function englishLocalizations() {

--- a/scripts/lib/on_alert.js
+++ b/scripts/lib/on_alert.js
@@ -113,17 +113,20 @@ function localizations() {
 
 function isPrivacyAlert(alert) {
 
-  var ans, exp, txt;
+  var expressions = localizations();
 
-  var exps = localizations();
+  var title = findAlertTitle(alert);
+  var buttonNames = findAlertButtonNames(alert);
 
-  txt = findAlertViewText(alert);
-  Log.output({"output":"alert: "+txt}, true);
-  for (var i = 0; i < exps.length; i++) {
-    ans = exps[i][0];
-    exp = exps[i][1];
-    if (exp.test(txt)) {
-      return ans;
+  Log.output({"output":"alert: " + title + "," + buttonNames}, true);
+
+  var answer;
+  var expression;
+  for (var i = 0; i < expressions.length; i++) {
+    answer = expressions[i][0];
+    expression = expressions[i][1];
+    if (expression.test(title)) {
+      return answer;
     }
   }
   return false;

--- a/scripts/lib/on_alert.js
+++ b/scripts/lib/on_alert.js
@@ -117,8 +117,11 @@ function isPrivacyAlert(alert) {
 
   var title = findAlertTitle(alert);
 
+  // Comment this out if you are capturing regexes.  See comment below.
+  Log.output({"output":"alert: " + title}, true);
+
   // When debugging or trying to capture the regexes for a new
-  // localization, uncomment these lines.
+  // localization, uncomment these lines and comment out the line above.
   // var buttonNames = findAlertButtonNames(alert);
   // Log.output({"output":"alert: " + title + "," + buttonNames}, true);
 

--- a/scripts/lib/on_alert.js
+++ b/scripts/lib/on_alert.js
@@ -1,18 +1,21 @@
-function findAlertViewText(alert) {
+function findAlertTitle(alert) {
     if (!alert) {
         return false;
     }
-    var txt = alert.name(),
-        txts;
-    if (txt == null) {
-        txts = alert.staticTexts();
-        if (txts != null && txts.length > 0) {
+    var title = alert.name();
+    var staticTexts;
 
-            txt = txts[0].name();
+    if (title == null) {
+        staticTexts = alert.staticTexts();
+        if (staticTexts != null && staticTexts.length > 0) {
+
+            title = staticText[0].name();
         }
 
     }
-    return txt;
+    return title;
+}
+
 }
 
 function englishLocalizations() {

--- a/scripts/localizations.rb
+++ b/scripts/localizations.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+PATH = File.expand_path(File.join("lib", "on_alert.js"))
+
+lines = []
+
+File.read(PATH).force_encoding("UTF-8").split($-0).each do |line|
+  if line[/\[\".+\", \/.+\/\]/, 0]
+     line.chomp!
+     if line[-1,1] == ","
+       line = line[0, line.length - 1]
+     end
+     lines << line
+  end
+end
+
+puts lines.join(",#{$-0}")
+

--- a/spec/lib/cli/locale_spec.rb
+++ b/spec/lib/cli/locale_spec.rb
@@ -1,0 +1,7 @@
+require "run_loop/cli/locale"
+
+describe RunLoop::CLI::Locale do
+  it "#print_alert_regexes" do
+    subject.print_alert_regexes
+  end
+end


### PR DESCRIPTION
### Motivation

I did this work in the context of:

* **No french localization for handling system dialogs like permissions** #369
* **run-loop: release - version TBD** [#93](https://github.com/xamarinhq/test-cloud-frameworks/issues/93)

Progress on **Ideas for dismissing Privacy alerts** #350.

@krukow You need to sign off on this because these changes remove a (perhaps) crucial log statement.  See the code comments.

I added a command line tool to dump the regular expression so they can be easily transferred to other systems.

```
$ be run-loop locale print-alert-regexes
```

These changes have been tested on the XTC.

* https://testcloud.xamarin.com/app/946807a0-8a14-4285-9f82-31fe8c22af40/master
