### PR TITLE
Flush pipe_io if Errno::EPIPE error is encountered

### DIFF
--- a/lib/run_loop/fifo.rb
+++ b/lib/run_loop/fifo.rb
@@ -22,10 +22,7 @@ module RunLoop
               wrote = pipe_io.write_nonblock msg
               bytes_written += wrote
               msg = msg[wrote..-1]
-            rescue Errno::EPIPE
-              pipe_io.flush
-              retry
-            rescue IO::WaitWritable, Errno::EINTR
+            rescue IO::WaitWritable, Errno::EINTR, Errno::EPIPE
               timeout_left = timeout - (Time.now - begin_at)
               raise WriteTimedOut if timeout_left <= 0
               IO.select nil, [pipe_io], nil, timeout_left

--- a/lib/run_loop/fifo.rb
+++ b/lib/run_loop/fifo.rb
@@ -22,6 +22,9 @@ module RunLoop
               wrote = pipe_io.write_nonblock msg
               bytes_written += wrote
               msg = msg[wrote..-1]
+            rescue Errno::EPIPE
+              pipe_io.flush
+              retry
             rescue IO::WaitWritable, Errno::EINTR
               timeout_left = timeout - (Time.now - begin_at)
               raise WriteTimedOut if timeout_left <= 0


### PR DESCRIPTION
Some users (myself included) were encountering seemingly random Errno::EPIPE errors around different Calabash gestures which caused tests to fail.  This fixes https://github.com/calabash/run_loop/issues/395.