### PR TITLE
App: improve exectuable detection in app bundles

### DIFF
--- a/lib/run_loop/app.rb
+++ b/lib/run_loop/app.rb
@@ -234,9 +234,11 @@ Bundle must:
     # @!visibility private
     def lproj_asset?(file)
       extension = File.extname(file)
+      dir_extension = File.extname(File.dirname(file))
 
-      file[/lproj/, 0] ||
-        file[/storyboard/, 0] ||
+      dir_extension == ".lproj" ||
+        dir_extension == ".storyboard" ||
+        dir_extension == ".storyboardc" ||
         extension == ".strings" ||
         extension == ".xib" ||
         extension == ".nib"

--- a/lib/run_loop/app.rb
+++ b/lib/run_loop/app.rb
@@ -205,6 +205,7 @@ Bundle must:
     # @!visibility private
     def text?(file)
        extension = File.extname(file)
+       filename = File.basename(file)
 
        extension == ".txt" ||
          extension == ".md" ||
@@ -214,7 +215,10 @@ Bundle must:
          extension == ".yaml" ||
          extension == ".yml" ||
          extension == ".rtf" ||
-         file[/NOTICE|LICENSE|README|ABOUT/, 0]
+
+         ["NOTICE", "LICENSE", "README", "ABOUT"].any? do |elm|
+           filename[/#{elm}/]
+         end
     end
 
     # @!visibility private

--- a/lib/run_loop/app.rb
+++ b/lib/run_loop/app.rb
@@ -135,7 +135,6 @@ Bundle must:
     def executables
       executables = []
       Dir.glob("#{path}/**/*") do |file|
-        next if File.directory?(file)
         next if skip_executable_check?(file)
         if otool(file).executable?
           executables << file
@@ -194,7 +193,8 @@ Bundle must:
 
     # @!visibility private
     def skip_executable_check?(file)
-      image?(file) ||
+      File.directory?(file) ||
+        image?(file) ||
         text?(file) ||
         plist?(file) ||
         lproj_asset?(file) ||

--- a/lib/run_loop/app.rb
+++ b/lib/run_loop/app.rb
@@ -199,7 +199,8 @@ Bundle must:
         plist?(file) ||
         lproj_asset?(file) ||
         code_signing_asset?(file) ||
-        core_data_asset?(file)
+        core_data_asset?(file) ||
+        font?(file)
     end
 
     # @!visibility private
@@ -266,6 +267,13 @@ Bundle must:
         extension == ".mom" ||
         extension == ".db" ||
         extension == ".omo"
+    end
+
+    # @!visibility private
+    def font?(file)
+      extension = File.extname(file)
+
+      extension == ".tff" || extension == ".otf"
     end
   end
 end

--- a/lib/run_loop/app.rb
+++ b/lib/run_loop/app.rb
@@ -260,10 +260,12 @@ Bundle must:
     # @!visibility private
     def core_data_asset?(file)
       extension = File.extname(file)
+      dir_extension = File.extname(File.dirname(file))
 
-      file[/momd/, 0] ||
+      dir_extension == ".momd" ||
         extension == ".mom" ||
-        extension == ".db"
+        extension == ".db" ||
+        extension == ".omo"
     end
   end
 end

--- a/lib/run_loop/app.rb
+++ b/lib/run_loop/app.rb
@@ -248,12 +248,13 @@ Bundle must:
     def code_signing_asset?(file)
       name = File.basename(file)
       extension = File.extname(file)
+      dirname = File.basename(File.dirname(file))
 
       name == "PkgInfo" ||
         name == "embedded" ||
         extension == ".mobileprovision" ||
         extension == ".xcent" ||
-        file[/_CodeSignature/, 0]
+        dirname == "_CodeSignature"
     end
 
     # @!visibility private

--- a/spec/lib/app_spec.rb
+++ b/spec/lib/app_spec.rb
@@ -1,6 +1,7 @@
 describe RunLoop::App do
 
-  let(:app) { RunLoop::App.new(Resources.shared.app_bundle_path) }
+  let(:bundle_path) { Resources.shared.app_bundle_path }
+  let(:app) { RunLoop::App.new(bundle_path) }
   let(:bundle_id) { 'sh.calaba.CalSmoke' }
 
   describe '.new' do
@@ -331,14 +332,17 @@ describe RunLoop::App do
   end
 
   it "#skip_executable_check?" do
-    expect(app).to receive(:image?).and_return(false)
-    expect(app).to receive(:text?).and_return(false)
-    expect(app).to receive(:plist?).and_return(false)
-    expect(app).to receive(:lproj_asset?).and_return(false)
-    expect(app).to receive(:code_signing_asset?).and_return(false)
-    expect(app).to receive(:core_data_asset?).and_return(false)
+    path = "path/to/file"
+    expect(File).to receive(:directory?).at_least(:once).with(bundle_path).and_return(true)
+    expect(File).to receive(:directory?).with(path).and_return(false)
+    expect(app).to receive(:image?).with(path).and_return(false)
+    expect(app).to receive(:text?).with(path).and_return(false)
+    expect(app).to receive(:plist?).with(path).and_return(false)
+    expect(app).to receive(:lproj_asset?).with(path).and_return(false)
+    expect(app).to receive(:code_signing_asset?).with(path).and_return(false)
+    expect(app).to receive(:core_data_asset?).with(path).and_return(false)
 
-    expect(app.send(:skip_executable_check?, "path/to/file")).to be_falsey
+    expect(app.send(:skip_executable_check?, path)).to be_falsey
   end
 
   describe "#image?" do

--- a/spec/lib/app_spec.rb
+++ b/spec/lib/app_spec.rb
@@ -396,6 +396,7 @@ describe RunLoop::App do
       expect(app.send(:lproj_asset?, "path/to/My.nib")).to be_truthy
       expect(app.send(:lproj_asset?, "path/to/My.xib")).to be_truthy
       expect(app.send(:lproj_asset?, "path/to/Main.storyboardc/any_file")).to be_truthy
+      expect(app.send(:lproj_asset?, "path/to/Main.storyboard/any_file")).to be_truthy
       expect(app.send(:lproj_asset?, "path/to/Localizable.strings")).to be_truthy
     end
 

--- a/spec/lib/app_spec.rb
+++ b/spec/lib/app_spec.rb
@@ -341,6 +341,7 @@ describe RunLoop::App do
     expect(app).to receive(:lproj_asset?).with(path).and_return(false)
     expect(app).to receive(:code_signing_asset?).with(path).and_return(false)
     expect(app).to receive(:core_data_asset?).with(path).and_return(false)
+    expect(app).to receive(:font?).with(path).and_return(false)
 
     expect(app.send(:skip_executable_check?, path)).to be_falsey
   end
@@ -433,6 +434,17 @@ describe RunLoop::App do
 
     it "returns false" do
       expect(app.send(:core_data_asset?, "path/to/foo")).to be_falsey
+    end
+  end
+
+  describe "#font?" do
+    it "returns trues" do
+      expect(app.send(:font?, "path/to/my.tff")).to be_truthy
+      expect(app.send(:font?, "path/to/my.otf")).to be_truthy
+    end
+
+    it "returns false" do
+      expect(app.send(:font?, "path/to/my.file")).to be_falsey
     end
   end
 

--- a/spec/lib/app_spec.rb
+++ b/spec/lib/app_spec.rb
@@ -424,6 +424,7 @@ describe RunLoop::App do
       expect(app.send(:core_data_asset?, "path/to/my.mom")).to be_truthy
       expect(app.send(:core_data_asset?, "path/to/CoreData.momd/SomeFile")).to be_truthy
       expect(app.send(:core_data_asset?, "path/to/my.db")).to be_truthy
+      expect(app.send(:core_data_asset?, "path/to/my.omo")).to be_truthy
     end
 
     it "returns false" do


### PR DESCRIPTION
### Motivation

See: 5ff7036 

The original implementation relied on regular expressions on the _path_ which in hindsight I see can lead to false positives in the `#skip_executable_check?` method which in turn cases the `#calabash_server_version` method to fail which then cause the automatic app detection algorithm to fail.


Resolves:

* App: should skip font files when collecting executables #397
* App: fix the regex for CoreData assets and include missing assets #398
* App: replace the /storyboard/ regex with a basename check #399

Thanks @topgenorth for the machine time!
