### PR TITLE
Core.detect_uia_strategy given options and RunLoop::Device

### DIFF
--- a/spec/resources.rb
+++ b/spec/resources.rb
@@ -114,7 +114,15 @@ class Resources
   end
 
   def bundle_id
-    @bundle_id = 'com.xamarin.CalSmoke-cal'
+    @bundle_id ||= 'com.xamarin.CalSmoke-cal'
+  end
+
+  def simulator
+    RunLoop::Device.new("iPhone 4s", "8.3", "CE5BA25E-9434-475A-8947-ECC3918E64E3")
+  end
+
+  def device
+    RunLoop::Device.new("denis", "8.3", "893688959205dc7eb48d603c558ede919ad8dd0c")
   end
 
   def global_preferences_plist


### PR DESCRIPTION
### Motivation

RunLoop should be responsible for determining the `:uia_strategy` given the launch options and the environment.

At the moment both Calabash 2.0 and Calabash 0.x implement this logic.  Further, in both cases, the logic requires calls to RunLoop to determine what the target device is and the Xcode version.

This change is made in the context of reducing the complexity in calabash-cucumber/launcher.rb to make space for launching with XCUITest/CBXDriver.