### PR TITLE
Drop Xcode 5 checks

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -71,21 +71,12 @@ module RunLoop
     # Raise an error if the application binary is not compatible with the
     # target simulator.
     #
-    # @note This method is implemented for CoreSimulator environments only;
-    #  for Xcode < 6.0 this method does nothing.
-    #
     # @param [RunLoop::Device] device The device to install on.
     # @param [RunLoop::App] app The app to install.
-    # @param [RunLoop::Xcode] xcode The active Xcode.
     #
     # @raise [RunLoop::IncompatibleArchitecture] Raises an error if the
     #  application binary is not compatible with the target simulator.
-    def self.expect_simulator_compatible_arch(device, app, xcode)
-      if !xcode.version_gte_6?
-        RunLoop.log_warn("Checking for compatible arches is only available in CoreSimulator environments")
-        return
-      end
-
+    def self.expect_simulator_compatible_arch(device, app)
       lipo = RunLoop::Lipo.new(app.path)
       lipo.expect_compatible_arch(device)
 
@@ -129,7 +120,7 @@ module RunLoop
       end
 
       # Validate the architecture.
-      self.expect_simulator_compatible_arch(device, app, xcode)
+      self.expect_simulator_compatible_arch(device, app)
 
       # Quits the simulator.
       core_sim = RunLoop::CoreSimulator.new(device, app)

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -466,43 +466,13 @@ Logfile: #{log_file}
         raise 'key :app or environment variable APP_BUNDLE_PATH, BUNDLE_ID or APP must be specified as path to app bundle (simulator) or bundle id (device)'
       end
 
-      udid = nil
+      if device_target.nil? || device_target.empty? || device_target == 'simulator'
+        device_target = self.default_simulator(xcode)
+      end
+      udid = device_target
 
-      if xcode.version_gte_51?
-        if device_target.nil? || device_target.empty? || device_target == 'simulator'
-          device_target = self.default_simulator(xcode)
-        end
-        udid = device_target
-
-        unless self.simulator_target?(options)
-          bundle_dir_or_bundle_id = options[:bundle_id] if options[:bundle_id]
-        end
-      else
-        #TODO: this can be removed - Xcode < 5.1.1 not supported.
-        if device_target == 'simulator'
-
-          unless File.exist?(bundle_dir_or_bundle_id)
-            raise "Unable to find app in directory #{bundle_dir_or_bundle_id} when trying to launch simulator"
-          end
-
-
-          device = options[:device] || :iphone
-          device = device && device.to_sym
-
-          plistbuddy='/usr/libexec/PlistBuddy'
-          plistfile="#{bundle_dir_or_bundle_id}/Info.plist"
-          if device == :iphone
-            uidevicefamily=1
-          else
-            uidevicefamily=2
-          end
-          system("#{plistbuddy} -c 'Delete :UIDeviceFamily' '#{plistfile}'")
-          system("#{plistbuddy} -c 'Add :UIDeviceFamily array' '#{plistfile}'")
-          system("#{plistbuddy} -c 'Add :UIDeviceFamily:0 integer #{uidevicefamily}' '#{plistfile}'")
-        else
-          udid = device_target
-          bundle_dir_or_bundle_id = options[:bundle_id] if options[:bundle_id]
-        end
+      unless self.simulator_target?(options)
+        bundle_dir_or_bundle_id = options[:bundle_id] if options[:bundle_id]
       end
       return udid, bundle_dir_or_bundle_id
     end

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -427,10 +427,8 @@ Logfile: #{log_file}
         "iPhone 5s (8.2 Simulator)"
       elsif xcode.version_gte_61?
         "iPhone 5s (8.1 Simulator)"
-      elsif xcode.version_gte_6?
-        "iPhone 5s (8.0 Simulator)"
       else
-        "iPhone Retina (4-inch) - Simulator - iOS 7.1"
+        "iPhone 5s (8.0 Simulator)"
       end
     end
 

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -380,18 +380,14 @@ Logfile: #{log_file}
       # Check for named simulators and Xcode >= 7.0 simulators.
       sim_control = run_options[:sim_control] || RunLoop::SimControl.new
       xcode = sim_control.xcode
-      if xcode.version_gte_6?
-        simulator = sim_control.simulators.find do |sim|
-          [
-            sim.instruments_identifier(xcode) == value,
-            sim.udid == value,
-            sim.name == value
-          ].any?
-        end
-        !simulator.nil?
-      else
-        false
+      simulator = sim_control.simulators.find do |sim|
+        [
+          sim.instruments_identifier(xcode) == value,
+          sim.udid == value,
+          sim.name == value
+        ].any?
       end
+      !simulator.nil?
     end
 
 

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -68,48 +68,6 @@ module RunLoop
       nil
     end
 
-    # @deprecated 1.5.2 No public replacement.
-    #
-    # Raise an error if the application binary is not compatible with the
-    # target simulator.
-    #
-    # @note This method is implemented for CoreSimulator environments only;
-    #  for Xcode < 6.0 this method does nothing.
-    #
-    # @param [Hash] launch_options These options need to contain the app bundle
-    #   path and a udid that corresponds to a simulator name or simulator udid.
-    #   In practical terms:  call this after merging the original launch
-    #   options with those options that are discovered.
-    #
-    # @param [RunLoop::SimControl] sim_control A simulator control object.
-    # @raise [RuntimeError] Raises an error if the `launch_options[:udid]`
-    #  cannot be used to find a simulator.
-    # @raise [RunLoop::IncompatibleArchitecture] Raises an error if the
-    #  application binary is not compatible with the target simulator.
-    def self.expect_compatible_simulator_architecture(launch_options, sim_control)
-      RunLoop.deprecated('1.5.2', 'No public replacement.')
-      logger = launch_options[:logger]
-      if sim_control.xcode_version_gte_6?
-        sim_identifier = launch_options[:udid]
-        simulator = sim_control.simulators.find do |simulator|
-          [simulator.instruments_identifier(sim_control.xcode),
-           simulator.udid].include?(sim_identifier)
-        end
-
-        if simulator.nil?
-          raise "Could not find simulator with identifier '#{sim_identifier}'"
-        end
-
-        lipo = RunLoop::Lipo.new(launch_options[:bundle_dir_or_bundle_id])
-        lipo.expect_compatible_arch(simulator)
-        RunLoop::Logging.log_debug(logger, "Simulator instruction set '#{simulator.instruction_set}' is compatible with #{lipo.info}")
-        true
-      else
-        RunLoop::Logging.log_debug(logger, "Xcode #{sim_control.xcode_version} detected; skipping simulator architecture check.")
-        false
-      end
-    end
-
     # Raise an error if the application binary is not compatible with the
     # target simulator.
     #

--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -508,11 +508,9 @@ $ bundle exec run-loop simctl manage-processes
   def sim_name
     @sim_name ||= lambda {
       if xcode.version_gte_7?
-        'Simulator'
-      elsif xcode.version_gte_6?
-        'iOS Simulator'
+        "Simulator"
       else
-        'iPhone Simulator'
+        "iOS Simulator"
       end
     }.call
   end

--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -527,10 +527,8 @@ $ bundle exec run-loop simctl manage-processes
       dev_dir = xcode.developer_dir
       if xcode.version_gte_7?
         "#{dev_dir}/Applications/Simulator.app"
-      elsif xcode.version_gte_6?
-        "#{dev_dir}/Applications/iOS Simulator.app"
       else
-        "#{dev_dir}/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app"
+        "#{dev_dir}/Applications/iOS Simulator.app"
       end
     }.call
   end

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -162,10 +162,8 @@ Please update your sources.))
 
         if xcode.version_gte_7?
           "#{name} (#{version_part})"
-        elsif xcode.version_gte_6?
-          "#{name} (#{version_part} Simulator)"
         else
-          udid
+          "#{name} (#{version_part} Simulator)"
         end
       end
     end

--- a/lib/run_loop/instruments.rb
+++ b/lib/run_loop/instruments.rb
@@ -198,20 +198,14 @@ module RunLoop
       @instruments_templates ||= lambda do
         args = ['instruments', '-s', 'templates']
         hash = xcrun.exec(args, log_cmd: true)
-        if xcode.version_gte_6?
-          hash[:out].chomp.split("\n").map do |elm|
-            stripped = elm.strip.tr('"', '')
-            if stripped == '' || stripped == 'Known Templates:'
-              nil
-            else
-              stripped
-            end
-          end.compact
-        else
-          hash[:out].strip.split("\n").delete_if do |path|
-            not path =~ /tracetemplate/
-          end.map { |elm| elm.strip }
-        end
+        hash[:out].chomp.split("\n").map do |elm|
+          stripped = elm.strip.tr('"', '')
+          if stripped == '' || stripped == 'Known Templates:'
+            nil
+          else
+            stripped
+          end
+        end.compact
       end.call
     end
 

--- a/lib/run_loop/l10n.rb
+++ b/lib/run_loop/l10n.rb
@@ -70,31 +70,7 @@ module RunLoop
     end
 
     def uikit_bundle_l10n_path
-      developer_dir = xcode.developer_dir
-      if !developer_dir
-        nil
-      else
-        if xcode.version_gte_6?
-          File.join(developer_dir, UIKIT_AXBUNDLE_PATH_CORE_SIM)
-        else
-          ['7.1', '7.0', '6.1'].map do |sdk|
-            path = axbundle_path_for_sdk(developer_dir, sdk)
-            if File.exist?(path)
-              path
-            else
-              nil
-            end
-          end.compact.first
-        end
-      end
-    end
-
-    # Xcode 5.1.1 path.
-    def axbundle_path_for_sdk(developer_dir, sdk)
-      File.join(developer_dir,
-                'Platforms/iPhoneSimulator.platform/Developer/SDKs',
-                "iPhoneSimulator#{sdk}.sdk",
-                'System/Library/AccessibilityBundles/UIKit.axbundle')
+      File.join(xcode.developer_dir, UIKIT_AXBUNDLE_PATH_CORE_SIM)
     end
 
     def is_full_name?(two_letter_country_code)

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -37,7 +37,9 @@ module RunLoop
     end
 
     # @!visibility private
+    # @deprecated 2.0.10
     def xcode_version_gte_51?
+      RunLoop.deprecated("2.0.10", "No replacement.")
       xcode.version_gte_51?
     end
 
@@ -401,10 +403,6 @@ module RunLoop
     end
 
     def software_keyboard_enabled?(device)
-      unless xcode_version_gte_51?
-        raise RuntimeError, 'Keyboard enabling is only available on Xcode >= 6'
-      end
-
       plist = device.simulator_preferences_plist_path
       return false unless File.exist?(plist)
 

--- a/lib/run_loop/xcode.rb
+++ b/lib/run_loop/xcode.rb
@@ -175,10 +175,12 @@ module RunLoop
       version >= v60
     end
 
+    # @deprecated 2.0.10
     # Is the active Xcode version 5.1 or above?
     #
     # @return [Boolean] `true` if the current Xcode version is >= 5.1
     def version_gte_51?
+      RunLoop.deprecated("2.0.10", "No replacement")
       version >= v51
     end
 

--- a/scripts/ci/jenkins/run.sh
+++ b/scripts/ci/jenkins/run.sh
@@ -27,7 +27,8 @@ $RBENV_EXEC bundle exec rspec \
   spec/integration/otool_spec.rb \
   spec/integration/strings_spec.rb \
   spec/integration/app_spec.rb \
-  spec/integration/codesign_spec.rb
+  spec/integration/codesign_spec.rb \
+  spec/integration/core_spec.rb
 
 # CLI tests
 

--- a/spec/integration/core_spec.rb
+++ b/spec/integration/core_spec.rb
@@ -13,15 +13,10 @@ describe RunLoop::Core do
       actual = RunLoop::Core.automation_template(instruments)
       expect(actual).not_to be == nil
       expect(actual).not_to be == tracetemplate
-      if xcode.version_gte_6?
-        if xcode.beta?
-          expect(actual[/Automation.tracetemplate/, 0]).to be_truthy
-        else
-          expect(actual).to be == 'Automation'
-        end
-
+      if xcode.beta?
+        expect(actual[/Automation.tracetemplate/, 0]).to be_truthy
       else
-        expect(File.exist?(actual)).to be == true
+        expect(actual).to be == 'Automation'
       end
     end
   end
@@ -83,14 +78,10 @@ describe RunLoop::Core do
       it "Xcode #{xcode.version}" do
         instruments = Resources.shared.instruments
         default_template = RunLoop::Core.default_tracetemplate(instruments)
-        if xcode.version_gte_6?
-          if xcode.beta?
-            expect(File.exist?(default_template)).to be true
-          else
-            expect(default_template).to be == 'Automation'
-          end
-        else
+        if xcode.beta?
           expect(File.exist?(default_template)).to be true
+        else
+          expect(default_template).to be == 'Automation'
         end
       end
 
@@ -107,14 +98,10 @@ describe RunLoop::Core do
                 instruments = RunLoop::Instruments.new
                 default_template = RunLoop::Core.default_tracetemplate(instruments)
                 internal_xcode = RunLoop::Xcode.new
-                if internal_xcode.version_gte_6?
-                  if internal_xcode.beta?
-                    expect(File.exist?(default_template)).to be true
-                  else
-                    expect(default_template).to be == 'Automation'
-                  end
-                else
+                if internal_xcode.beta?
                   expect(File.exist?(default_template)).to be true
+                else
+                  expect(default_template).to be == 'Automation'
                 end
               }
             end

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -938,14 +938,7 @@ describe RunLoop::CoreSimulator do
 
       it '6.0 <= Xcode < 7.0' do
         expect(core_sim.xcode).to receive(:version_gte_7?).and_return false
-        expect(core_sim.xcode).to receive(:version_gte_6?).and_return true
         expect(core_sim.send(:sim_name)).to be == 'iOS Simulator'
-      end
-
-      it 'Xcode < 6.0' do
-        expect(core_sim.xcode).to receive(:version_gte_7?).and_return false
-        expect(core_sim.xcode).to receive(:version_gte_6?).and_return false
-        expect(core_sim.send(:sim_name)).to be == 'iPhone Simulator'
       end
     end
 

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -966,19 +966,8 @@ describe RunLoop::CoreSimulator do
 
         it '6.0 <= Xcode < 7.0' do
           expect(core_sim.xcode).to receive(:version_gte_7?).and_return false
-          expect(core_sim.xcode).to receive(:version_gte_6?).and_return true
 
           expected = '/Xcode/Applications/iOS Simulator.app'
-          expect(core_sim.send(:sim_app_path)).to be == expected
-          expect(core_sim.instance_variable_get(:@sim_app_path)).to be == expected
-          expect(core_sim.send(:sim_app_path)).to be == expected
-        end
-
-        it 'Xcode < 6.0' do
-          expect(core_sim.xcode).to receive(:version_gte_7?).and_return false
-          expect(core_sim.xcode).to receive(:version_gte_6?).and_return false
-
-          expected = '/Xcode/Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app'
           expect(core_sim.send(:sim_app_path)).to be == expected
           expect(core_sim.instance_variable_get(:@sim_app_path)).to be == expected
           expect(core_sim.send(:sim_app_path)).to be == expected

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -42,12 +42,6 @@ describe RunLoop::Core do
   end
 
   describe '.default_simulator' do
-    it 'Xcode < 6.0' do
-      expected = 'iPhone Retina (4-inch) - Simulator - iOS 7.1'
-      expect(xcode).to receive(:version).at_least(:once).and_return xcode.v51
-      expect(RunLoop::Core.default_simulator(xcode)).to be == expected
-    end
-
     it 'Xcode 6.0*' do
       expected = 'iPhone 5s (8.0 Simulator)'
       expect(xcode).to receive(:version).at_least(:once).and_return xcode.v60

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -307,42 +307,26 @@ describe RunLoop::Core do
   end
 
   describe '.expect_simulator_compatible_arch' do
-    let(:xcode) { RunLoop::Xcode.new }
-
     let(:device) { RunLoop::Device.new('Sim', '8.0', 'UDID') }
 
-    it 'is not implemented for Xcode < 6.0' do
-      expect(xcode).to receive(:version_gte_6?).and_return false
+    let(:fat_arm_app) { RunLoop::App.new(Resources.shared.app_bundle_path_arm_FAT) }
+    let(:i386_app) { RunLoop::App.new(Resources.shared.app_bundle_path_i386) }
 
-      actual = RunLoop::Core.expect_simulator_compatible_arch(nil, nil, xcode)
-      expect(actual).to be_falsey
+    it 'raises an error' do
+      expect(device).to receive(:instruction_set).and_return 'nonsense'
+
+      expect do
+        RunLoop::Core.expect_simulator_compatible_arch(device, fat_arm_app)
+      end.to raise_error RunLoop::IncompatibleArchitecture,
+                         /does not contain a compatible architecture for target device/
     end
 
-    describe 'CoreSimulator' do
+    it 'compatible' do
+      expect(device).to receive(:instruction_set).and_return 'i386'
 
-      let(:fat_arm_app) { RunLoop::App.new(Resources.shared.app_bundle_path_arm_FAT) }
-      let(:i386_app) { RunLoop::App.new(Resources.shared.app_bundle_path_i386) }
-
-      before do
-        expect(xcode).to receive(:version_gte_6?).and_return true
-      end
-
-      it 'raises an error' do
-        expect(device).to receive(:instruction_set).and_return 'nonsense'
-
-        expect do
-          RunLoop::Core.expect_simulator_compatible_arch(device, fat_arm_app, xcode)
-        end.to raise_error RunLoop::IncompatibleArchitecture,
-                           /does not contain a compatible architecture for target device/
-      end
-
-      it 'compatible' do
-        expect(device).to receive(:instruction_set).and_return 'i386'
-
-        expect do
-          RunLoop::Core.expect_simulator_compatible_arch(device, i386_app, xcode)
-        end.not_to raise_error
-      end
+      expect do
+        RunLoop::Core.expect_simulator_compatible_arch(device, i386_app)
+      end.not_to raise_error
     end
   end
 end

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -108,7 +108,6 @@ describe RunLoop::Core do
     let(:app) { options[:app] }
 
     before do
-      expect(xcode).to receive(:version).and_return xcode.v51
       expect(RunLoop::Core).to receive(:default_simulator).with(xcode).and_return 'Simulator'
     end
 

--- a/spec/lib/device_spec.rb
+++ b/spec/lib/device_spec.rb
@@ -181,7 +181,6 @@ describe RunLoop::Device do
       describe '6.0 <= Xcode < 7.0' do
         before do
           expect(xcode).to receive(:version_gte_7?).and_return false
-          expect(xcode).to receive(:version_gte_6?).and_return true
         end
 
         context 'with Major.Minor SDK version' do
@@ -193,16 +192,6 @@ describe RunLoop::Device do
           let(:device) { RunLoop::Device.new('Form Factor', '7.0.3', 'not a device udid', 'Shutdown') }
           it { is_expected.to be == 'Form Factor (7.0.3 Simulator)' }
         end
-      end
-
-      describe '5.1 <= Xcode < 6' do
-        before do
-          expect(xcode).to receive(:version_gte_7?).and_return false
-          expect(xcode).to receive(:version_gte_6?).and_return false
-        end
-
-        let(:device) { RunLoop::Device.new('Form Factor', '7.0.3', 'Xcode 5 Simulator', 'Shutdown') }
-        it { is_expected.to be == 'Xcode 5 Simulator' }
       end
     end
   end

--- a/spec/lib/instruments_spec.rb
+++ b/spec/lib/instruments_spec.rb
@@ -348,12 +348,9 @@ describe RunLoop::Instruments do
 
     before do
       expect(instruments).to receive(:xcrun).and_return xcrun
-      expect(instruments).to receive(:xcode).and_return xcode
     end
 
     it 'Xcode >= 6.0' do
-      expect(xcode).to receive(:version_gte_6?).at_least(:once).and_return true
-
       # TODO: Xcrun#exec no longer returns a hash with :err; stderr and stdout are combined
       hash =
             {
@@ -364,22 +361,6 @@ describe RunLoop::Instruments do
       expect(xcrun).to receive(:exec).with(args, options).and_return hash
 
       expected = RunLoop::RSpec::Instruments::TEMPLATES_GTE_60[:expected]
-      expect(instruments.templates).to be == expected
-      expect(instruments.instance_variable_get(:@instruments_templates)).to be == expected
-    end
-
-    it '5.1 <= Xcode < 6.0' do
-      expect(xcode).to receive(:version).at_least(:once).and_return xcode.v51
-
-      # TODO: Xcrun#exec no longer returns a hash with :err; stderr and stdout are combined
-      hash =
-            {
-                  :out => RunLoop::RSpec::Instruments::TEMPLATES_511[:output],
-                  :err => ''
-            }
-      expect(xcrun).to receive(:exec).with(args, options).and_return hash
-
-      expected = RunLoop::RSpec::Instruments::TEMPLATES_511[:expected]
       expect(instruments.templates).to be == expected
       expect(instruments.instance_variable_get(:@instruments_templates)).to be == expected
     end


### PR DESCRIPTION
### Motivation

Xcode 5 has not been supported for over a year.  Removing these checks makes adding new features easier.