### PR TITLE
DNSSD: detect bonjour services

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -3,6 +3,7 @@ require 'irb/ext/save-history'
 require 'benchmark'
 require 'run_loop'
 require 'command_runner'
+require "dnssd"
 
 AwesomePrint.irb!
 

--- a/bin/dnssd
+++ b/bin/dnssd
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+
+require "dnssd"
+require "socket"
+require "ap"
+require "json"
+
+Thread.abort_on_exception = true
+
+trap 'INT' do exit end
+trap 'TERM' do exit end
+
+services = []
+addresses = []
+
+DNSSD.browse("_calabus._tcp") do |reply|
+  services << reply
+  next if reply.flags.more_coming?
+
+  added = services.select do |service|
+    service.flags.add?
+  end
+
+  added.each do |service|
+
+    resolved = service.resolve
+
+    addr = Socket.getaddrinfo(resolved.target, nil, Socket::AF_INET)
+
+    addr.each do |address|
+      match = addresses.find do |hash|
+        hash[:service] == service.name
+      end
+
+      if !match
+        addresses << {
+          :service => service.name,
+          :ip => addr[0][2],
+          :port => resolved.port,
+          :txt => resolved.text_record
+        }
+      end
+    end
+	end
+  json = JSON.generate(addresses)
+  puts json
+  exit
+end
+
+sleep
+

--- a/lib/run_loop.rb
+++ b/lib/run_loop.rb
@@ -49,6 +49,7 @@ require "run_loop/http/server"
 require "run_loop/http/request"
 require "run_loop/http/retriable_client"
 require "run_loop/physical_device/life_cycle"
+require "run_loop/dnssd"
 
 module RunLoop
 

--- a/lib/run_loop/dnssd.rb
+++ b/lib/run_loop/dnssd.rb
@@ -1,0 +1,148 @@
+module RunLoop
+
+  # @!visibility private
+  # This class is a work in progress.
+  #
+  # At the moment, it is only useful for debugging the bonjour
+  # server that is started by DeviceAgent.
+  class DNSSD
+
+    # @!visibility private
+    def self.factory(json)
+      array = JSON.parse(json, {:symbolize_names => true})
+      array.map do |dns|
+        RunLoop::DNSSD.new(dns[:service],
+                           dns[:ip],
+                           dns[:port],
+                           dns[:txt])
+      end
+    end
+
+    # @!visibility private
+    attr_reader :service
+
+    # @!visibility private
+    attr_reader :ip
+
+    # @!visibility private
+    attr_reader :port
+
+    # @!visibility private
+    attr_reader :txt
+
+    # @!visibility private
+    def initialize(service, ip, port, txt)
+      @service = service
+      @ip = ip
+      @port = port
+      @txt = txt
+    end
+
+    # @!visibility private
+    def url
+      @url ||= "http://#{ip}:#{port}"
+    end
+
+    # @!visibility private
+    def to_s
+      "#<#{service}: #{url} TXT: #{txt}"
+    end
+
+    # @!visibility private
+    def inspect
+      to_s
+    end
+
+    # @!visibility private
+    def ==(other)
+      service == other.service
+    end
+
+    DEVICE_AGENT = "_calabus._tcp"
+
+    def self.wait_for_new_device_agent(old, options={})
+      new = self.wait_for_device_agents(options)
+      new.find do |new_dns|
+        !old.include?(new_dns)
+      end
+    end
+
+    def self.wait_for_device_agents(options={})
+      default_opts = {
+        :timeout => 0.1,
+        :retries => 150,
+        :interval => 0.1
+      }
+
+      merged_opts = default_opts.merge(options)
+      timeout = merged_opts[:timeout]
+      retries = merged_opts[:retries]
+      interval = merged_opts[:interval]
+
+      start_time = Time.now
+
+      retries.times do |try|
+        time_diff = start_time + timeout - Time.now
+
+        if time_diff <= 0
+          elapsed = Time.now - start_time
+          RunLoop.log_debug("Timed out waiting after #{elapsed} seconds for DeviceAgents")
+          return []
+        end
+
+        agents = self.device_agents(timeout)
+
+        if !agents.empty?
+          elapsed = Time.now - start_time
+          RunLoop.log_debug("Found #{agents.count} DeviceAgents after #{elapsed} seconds")
+          return agents
+        end
+
+        sleep(interval)
+      end
+      []
+    end
+
+    def self.device_agents(timeout)
+      services = []
+      addresses = []
+      self.browse(DEVICE_AGENT, timeout) do |reply|
+        if reply.flags.add?
+          services << reply
+        end
+        next if reply.flags.more_coming?
+
+        services.each do |service|
+          resolved = service.resolve
+          addr = Socket.getaddrinfo(resolved.target, nil, Socket::AF_INET)
+          addr.each do |address|
+            match = addresses.find do |dns|
+              dns.service == service.name
+            end
+
+            if !match
+              dns = RunLoop::DNSSD.new(service.name,
+                                       addr[0][2],
+                                       resolved.port,
+                                       resolved.text_record)
+              addresses << dns
+            end
+          end
+        end
+      end
+      addresses
+    end
+
+    def self.browse(type, timeout)
+      domain = nil
+      flags = 0
+      interface = ::DNSSD::InterfaceAny
+      service = ::DNSSD::Service.browse(type, domain, flags, interface)
+      service.each(timeout) { |r| yield r }
+    ensure
+      service.stop if service
+    end
+
+  end
+end
+

--- a/run_loop.gemspec
+++ b/run_loop.gemspec
@@ -51,6 +51,7 @@ tools like instruments and simctl.}
   s.add_dependency('thor', '>= 0.18.1', '< 1.0')
   s.add_dependency('command_runner_ng', '>= 0.0.2')
   s.add_dependency("httpclient", "~> 2.6")
+  s.add_dependency("dnssd", "~> 3.0")
 
   s.add_development_dependency("rspec_junit_formatter", "~> 0.2")
   s.add_development_dependency("luffa", "~> 2.0")


### PR DESCRIPTION
### Motivation

Demonstrates how to discover Bonjour services for the purpose of finding the IP and port of bonjour service on a physical device.

This will only work on some networks and it is not clear yet how helpful this will be.