### PR TITLE
Environment: handle empty strings for DEVICE_TARGET, DEVICE_ENDPOINT, and TRACE_TEMPLATE

### DIFF
--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -57,7 +57,7 @@ module RunLoop
     def self.xcodeproj
       value = ENV["XCODEPROJ"]
       if value.nil? || value == ""
-        return nil
+        nil
       else
         File.expand_path(value)
       end

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -40,7 +40,12 @@ module RunLoop
 
     # Returns the value of DEVICE_ENDPOINT
     def self.device_endpoint
-      ENV["DEVICE_ENDPOINT"]
+      value = ENV["DEVICE_ENDPOINT"]
+      if value.nil? || value == ""
+        nil
+      else
+        value
+      end
     end
 
     # Returns the value of XCODEPROJ which can be used to specify an Xcode

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -30,7 +30,12 @@ module RunLoop
 
     # Returns the value of DEVICE_TARGET
     def self.device_target
-      ENV["DEVICE_TARGET"]
+      value = ENV["DEVICE_TARGET"]
+      if value.nil? || value == ""
+        nil
+      else
+        value
+      end
     end
 
     # Returns the value of DEVICE_ENDPOINT

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -94,7 +94,12 @@ module RunLoop
     # Returns the value of TRACE_TEMPLATE; the Instruments template to use
     # during testing.
     def self.trace_template
-      ENV['TRACE_TEMPLATE']
+      value = ENV['TRACE_TEMPLATE']
+      if value.nil? || value == ""
+        nil
+      else
+        File.expand_path(value)
+      end
     end
 
     # Returns the value of UIA_TIMEOUT.  Use this control how long to wait

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -52,9 +52,23 @@ describe RunLoop::Environment do
     end
   end
 
-  it ".device_target" do
-    stub_env({"DEVICE_TARGET" => "target"})
-    expect(RunLoop::Environment.device_target).to be == "target"
+  describe ".device_target" do
+    it ".device_target" do
+      stub_env({"DEVICE_TARGET" => "target"})
+      expect(RunLoop::Environment.device_target).to be == "target"
+    end
+
+    describe "returns nil" do
+      it "is undefined" do
+        stub_env({"DEVICE_TARGET" => nil})
+        expect(RunLoop::Environment.device_target).to be == nil
+      end
+
+      it "is the empty string" do
+        stub_env({"DEVICE_TARGET" => ""})
+        expect(RunLoop::Environment.device_target).to be == nil
+      end
+    end
   end
 
   it ".device_endpoint" do

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -53,7 +53,7 @@ describe RunLoop::Environment do
   end
 
   describe ".device_target" do
-    it ".device_target" do
+    it "returns DEVICE_TARGET" do
       stub_env({"DEVICE_TARGET" => "target"})
       expect(RunLoop::Environment.device_target).to be == "target"
     end
@@ -71,11 +71,26 @@ describe RunLoop::Environment do
     end
   end
 
-  it ".device_endpoint" do
-    url = "http://denis.local:27753"
-    stub_env({"DEVICE_ENDPOINT" => url})
-    expect(RunLoop::Environment.device_endpoint).to be == url
+  describe ".device_endpoint" do
+    it "returns DEVICE_ENDPOINT" do
+      url = "http://denis.local:27753"
+      stub_env({"DEVICE_ENDPOINT" => url})
+      expect(RunLoop::Environment.device_endpoint).to be == url
+    end
+
+    describe "returns nil" do
+      it "is undefined" do
+        stub_env({"DEVICE_ENDPOINT" => nil})
+        expect(RunLoop::Environment.device_endpoint).to be == nil
+      end
+
+      it "is the empty string" do
+        stub_env({"DEVICE_ENDPOINT" => ""})
+        expect(RunLoop::Environment.device_endpoint).to be == nil
+      end
+    end
   end
+
 
   it '.trace_template' do
     stub_env('TRACE_TEMPLATE', '/my/tracetemplate')

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -92,9 +92,24 @@ describe RunLoop::Environment do
   end
 
 
-  it '.trace_template' do
-    stub_env('TRACE_TEMPLATE', '/my/tracetemplate')
-    expect(RunLoop::Environment.trace_template).to be == '/my/tracetemplate'
+  describe '.trace_template' do
+    it "returns TRACE_TEMPLATE expanded" do
+      stub_env('TRACE_TEMPLATE', './my/tracetemplate')
+      expected = File.join(Dir.pwd, "my", "tracetemplate")
+      expect(RunLoop::Environment.trace_template).to be == expected
+    end
+
+    describe "returns nil" do
+      it "is undefined" do
+        stub_env({'TRACE_TEMPLATE' => nil})
+        expect(RunLoop::Environment.trace_template).to be == nil
+      end
+
+      it "is the empty string" do
+        stub_env({'TRACE_TEMPLATE' => ""})
+        expect(RunLoop::Environment.trace_template).to be == nil
+      end
+    end
   end
 
   describe '.uia_timeout' do


### PR DESCRIPTION
### Motivation

If these values are `""` we should treat them as nil.