### PR TITLE
Raise error if Xcode#developer_dir path does not exist

### DIFF
--- a/spec/lib/l10n_spec.rb
+++ b/spec/lib/l10n_spec.rb
@@ -1,11 +1,17 @@
 describe RunLoop::L10N do
 
   subject(:l10n) { RunLoop::L10N.new }
+  let(:xcode) { RunLoop::Xcode.new }
 
+  before do
+    allow(l10n).to receive(:xcode).and_return(xcode)
+  end
   describe '#uikit_bundle_l10n_path' do
     it 'return value' do
       if Resources.shared.core_simulator_env?
+        expect(xcode).to receive(:developer_dir).and_return("/some/xcode/path")
         stub_env('DEVELOPER_DIR', '/some/xcode/path')
+
         axbundle_path = RunLoop::L10N.const_get('UIKIT_AXBUNDLE_PATH_CORE_SIM')
         expected = File.join('/some/xcode/path', axbundle_path)
         expect(l10n.send(:uikit_bundle_l10n_path)).to be == expected
@@ -26,7 +32,6 @@ describe RunLoop::L10N do
       let('localization') { 'da' }
       it { is_expected.to be == 'Slet' }
     end
-
     context 'when using an unknown localization' do
       let('localization') { 'not-real' }
       it { is_expected.to be == nil }

--- a/spec/lib/xcode_spec.rb
+++ b/spec/lib/xcode_spec.rb
@@ -209,6 +209,7 @@ describe RunLoop::Xcode do
   describe '#developer_dir' do
     it 'respects the DEVELOPER_DIR env var' do
       expected = '/developer/dir'
+      expect(File).to receive(:directory?).with(expected).and_return(true)
       stub_env({'DEVELOPER_DIR' => expected})
 
       expect(xcode.developer_dir).to be == expected
@@ -220,6 +221,7 @@ describe RunLoop::Xcode do
 
     it 'or it returns the value of xcode-select' do
       expected = '/xcode-select/path'
+      expect(File).to receive(:directory?).with(expected).and_return(true)
       expect(xcode).to receive(:xcode_select_path).and_return(expected)
       stub_env({'DEVELOPER_DIR' => nil})
 
@@ -229,6 +231,16 @@ describe RunLoop::Xcode do
       expect(xcode).not_to receive(:xcode_select_path)
 
       expect(xcode.instance_variable_get(:@xcode_developer_dir)).to be == expected
+    end
+
+    it "raises an error if active Xcode cannot be determined" do
+      expected = '/developer/dir'
+      expect(File).to receive(:directory?).with(expected).and_return(false)
+      stub_env({'DEVELOPER_DIR' => expected})
+
+      expect do
+        xcode.developer_dir
+      end.to raise_error RuntimeError, /Cannot determine the active Xcode/
     end
   end
 


### PR DESCRIPTION
### Motivation

Resolves **Xcode developer_dir should check if the path exists and fail fast** #371

