### PR TITLE
Improve automatic .app detection

### DIFF
--- a/lib/run_loop/detect_aut/detect.rb
+++ b/lib/run_loop/detect_aut/detect.rb
@@ -10,6 +10,11 @@ module RunLoop
       include RunLoop::DetectAUT::Xcode
 
       # @!visibility private
+      DEFAULTS = {
+        :search_depth => 5
+      }
+
+      # @!visibility private
       def app_for_simulator
         path = RunLoop::Environment.path_to_app_bundle
         return RunLoop::App.new(path) if path
@@ -32,7 +37,7 @@ module RunLoop
         end
 
         if apps.empty?
-          raise_no_simulator_app_found(search_dirs)
+          raise_no_simulator_app_found(search_dirs, DEFAULTS[:search_depth])
         end
 
         app = select_most_recent_app(apps)
@@ -90,6 +95,14 @@ module RunLoop
       def mtime(app)
         path = File.join(app.path, app.executable_name)
         File.mtime(path)
+      end
+
+      # @!visibility private
+      def globs_for_app_search(base_dir)
+        search_depth = DEFAULTS[:search_depth]
+        Array.new(search_depth) do |depth|
+          File.join(base_dir, *Array.new(depth) { |_| "*"}, "*.app")
+        end
       end
     end
   end

--- a/lib/run_loop/detect_aut/detect.rb
+++ b/lib/run_loop/detect_aut/detect.rb
@@ -63,7 +63,12 @@ module RunLoop
       # @param [String] base_dir where to start the recursive search
       def candidate_apps(base_dir)
         candidates = []
-        Dir.glob("#{base_dir}/**/*.app").each do |bundle_path|
+
+        globs = globs_for_app_search(base_dir)
+        Dir.glob(globs).each do |bundle_path|
+          # Gems, like run-loop, can contain *.app if the user is building
+          # from :git =>, :github =>, or :path => sources.
+          next if bundle_path[/vendor\/cache/, 0] != nil
           app = app_or_nil(bundle_path)
           candidates << app if app
         end

--- a/lib/run_loop/detect_aut/detect.rb
+++ b/lib/run_loop/detect_aut/detect.rb
@@ -25,15 +25,8 @@ module RunLoop
           search_dirs = [solution_directory]
           apps = candidate_apps(search_dirs.first)
         else
-          apps = []
-          search_dirs = []
-        end
-
-        # If this is a Xamarin project, we've already searched the local
-        # directory tree for .app.
-        if apps.empty? && !xamarin_project?
-          search_dirs << File.expand_path("./")
-          apps = candidate_apps(File.expand_path("./"))
+          search_dirs = [Dir.pwd]
+          apps = candidate_apps(search_dirs.first)
         end
 
         if apps.empty?

--- a/lib/run_loop/detect_aut/errors.rb
+++ b/lib/run_loop/detect_aut/errors.rb
@@ -116,8 +116,8 @@ but could not find any .app for the simulator that links the Calabash iOS server
 
 Make sure you have built your app for a simulator target from Xcode.
 
-If you testing a stand-alone .app (you don't have an Xcode project), put your
-.app in the same directory (or below) the directory you run `cucumber` from.
+If you are testing a stand-alone .app (you don't have an Xcode project), put
+your .app in the same directory (or below) the directory you run `cucumber` from.
 ]
       end
     end

--- a/lib/run_loop/detect_aut/errors.rb
+++ b/lib/run_loop/detect_aut/errors.rb
@@ -106,9 +106,9 @@ $ SOLUTION=~/some/other/directory/MyApp.sln
 
       # @!visibility private
       # Raised when no app can found by the discovery algorithm
-      def raise_no_simulator_app_found(search_directories)
+      def raise_no_simulator_app_found(search_directories, search_depth)
         raise RunLoop::NoSimulatorAppFoundError,
-              %Q[Searched these directories:
+%Q[Recursively searched these directories to depth #{search_depth}:
 
 #{search_directories.join($-0)}
 

--- a/lib/run_loop/detect_aut/xcode.rb
+++ b/lib/run_loop/detect_aut/xcode.rb
@@ -42,6 +42,9 @@ module RunLoop
           dirs_to_search << dir_from_prefs
         end
 
+        dirs_to_search << Dir.pwd
+        dirs_to_search.uniq!
+
         apps = []
         dirs_to_search.each do |dir|
           # defined in detect_aut/apps.rb

--- a/lib/run_loop/detect_aut/xcode.rb
+++ b/lib/run_loop/detect_aut/xcode.rb
@@ -30,7 +30,19 @@ module RunLoop
 
       # @!visibility private
       def find_xcodeproj
-        Dir.glob("#{Dir.pwd}/**/*.xcodeproj")
+        xcode_projects = []
+        Dir.glob("#{Dir.pwd}/**/*.xcodeproj").each do |path|
+          next if ignore_xcodeproj?(path)
+          xcode_projects << path
+        end
+        xcode_projects
+      end
+
+      # @!visibility private
+      def ignore_xcodeproj?(path)
+        path[/CordovaLib/, 0] ||
+          path[/Pods/, 0] ||
+          path[/Carthage/, 0]
       end
 
       # @!visibility private

--- a/spec/lib/detect_aut/detect_spec.rb
+++ b/spec/lib/detect_aut/detect_spec.rb
@@ -165,4 +165,35 @@ describe RunLoop::DetectAUT::Detect do
 
     obj.mtime(app)
   end
+
+  describe "#globs_for_app_search" do
+    it "array of globs that based on default search depth" do
+      expected_count = RunLoop::DetectAUT::Detect::DEFAULTS[:search_depth]
+      expected = [
+        "./*.app",
+        "./*/*.app",
+        "./*/*/*.app",
+        "./*/*/*/*.app",
+        "./*/*/*/*/*.app"
+      ]
+      expect(expected.count).to be == expected_count
+
+      actual = obj.send(:globs_for_app_search, "./")
+      expect(actual).to be == expected
+    end
+
+    it "respects changes to DEFAULTS[:search_depth]" do
+      stub_const("RunLoop::DetectAUT::Detect::DEFAULTS",  {search_depth: 2})
+
+      expected_count = RunLoop::DetectAUT::Detect::DEFAULTS[:search_depth]
+      expected = [
+        "./*.app",
+        "./*/*.app",
+      ]
+      expect(expected.count).to be == expected_count
+
+      actual = obj.send(:globs_for_app_search, "./")
+      expect(actual).to be == expected
+    end
+  end
 end

--- a/spec/lib/detect_aut/detect_spec.rb
+++ b/spec/lib/detect_aut/detect_spec.rb
@@ -3,7 +3,7 @@ describe RunLoop::DetectAUT::Detect do
   let(:app) { RunLoop::App.new(Resources.shared.cal_app_bundle_path) }
   let(:obj) { RunLoop::DetectAUT::Detect.new }
 
-  describe "#simulator" do
+  describe "#app_for_simulator" do
     it "respects the APP variable" do
       expect(RunLoop::Environment).to receive(:path_to_app_bundle).and_return(app.path)
 
@@ -86,21 +86,10 @@ describe RunLoop::DetectAUT::Detect do
       end
 
       describe "found no apps" do
-        it "found an app by recursively searching down from the local directory" do
-          apps = [app]
-          expect(obj).to receive(:detect_xcode_apps).and_return([[], search_dirs])
-          expect(obj).to receive(:candidate_apps).with(File.expand_path("./")).and_return(apps)
-          expect(obj).to receive(:select_most_recent_app).with(apps).and_return(app)
-
-          expect(obj.app_for_simulator).to be == app
-        end
 
         it "did not find any apps in DerivedData or by search recursively down from the directory" do
           depth = RunLoop::DetectAUT::Detect::DEFAULTS[:search_depth]
           expect(obj).to receive(:detect_xcode_apps).and_return([[], search_dirs])
-          local_path = File.expand_path("./")
-          search_dirs << local_path
-          expect(obj).to receive(:candidate_apps).with(local_path).and_return([])
           expect(obj).to receive(:raise_no_simulator_app_found).with(search_dirs, depth).and_call_original
 
           expect do

--- a/spec/lib/detect_aut/detect_spec.rb
+++ b/spec/lib/detect_aut/detect_spec.rb
@@ -57,9 +57,10 @@ describe RunLoop::DetectAUT::Detect do
       end
 
       it "found no apps" do
+        depth = RunLoop::DetectAUT::Detect::DEFAULTS[:search_depth]
         expect(obj).to receive(:solution_directory).and_return(search_dirs.first)
         expect(obj).to receive(:candidate_apps).with(search_dirs.first).and_return([])
-        expect(obj).to receive(:raise_no_simulator_app_found).with(search_dirs).and_call_original
+        expect(obj).to receive(:raise_no_simulator_app_found).with(search_dirs, depth).and_call_original
 
         expect do
           obj.app_for_simulator
@@ -95,11 +96,12 @@ describe RunLoop::DetectAUT::Detect do
         end
 
         it "did not find any apps in DerivedData or by search recursively down from the directory" do
+          depth = RunLoop::DetectAUT::Detect::DEFAULTS[:search_depth]
           expect(obj).to receive(:detect_xcode_apps).and_return([[], search_dirs])
           local_path = File.expand_path("./")
           search_dirs << local_path
           expect(obj).to receive(:candidate_apps).with(local_path).and_return([])
-          expect(obj).to receive(:raise_no_simulator_app_found).with(search_dirs).and_call_original
+          expect(obj).to receive(:raise_no_simulator_app_found).with(search_dirs, depth).and_call_original
 
           expect do
             obj.app_for_simulator

--- a/spec/lib/detect_aut/errors_spec.rb
+++ b/spec/lib/detect_aut/errors_spec.rb
@@ -27,7 +27,7 @@ describe RunLoop::DetectAUT::Errors do
 
   it "#raise_no_simulator_app_found" do
     expect do
-      obj.raise_no_simulator_app_found(["path/a", "path/b", "path/c"])
+      obj.raise_no_simulator_app_found(["path/a", "path/b", "path/c"], 4)
     end.to raise_error RunLoop::NoSimulatorAppFoundError
   end
 end

--- a/spec/lib/detect_aut/xcode_spec.rb
+++ b/spec/lib/detect_aut/xcode_spec.rb
@@ -80,9 +80,42 @@ describe RunLoop::DetectAUT::Xcode do
 
   it "#find_xcodeproj" do
     glob = "#{Dir.pwd}/**/*.xcodeproj"
-    expect(Dir).to receive(:glob).with(glob).and_return([])
 
-    expect(obj.find_xcodeproj).to be == []
+    glob_result = [
+      "path/to/ProjectA.xcodeproj",
+      "path/to/ProjectB.xcodeproj",
+      "path/to/ProjectC.xcodeproj"
+    ]
+
+    expect(Dir).to receive(:glob).with(glob).and_return(glob_result)
+
+    expect(obj).to receive(:ignore_xcodeproj?).with(glob_result[0]).and_return(true)
+    expect(obj).to receive(:ignore_xcodeproj?).with(glob_result[1]).and_return(false)
+    expect(obj).to receive(:ignore_xcodeproj?).with(glob_result[2]).and_return(true)
+
+    expect(obj.find_xcodeproj).to be == ["path/to/ProjectB.xcodeproj"]
+  end
+
+  describe "#ignore_xcodeproj?" do
+    it "ignores CordovaLib" do
+      path = "path/CordovaLib/Cordova.xcodeproj"
+      expect(obj.ignore_xcodeproj?(path)).to be_truthy
+    end
+
+    it "ignores Pods" do
+      path = "path/Pods/Pods.xcodeproj"
+      expect(obj.ignore_xcodeproj?(path)).to be_truthy
+    end
+
+    it "ignores Carthage" do
+      path = "path/Carthage/AFNetworking/AFNetworking.xcodeproj"
+      expect(obj.ignore_xcodeproj?(path)).to be_truthy
+    end
+
+    it "returns false" do
+      path = "path/ProjectA.xcodeproj"
+      expect(obj.ignore_xcodeproj?(path)).to be_falsey
+    end
   end
 
   describe "#detect_xcode_apps" do

--- a/spec/lib/detect_aut/xcode_spec.rb
+++ b/spec/lib/detect_aut/xcode_spec.rb
@@ -89,28 +89,34 @@ describe RunLoop::DetectAUT::Xcode do
     let(:derived) { ["path/a", "path/b", "path/c"] }
     let(:prefs) { "path/prefs" }
 
-    it "only derived data" do
+    before do
+      allow(Dir).to receive(:pwd).and_return("./")
+    end
+
+    it "only derived data and local directory" do
       expect(obj).to receive(:candidate_apps).with(derived[0]).and_return(["a"])
       expect(obj).to receive(:candidate_apps).with(derived[1]).and_return(["b"])
       expect(obj).to receive(:candidate_apps).with(derived[2]).and_return(["c"])
+      expect(obj).to receive(:candidate_apps).with("./").and_return(["d"])
       expect(obj).to receive(:derived_data_search_dirs).and_return(derived)
       expect(obj).to receive(:xcode_preferences_search_dir).and_return(nil)
 
-      e_apps = ["a", "b", "c"]
-      e_search_dirs = derived
+      e_apps = ["a", "b", "c", "d"]
+      e_search_dirs = derived +  ["./"]
 
       a_apps, a_search_dirs = obj.detect_xcode_apps
       expect(a_apps).to be == e_apps
       expect(a_search_dirs).to be == e_search_dirs
     end
 
-    it "only xcode preferences dir" do
+    it "only xcode preferences dir and local directory" do
       expect(obj).to receive(:derived_data_search_dirs).and_return([])
       expect(obj).to receive(:xcode_preferences_search_dir).and_return(prefs)
       expect(obj).to receive(:candidate_apps).with(prefs).and_return(["d"])
+      expect(obj).to receive(:candidate_apps).with("./").and_return(["e"])
 
-      e_apps = ["d"]
-      e_search_dirs = [prefs]
+      e_apps = ["d", "e"]
+      e_search_dirs = [prefs] + ["./"]
 
       a_apps, a_search_dirs = obj.detect_xcode_apps
       expect(a_apps).to be == e_apps
@@ -124,9 +130,10 @@ describe RunLoop::DetectAUT::Xcode do
       expect(obj).to receive(:candidate_apps).with(derived[1]).and_return(["b"])
       expect(obj).to receive(:candidate_apps).with(derived[2]).and_return(["c"])
       expect(obj).to receive(:candidate_apps).with(prefs).and_return(["d"])
+      expect(obj).to receive(:candidate_apps).with("./").and_return(["e"])
 
-      e_apps = ["a", "b", "c", "d"]
-      e_search_dirs = derived.dup << prefs
+      e_apps = ["a", "b", "c", "d", "e"]
+      e_search_dirs = derived.dup + [prefs] + ["./"]
 
       a_apps, a_search_dirs = obj.detect_xcode_apps
       expect(a_apps).to be == e_apps


### PR DESCRIPTION
### Motivation

I did a round of user testing last night and discovered some short falls.

We need to filter out these common .xcodeproj from our Xcode project results:

* CordovaLib
* Pods/Pods.xcodeproj
* Carthage/**/*.xcodeproj

The next obvious step will be to collect _all_ .xcodeproj in the directory and do a search of the resulting DerivedData directories.  There was at least one user with an iOS and MacOS .xcodeproj in their working directory.  We could filter further by asking the .xcodeproj if it has a `osx` target, but I think that might lead to false positives.

Users that receive a `RunLoop::DetectAUT::MultipleXcodeprojError` can set the `XCODEPROJ` env variable to indicate which .xcodeproj they are using.

```
$ XCODEPROCT=MyiOS.xcodeproj be cucumber
```
