### PR TITLE
App and Ipa can return arches

### DIFF
--- a/lib/run_loop/app.rb
+++ b/lib/run_loop/app.rb
@@ -85,6 +85,11 @@ Bundle must:
       identifier
     end
 
+    # Returns the arches for the binary.
+    def arches
+      @arches ||= lipo.info
+    end
+
     # Inspects the app's file for the server version
     def calabash_server_version
       version = nil
@@ -130,6 +135,11 @@ Bundle must:
     end
 
     private
+
+    # @!visibility private
+    def lipo
+      @lipo ||= RunLoop::Lipo.new(path)
+    end
 
     # @!visibility private
     def plist_buddy

--- a/lib/run_loop/ipa.rb
+++ b/lib/run_loop/ipa.rb
@@ -45,6 +45,11 @@ module RunLoop
       app.executable_name
     end
 
+    # Returns the arches for the binary.
+    def arches
+      app.arches
+    end
+
     # Inspects the app's executables for the server version
     # @return[RunLoop::Version] a version instance
     def calabash_server_version

--- a/spec/lib/app_spec.rb
+++ b/spec/lib/app_spec.rb
@@ -119,6 +119,11 @@ describe RunLoop::App do
     end
   end
 
+  it "#arches" do
+    arches = app.arches
+    expect(arches).to be == ["i386", "x86_64"]
+  end
+
   context '#calabash_server_version' do
     subject { RunLoop::App.new(Resources.shared.cal_app_bundle_path).calabash_server_version }
     it { should be_kind_of(RunLoop::Version) }
@@ -297,6 +302,12 @@ describe RunLoop::App do
     it "returns false" do
       expect(app.send(:core_data_asset?, "path/to/foo")).to be_falsey
     end
+  end
+
+  it "#lipo" do
+    actual = app.send(:lipo)
+    expect(actual).to be_a_kind_of(RunLoop::Lipo)
+    expect(app.instance_variable_get(:@lipo)).to be == actual
   end
 end
 

--- a/spec/lib/ipa_spec.rb
+++ b/spec/lib/ipa_spec.rb
@@ -37,6 +37,10 @@ describe RunLoop::Ipa do
     expect(ipa.executable_name).to be == 'CalSmoke-cal'
   end
 
+  it "#arches" do
+    expect(ipa.arches).to be == ["armv7", "armv7s", "arm64"]
+  end
+
   it "calabash_server_version" do
     version = ipa.calabash_server_version
     expect(version).to be_a_kind_of(RunLoop::Version)


### PR DESCRIPTION
### Motivation

Progress on **0.18.1 Cannot automatically detect .app** [#1008](https://github.com/calabash/calabash-ios/issues/1008)

We should not have to call out to Lipo directly.