### PR TITLE
DetectAUT.detect_app_under_test

### DIFF
--- a/lib/run_loop/detect_aut/detect.rb
+++ b/lib/run_loop/detect_aut/detect.rb
@@ -4,6 +4,24 @@ module RunLoop
   module DetectAUT
 
     # @!visibility private
+    def self.detect_app_under_test(options)
+      app = self.detect_app(options)
+      if app.is_a?(RunLoop::App) || app.is_a?(RunLoop::Ipa)
+        {
+          :app => app,
+          :bundle_id => app.bundle_identifier,
+          :ipa => app.is_a?(RunLoop::Ipa)
+        }
+      else
+        {
+          :app => nil,
+          :bundle_id => app,
+          :ipa => false
+        }
+      end
+    end
+
+    # @!visibility private
     class Detect
       include RunLoop::DetectAUT::Errors
       include RunLoop::DetectAUT::XamarinStudio
@@ -101,6 +119,60 @@ module RunLoop
         Array.new(search_depth) do |depth|
           File.join(base_dir, *Array.new(depth) { |_| "*"}, "*.app")
         end
+      end
+    end
+
+    private
+
+    # @!visibility private
+    def self.app_from_options(options)
+      options[:app] || options[:bundle_id]
+    end
+
+    # @!visibility private
+    def self.app_from_environment
+      RunLoop::Environment.path_to_app_bundle ||
+        RunLoop::Environment.bundle_id
+    end
+
+    # @!visibility private
+    def self.app_from_constant
+      (defined?(APP_BUNDLE_PATH) && APP_BUNDLE_PATH) ||
+        (defined?(APP) && APP)
+    end
+
+    # @!visibility private
+    def self.app_from_opts_or_env_or_constant(options)
+       self.app_from_options(options) ||
+         self.app_from_environment ||
+         self.app_from_constant
+    end
+
+    # @!visibility private
+    def self.detector
+      RunLoop::DetectAUT::Detect.new
+    end
+
+    # @!visibility private
+    def self.detect_app(options)
+      app = self.app_from_opts_or_env_or_constant(options)
+
+      # Options or constant defined an instance of App or Ipa
+      return app if app && (app.is_a?(RunLoop::App) || app.is_a?(RunLoop::Ipa))
+
+      # User provided no information, so we attempt to auto detect
+      if app.nil? || app == ""
+        return self.detector.app_for_simulator
+      end
+
+      extension = File.extname(app)
+      if extension == ".ipa" && File.exist?(app)
+        RunLoop::Ipa.new(app)
+      elsif extension == ".app" && File.exist?(app)
+        RunLoop::App.new(app)
+      else
+        # Probably a bundle identifier.
+        app
       end
     end
   end

--- a/spec/lib/detect_aut/detect_spec.rb
+++ b/spec/lib/detect_aut/detect_spec.rb
@@ -185,4 +185,235 @@ describe RunLoop::DetectAUT::Detect do
       expect(actual).to be == expected
     end
   end
+
+  describe "detecting the AUT" do
+    let(:app_path) { Resources.shared.app_bundle_path }
+    let(:app) { RunLoop::App.new(app_path) }
+    let(:app_bundle_id) { app.bundle_identifier }
+
+    let(:ipa_path) { Resources.shared.ipa_path }
+    let(:ipa) { RunLoop::Ipa.new(ipa_path) }
+    let(:ipa_bundle_id) { ipa.bundle_identifier }
+    let(:options) do
+      {
+        :app => app_path,
+        :bundle_id => app_bundle_id
+      }
+    end
+
+    describe ".app_from_options" do
+      it ":app" do
+        actual = RunLoop::DetectAUT.send(:app_from_options, options)
+        expect(actual).to be == options[:app]
+      end
+
+      it ":bundle_id" do
+        options[:app] = nil
+        actual = RunLoop::DetectAUT.send(:app_from_options, options)
+        expect(actual).to be == options[:bundle_id]
+      end
+    end
+
+    describe ".app_from_environment" do
+      it "APP or APP_BUNDLE_PATH" do
+        expect(RunLoop::Environment).to receive(:path_to_app_bundle).and_return(app_path)
+
+        actual = RunLoop::DetectAUT.send(:app_from_environment)
+        expect(actual).to be == app_path
+      end
+
+      it "BUNDLE_ID" do
+        expect(RunLoop::Environment).to receive(:path_to_app_bundle).and_return(nil)
+        expect(RunLoop::Environment).to receive(:bundle_id).and_return(app_bundle_id)
+
+        actual = RunLoop::DetectAUT.send(:app_from_environment)
+        expect(actual).to be == app_bundle_id
+      end
+    end
+
+    # Untestable?
+    # describe ".app_from_constant" do
+    #   let(:world_with_app) do
+    #     Class.new do
+    #       APP = Resources.shared.app_bundle_path
+    #       def self.app_from_constant
+    #         RunLoop::DetectAUT.send(:app_from_constant)
+    #       end
+    #     end
+    #   end
+    #
+    #   let(:world_with_app_bundle_path) do
+    #     Class.new do
+    #       APP_BUNDLE_PATH = Resources.shared.app_bundle_path
+    #       def self.app_from_constant
+    #         RunLoop::DetectAUT.send(:app_from_constant)
+    #       end
+    #     end
+    #   end
+    #
+    #   after do
+    #     if Object.constants.include?(world_with_app)
+    #       Object.send(:remove_const, world_with_app)
+    #     end
+    #
+    #     if Object.constants.include?(world_with_app_bundle_path)
+    #       Object.send(:remove_const, world_with_app_bundle_path)
+    #     end
+    #   end
+    #
+    #   it "APP and APP_BUNDLE_PATH not defined" do
+    #     actual = RunLoop::DetectAUT.send(:app_from_constant)
+    #     expect(actual).to be == nil
+    #   end
+    #
+    #   it "APP defined and non-nil" do
+    #     actual = world_with_app.send(:app_from_constant)
+    #     expect(actual).to be == app_path
+    #   end
+    #
+    #   it "APP_BUNDLE_PATH defined and non-nil" do
+    #     actual = world_with_app_bundle_path.send(:app_from_constant)
+    #     expect(actual).to be == app_path
+    #   end
+    # end
+
+    describe ".app_from_opts_or_env_or_constant" do
+      it "app is defined in options" do
+        expect(RunLoop::DetectAUT).to receive(:app_from_options).and_return(app)
+
+        actual = RunLoop::DetectAUT.send(:app_from_opts_or_env_or_constant, options)
+        expect(actual).to be == app
+      end
+
+      it "app is defined in environment" do
+        expect(RunLoop::DetectAUT).to receive(:app_from_options).and_return(nil)
+        expect(RunLoop::DetectAUT).to receive(:app_from_environment).and_return(app)
+
+        actual = RunLoop::DetectAUT.send(:app_from_opts_or_env_or_constant, options)
+        expect(actual).to be == app
+      end
+
+      it "app is defined as constant" do
+        expect(RunLoop::DetectAUT).to receive(:app_from_options).and_return(nil)
+        expect(RunLoop::DetectAUT).to receive(:app_from_environment).and_return(nil)
+        expect(RunLoop::DetectAUT).to receive(:app_from_constant).and_return(app)
+
+        actual = RunLoop::DetectAUT.send(:app_from_opts_or_env_or_constant, options)
+        expect(actual).to be == app
+      end
+
+      it "app is not defined anywhere" do
+        expect(RunLoop::DetectAUT).to receive(:app_from_options).and_return(nil)
+        expect(RunLoop::DetectAUT).to receive(:app_from_environment).and_return(nil)
+        expect(RunLoop::DetectAUT).to receive(:app_from_constant).and_return(nil)
+
+        actual = RunLoop::DetectAUT.send(:app_from_opts_or_env_or_constant, options)
+        expect(actual).to be == nil
+      end
+    end
+
+    describe ".detect_app" do
+      describe "defined some where" do
+        it "is an App" do
+          expect(RunLoop::DetectAUT).to receive(:app_from_opts_or_env_or_constant).with(options).and_return(app)
+
+          actual = RunLoop::DetectAUT.send(:detect_app, options)
+          expect(actual).to be == app
+        end
+
+        it "is an Ipa" do
+          expect(RunLoop::DetectAUT).to receive(:app_from_opts_or_env_or_constant).with(options).and_return(ipa)
+
+          actual = RunLoop::DetectAUT.send(:detect_app, options)
+          expect(actual).to be == ipa
+        end
+
+        it "is an app path" do
+          expect(RunLoop::DetectAUT).to receive(:app_from_opts_or_env_or_constant).with(options).and_return(app_path)
+
+          actual = RunLoop::DetectAUT.send(:detect_app, options)
+          expect(actual).to be_a_kind_of(RunLoop::App)
+          expect(actual.bundle_identifier).to be == app.bundle_identifier
+        end
+
+        it "is an ipa path" do
+          expect(RunLoop::DetectAUT).to receive(:app_from_opts_or_env_or_constant).with(options).and_return(ipa_path)
+
+          actual = RunLoop::DetectAUT.send(:detect_app, options)
+          expect(actual).to be_a_kind_of(RunLoop::Ipa)
+          expect(actual.bundle_identifier).to be == ipa.bundle_identifier
+        end
+
+        it "is a bundle identifier" do
+          expect(RunLoop::DetectAUT).to receive(:app_from_opts_or_env_or_constant).with(options).and_return(app_bundle_id)
+
+          actual = RunLoop::DetectAUT.send(:detect_app, options)
+          expect(actual).to be == app_bundle_id
+        end
+      end
+
+      describe "it is not defined" do
+        let(:detector) { RunLoop::DetectAUT::Detect.new }
+
+        before do
+          allow(RunLoop::DetectAUT).to receive(:detector).and_return(detector)
+        end
+
+        it "is auto detected" do
+          expect(detector).to receive(:app_for_simulator).twice.and_return(app)
+
+          expect(RunLoop::DetectAUT).to receive(:app_from_opts_or_env_or_constant).with(options).and_return(nil)
+          actual = RunLoop::DetectAUT.send(:detect_app, options)
+          expect(actual).to be == app
+
+          expect(RunLoop::DetectAUT).to receive(:app_from_opts_or_env_or_constant).with(options).and_return("")
+          actual = RunLoop::DetectAUT.send(:detect_app, options)
+          expect(actual).to be == app
+        end
+
+        it "is not auto detected" do
+          expect(RunLoop::DetectAUT).to receive(:app_from_opts_or_env_or_constant).with(options).and_return("")
+          expect(detector).to receive(:app_for_simulator).and_raise(RuntimeError)
+
+          expect do
+            RunLoop::DetectAUT.send(:detect_app, options)
+          end.to raise_error RuntimeError
+        end
+      end
+
+      describe ".detect_app_under_test" do
+        describe "App or Ipa instance" do
+          it "App" do
+            expect(RunLoop::DetectAUT).to receive(:detect_app).with(options).and_return(app)
+
+            hash = RunLoop::DetectAUT.detect_app_under_test(options)
+
+            expect(hash[:app]).to be == app
+            expect(hash[:bundle_id]).to be == app_bundle_id
+            expect(hash[:ipa]).to be == false
+          end
+
+          it "Ipa" do
+            expect(RunLoop::DetectAUT).to receive(:detect_app).with(options).and_return(ipa)
+
+            hash = RunLoop::DetectAUT.detect_app_under_test(options)
+
+            expect(hash[:app]).to be == ipa
+            expect(hash[:bundle_id]).to be == ipa_bundle_id
+            expect(hash[:ipa]).to be == true
+          end
+        end
+
+        it "bundle identifier" do
+          expect(RunLoop::DetectAUT).to receive(:detect_app).with(options).and_return(app_bundle_id)
+
+          hash = RunLoop::DetectAUT.detect_app_under_test(options)
+
+          expect(hash[:app]).to be == nil
+          expect(hash[:bundle_id]).to be == app_bundle_id
+          expect(hash[:ipa]).to be == false
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Motivation

This is a high-level API to infer what app is under test.

At the moment Calabash + RunLoop share responsibility for determining what app is under test.

The user can indicate the AUT using:

* APP, APP_BUNDLE_PATH, and BUNDLE_ID environment variables
* APP_BUNDLE_PATH constant
* `:app`, `:bundle_id`, and `:app_bundle_path` launch options

Further, Calabash users expect their .app bundles to be autodetected.

At the moment, the code to sort out all this options is more than a bit confusing and is _duplicated in run-loop and calabash-ios_.

XCUITest/CBXDriver and Calabash 2.0 will add more options/ENV vars.

This PR is part of an on-going effort to simplify the interaction between RunLoop and calabash-cucumber/launcher.rb.