### PR TITLE
Device is responsible for inferring which device to target

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -57,6 +57,7 @@ module RunLoop
       SCRIPTS[key]
     end
 
+    # @deprecated 2.0.10
     def self.detect_connected_device
       begin
         Timeout::timeout(1, RunLoop::TimeoutError) do

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -156,11 +156,9 @@ module RunLoop
       self.prepare(options)
 
       logger = options[:logger]
-      sim_control ||= options[:sim_control] || RunLoop::SimControl.new
-
-      xcode ||= options[:xcode] || sim_control.xcode
-
-      instruments = RunLoop::Instruments.new
+      sim_control = RunLoop::SimControl.new
+      xcode = sim_control.xcode
+      instruments = options[:instruments] || RunLoop::Instruments.new
       instruments.kill_instruments(xcode)
 
       device_target = options[:udid] || options[:device_target] || detect_connected_device || 'simulator'

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -129,6 +129,41 @@ Please update your sources.))
     end
 
     # @!visibility private
+    #
+    # Please don't call this method.  It is for internal use only.  The behavior
+    # may change at any time!  You have been warned.
+    #
+    # @param [Hash] options The launch options passed to RunLoop::Core
+    # @param [RunLoop::Xcode] xcode An Xcode instance
+    # @param [RunLoop::SimControl] simctl A SimControl instance
+    # @param [RunLoop::Instruments] instruments An Instruments instance
+    #
+    # @raise [ArgumentError] If "device" is detected as the device target and
+    #  there is no matching device.
+    # @raise [ArgumentError] If DEVICE_TARGET or options specify an identifier
+    #  that does not match an iOS Simulator or phyiscal device.
+    def self.detect_device(options, xcode, simctl, instruments)
+      device = self.device_from_opts_or_env(options)
+
+      # Passed an instance of RunLoop::Device
+      return device if device && device.is_a?(RunLoop::Device)
+
+      # Need to infer what what the user wants from the environment and options.
+      if device == "device"
+        identifier = self.detect_physical_device_on_usb
+        self.ensure_physical_device_connected(identifier, options)
+      elsif device.nil? || device == "" || device == "simulator"
+        identifier = RunLoop::Core.default_simulator(xcode)
+      else
+        identifier = device
+      end
+
+      # Raises ArgumentError if no matching device can be found.
+      self.device_with_identifier(identifier, sim_control: simctl,
+                                  instruments: instruments)
+    end
+
+    # @!visibility private
     def to_s
       if simulator?
         "#<Simulator: #{name} (#{version.to_s}) #{udid} #{instruction_set}>"
@@ -171,13 +206,13 @@ Please update your sources.))
     # Is this a physical device?
     # @return [Boolean] Returns true if this is a device.
     def physical_device?
-      not udid[DEVICE_UDID_REGEX, 0].nil?
+      !udid[DEVICE_UDID_REGEX, 0].nil?
     end
 
     # Is this a simulator?
     # @return [Boolean] Returns true if this is a simulator.
     def simulator?
-      not physical_device?
+      !physical_device?
     end
 
     # Return the instruction set for this device.
@@ -570,5 +605,78 @@ Please update your sources.))
 
     # TODO Is this a good idea?  It speeds up rspec tests by a factor of ~2x...
     SIM_CONTROL = RunLoop::SimControl.new
+
+    # @!visibility private
+    def self.device_from_options(options)
+      options[:device] || options[:device_target] || options[:udid]
+    end
+
+    # @!visibility private
+    def self.device_from_environment
+      RunLoop::Environment.device_target
+    end
+
+    # @!visibility private
+    def self.device_from_opts_or_env(options)
+      self.device_from_options(options) || self.device_from_environment
+    end
+
+    # @!visibility private
+    UDID_DETECT = File.expand_path(File.join(File.dirname(__FILE__), "..", "..", 'scripts', "udidetect"))
+
+    # @!visibility private
+    def self.detect_physical_device_on_usb
+      require "command_runner"
+
+      udid = nil
+      begin
+        hash = CommandRunner.run([UDID_DETECT], timeout: 1)
+        udid = hash[:out].chomp
+        if udid == ""
+          udid = nil
+        end
+      rescue => e
+        RunLoop.log_debug("Running `udidetect` raised: #{e}")
+      ensure
+        `killall udidetect &> /dev/null`
+      end
+      udid
+    end
+
+    # @!visibility private
+    def self.ensure_physical_device_connected(identifier, options)
+      if identifier.nil?
+        env = self.device_from_environment
+        if env == "device"
+          message = "DEVICE_TARGET=device means that you want to test on physical device"
+        elsif env && env[DEVICE_UDID_REGEX, 0]
+          message = "DEVICE_TARGET=#{env} did not match any connected device"
+        else
+          if options[:device]
+            key = ":device"
+          elsif options[:device_target]
+            key = ":device_target"
+          else
+            key = ":udid"
+          end
+          message = "#{key} => \"device\" means that you want to test on a physical device"
+        end
+
+        raise ArgumentError, %Q[Expected a physical device to be connected via USB.
+
+#{message}
+
+1. Is your device connected?
+2. Does your device appear in the output of `xcrun instruments -s devices`?
+3. Does your device appear in Xcode > Windows > Devices without a warning message?
+
+Please see the documentation about testing on physical devices.
+
+https://github.com/calabash/calabash-ios/wiki/Testing-on-Physical-Devices
+]
+      end
+      true
+    end
   end
 end
+


### PR DESCRIPTION
### Motivation

The responsibility for inferring which device to target is spread across Calabash and RunLoop.  This PR centralizes the rules in the Device class.  The `Device#detect_device` method inspects the launch options and the ENV to determine which device to launch the AUT on. 

This work is being done in the context of Calabash 2.0 support and CBXDriver support.