### PR TITLE
App: can report if was built for sim or device

### DIFF
--- a/lib/run_loop/app.rb
+++ b/lib/run_loop/app.rb
@@ -93,6 +93,18 @@ Bundle must:
       @arches ||= lipo.info
     end
 
+    # True if the app has been built for the simulator
+    def simulator?
+      arches.include?("i386") || arches.include?("x86_64")
+    end
+
+    # True if the app has been built for physical devices
+    def physical_device?
+      arches.any? do |arch|
+        arch[/arm/, 0]
+      end
+    end
+
     # Inspects the app's file for the server version
     def calabash_server_version
       version = nil

--- a/spec/lib/app_spec.rb
+++ b/spec/lib/app_spec.rb
@@ -207,6 +207,62 @@ describe RunLoop::App do
     end
   end
 
+  describe "#simulator_app?" do
+    it "false" do
+      expect(app).to receive(:arches).twice.and_return(["arm64", "armv7"])
+
+      expect(app.simulator?).to be_falsey
+    end
+
+    describe "true" do
+      it "i386" do
+        expect(app).to receive(:arches).at_least(:once).and_return(["i386"])
+
+        expect(app.simulator?).to be_truthy
+      end
+
+      it "x86_64" do
+        expect(app).to receive(:arches).at_least(:once).and_return(["x86_64"])
+
+        expect(app.simulator?).to be_truthy
+      end
+
+      it "both" do
+        expect(app).to receive(:arches).at_least(:once).and_return(["x86_64", "i386"])
+
+        expect(app.simulator?).to be_truthy
+      end
+    end
+  end
+
+  describe "#physical_device_app?" do
+    it "false" do
+      expect(app).to receive(:arches).at_least(:once).and_return(["x86_64", "i386"])
+
+      expect(app.physical_device?).to be_falsey
+    end
+
+    describe "true" do
+      it "arm64" do
+        expect(app).to receive(:arches).at_least(:once).and_return(["arm64"])
+
+        expect(app.physical_device?).to be_truthy
+      end
+
+      it "armv7" do
+        expect(app).to receive(:arches).at_least(:once).and_return(["armv7"])
+
+        expect(app.physical_device?).to be_truthy
+      end
+
+      it "armv7s" do
+        expect(app).to receive(:arches).at_least(:once).and_return(["armv7s"])
+
+        expect(app.physical_device?).to be_truthy
+      end
+    end
+  end
+
   describe "codesign" do
     it "#codesign_info" do
       expect(RunLoop::Codesign).to receive(:info).with(app.path).and_return(:info)


### PR DESCRIPTION
### Motivation

Progress on **0.18.1 Cannot automatically detect .app** [#1008](https://github.com/calabash/calabash-ios/issues/1008)

We need a way of filtering .apps by simulator bundles.