### PR TITLE
Core.run_with_options improve the way AUT and DUT are inferred

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -736,5 +736,16 @@ Logfile: #{log_file}
       end
       strategy
     end
+
+    # @!visibility private
+    #
+    # @param [Hash] options The launch options passed to .run_with_options
+    def self.detect_reset_options(options)
+      return options[:reset] if options.has_key?(:reset)
+
+      return options[:reset_app_sandbox] if options.has_key?(:reset_app_sandbox)
+
+      RunLoop::Environment.reset_between_scenarios?
+    end
   end
 end

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -145,8 +145,8 @@ module RunLoop
       self.prepare(options)
 
       logger = options[:logger]
-      sim_control = RunLoop::SimControl.new
-      xcode = sim_control.xcode
+      sim_control = options[:sim_control] || options[:simctl] || RunLoop::SimControl.new
+      xcode = options[:xcode] || RunLoop::Xcode.new
       instruments = options[:instruments] || RunLoop::Instruments.new
       instruments.kill_instruments(xcode)
 

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -57,21 +57,6 @@ module RunLoop
       SCRIPTS[key]
     end
 
-    # Raise an error if the application binary is not compatible with the
-    # target simulator.
-    #
-    # @param [RunLoop::Device] device The device to install on.
-    # @param [RunLoop::App] app The app to install.
-    #
-    # @raise [RunLoop::IncompatibleArchitecture] Raises an error if the
-    #  application binary is not compatible with the target simulator.
-    def self.expect_simulator_compatible_arch(device, app)
-      lipo = RunLoop::Lipo.new(app.path)
-      lipo.expect_compatible_arch(device)
-
-      RunLoop.log_debug("Simulator instruction set '#{device.instruction_set}' is compatible with '#{lipo.info}'")
-    end
-
     def self.run_with_options(options)
       before = Time.now
 
@@ -724,6 +709,22 @@ Logfile: #{log_file}
 
       # If CoreSimulator has already launched the simulator, it will not launch it again.
       core_sim.launch_simulator
+    end
+
+    # @!visibility private
+    # Raise an error if the application binary is not compatible with the
+    # target simulator.
+    #
+    # @param [RunLoop::Device] device The device to install on.
+    # @param [RunLoop::App] app The app to install.
+    #
+    # @raise [RunLoop::IncompatibleArchitecture] Raises an error if the
+    #  application binary is not compatible with the target simulator.
+    def self.expect_simulator_compatible_arch(device, app)
+      lipo = RunLoop::Lipo.new(app.path)
+      lipo.expect_compatible_arch(device)
+
+      RunLoop.log_debug("Simulator instruction set '#{device.instruction_set}' is compatible with '#{lipo.info}'")
     end
   end
 end

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -72,73 +72,6 @@ module RunLoop
       RunLoop.log_debug("Simulator instruction set '#{device.instruction_set}' is compatible with '#{lipo.info}'")
     end
 
-    # Prepares the simulator for running.
-    #
-    # 1. enabling accessibility and software keyboard
-    # 2. installing / uninstalling apps
-    def self.prepare_simulator(launch_options, sim_control)
-
-      xcode = sim_control.xcode
-
-      # Respect option passed from Calabash
-      if launch_options[:relaunch_simulator]
-        sim_control.quit_sim
-      end
-
-      app_bundle_path = launch_options[:bundle_dir_or_bundle_id]
-      app = RunLoop::App.new(app_bundle_path)
-
-      unless app.valid?
-        if !File.exist?(app.path)
-          message = "App '#{app_bundle_path}' does not exist."
-        else
-          message = "App '#{app_bundle_path}' is not a valid .app bundle"
-        end
-        raise RuntimeError, message
-      end
-
-      udid = launch_options[:udid]
-
-      device = sim_control.simulators.find do |sim|
-        sim.udid == udid || sim.instruments_identifier(xcode) == udid
-      end
-
-      if device.nil?
-        raise RuntimeError,
-              "Could not find simulator with name or UDID that matches: '#{udid}'"
-      end
-
-      # Validate the architecture.
-      self.expect_simulator_compatible_arch(device, app)
-
-      # Quits the simulator.
-      core_sim = RunLoop::CoreSimulator.new(device, app)
-
-      # :reset is a legacy variable; has been replaced with :reset_app_sandbox
-      if launch_options[:reset] || launch_options[:reset_app_sandbox]
-        core_sim.reset_app_sandbox
-      end
-
-      # Will quit the simulator if it is running.
-      # @todo fix accessibility_enabled? so we don't have to quit the sim
-      # SimControl#accessibility_enabled? is always false during Core#prepare_simulator
-      # https://github.com/calabash/run_loop/issues/167
-      sim_control.ensure_accessibility(device)
-
-      # Will quit the simulator if it is running.
-      # @todo fix software_keyboard_enabled? so we don't have to quit the sim
-      # SimControl#software_keyboard_enabled? is always false during Core#prepare_simulator
-      # https://github.com/calabash/run_loop/issues/168
-      sim_control.ensure_software_keyboard(device)
-
-      # Launches the simulator if the app is not installed.
-      core_sim.install
-
-      # If CoreSimulator has already launched the simulator, it will not
-      # launching it again.
-      core_sim.launch_simulator
-    end
-
     def self.run_with_options(options)
       before = Time.now
 
@@ -754,6 +687,43 @@ Logfile: #{log_file}
       return options[:reset_app_sandbox] if options.has_key?(:reset_app_sandbox)
 
       RunLoop::Environment.reset_between_scenarios?
+    end
+
+    # Prepares the simulator for running.
+    #
+    # 1. enabling accessibility and software keyboard
+    # 2. installing / uninstalling apps
+    def self.prepare_simulator(app, device, xcode, simctl, reset_options)
+
+      # Validate the architecture.
+      self.expect_simulator_compatible_arch(device, app)
+
+      # Quits the simulator.
+      core_sim = RunLoop::CoreSimulator.new(device, app, :xcode => xcode)
+
+      # Calabash 0.x can only reset the app sandbox (true/false).
+      # Calabash 2.x has advanced reset options.
+      if reset_options
+        core_sim.reset_app_sandbox
+      end
+
+      # Will quit the simulator if it is running.
+      # @todo fix accessibility_enabled? so we don't have to quit the sim
+      # SimControl#accessibility_enabled? is always false during Core#prepare_simulator
+      # https://github.com/calabash/run_loop/issues/167
+      simctl.ensure_accessibility(device)
+
+      # Will quit the simulator if it is running.
+      # @todo fix software_keyboard_enabled? so we don't have to quit the sim
+      # SimControl#software_keyboard_enabled? is always false during Core#prepare_simulator
+      # https://github.com/calabash/run_loop/issues/168
+      simctl.ensure_software_keyboard(device)
+
+      # Launches the simulator if the app is not installed.
+      core_sim.install
+
+      # If CoreSimulator has already launched the simulator, it will not launch it again.
+      core_sim.launch_simulator
     end
   end
 end

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -331,44 +331,6 @@ Logfile: #{log_file}
       true
     end
 
-    # @!visibility private
-    # Are we targeting a simulator?
-    #
-    # @note  The behavior of this method is different than the corresponding
-    #   method in Calabash::Cucumber::Launcher method.  If
-    #   `:device_target => {nil | ''}`, then the calabash-ios method returns
-    #   _false_.  I am basing run-loop's behavior off the behavior in
-    #   `self.udid_and_bundle_for_launcher`
-    #
-    # @see {Core::RunLoop.udid_and_bundle_for_launcher}
-    #
-    # @todo sim_control argument is no longer necessary and can be removed.
-    def self.simulator_target?(run_options, sim_control=nil)
-      value = run_options[:device_target]
-
-      # Match the behavior of udid_and_bundle_for_launcher.
-      return true if value.nil? or value == ''
-
-      # 5.1 <= Xcode < 7.0
-      return true if value.downcase.include?('simulator')
-
-      # Not a physical device.
-      return false if value[DEVICE_UDID_REGEX, 0] != nil
-
-      # Check for named simulators and Xcode >= 7.0 simulators.
-      sim_control = run_options[:sim_control] || RunLoop::SimControl.new
-      xcode = sim_control.xcode
-      simulator = sim_control.simulators.find do |sim|
-        [
-          sim.instruments_identifier(xcode) == value,
-          sim.udid == value,
-          sim.name == value
-        ].any?
-      end
-      !simulator.nil?
-    end
-
-
     # Extracts the value of :inject_dylib from options Hash.
     # @param options [Hash] arguments passed to {RunLoop.run}
     # @return [String, nil] If the options contains :inject_dylibs and it is a
@@ -625,7 +587,7 @@ Logfile: #{log_file}
     end
 
     # @deprecated 2.1.0
-    # Replaced with Device.detect_phyical_device_on_usb
+    # Replaced with Device.detect_physical_device_on_usb
     def self.detect_connected_device
       begin
         Timeout::timeout(1, RunLoop::TimeoutError) do
@@ -635,6 +597,46 @@ Logfile: #{log_file}
         `killall udidetect &> /dev/null`
       end
       nil
+    end
+
+    # @deprecated 2.1.0
+    # @!visibility private
+    # Are we targeting a simulator?
+    #
+    # @note  The behavior of this method is different than the corresponding
+    #   method in Calabash::Cucumber::Launcher method.  If
+    #   `:device_target => {nil | ''}`, then the calabash-ios method returns
+    #   _false_.  I am basing run-loop's behavior off the behavior in
+    #   `self.udid_and_bundle_for_launcher`
+    #
+    # @see {Core::RunLoop.udid_and_bundle_for_launcher}
+    #
+    # @todo sim_control argument is no longer necessary and can be removed.
+    def self.simulator_target?(run_options, sim_control=nil)
+      # TODO Enable deprecation warning
+      # RunLoop.deprecated("2.1.0", "No replacement")
+      value = run_options[:device_target]
+
+      # Match the behavior of udid_and_bundle_for_launcher.
+      return true if value.nil? or value == ''
+
+      # 5.1 <= Xcode < 7.0
+      return true if value.downcase.include?('simulator')
+
+      # Not a physical device.
+      return false if value[DEVICE_UDID_REGEX, 0] != nil
+
+      # Check for named simulators and Xcode >= 7.0 simulators.
+      sim_control = run_options[:sim_control] || RunLoop::SimControl.new
+      xcode = sim_control.xcode
+      simulator = sim_control.simulators.find do |sim|
+        [
+          sim.instruments_identifier(xcode) == value,
+          sim.udid == value,
+          sim.name == value
+        ].any?
+      end
+      !simulator.nil?
     end
 
     # @!visibility private

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -419,25 +419,6 @@ Logfile: #{log_file}
       end
     end
 
-    def self.udid_and_bundle_for_launcher(device_target, options, sim_control=RunLoop::SimControl.new)
-      xcode = sim_control.xcode
-
-      bundle_dir_or_bundle_id = options[:app] || RunLoop::Environment.bundle_id || RunLoop::Environment.path_to_app_bundle
-
-      unless bundle_dir_or_bundle_id
-        raise 'key :app or environment variable APP_BUNDLE_PATH, BUNDLE_ID or APP must be specified as path to app bundle (simulator) or bundle id (device)'
-      end
-
-      if device_target.nil? || device_target.empty? || device_target == 'simulator'
-        device_target = self.default_simulator(xcode)
-      end
-      udid = device_target
-
-      unless self.simulator_target?(options)
-        bundle_dir_or_bundle_id = options[:bundle_id] if options[:bundle_id]
-      end
-      return udid, bundle_dir_or_bundle_id
-    end
 
     def self.create_uia_pipe(repl_path)
       begin
@@ -643,7 +624,7 @@ Logfile: #{log_file}
       raise message.join("\n")
     end
 
-    # @deprecated 2.0.10
+    # @deprecated 2.1.0
     # Replaced with Device.detect_phyical_device_on_usb
     def self.detect_connected_device
       begin
@@ -654,6 +635,31 @@ Logfile: #{log_file}
         `killall udidetect &> /dev/null`
       end
       nil
+    end
+
+    # @!visibility private
+    # @deprecated 2.1.0
+    #
+    # Do not call this method.
+    def self.udid_and_bundle_for_launcher(device_target, options, sim_control=RunLoop::SimControl.new)
+      RunLoop.deprecated("2.1.0", "No replacement")
+      xcode = sim_control.xcode
+
+      bundle_dir_or_bundle_id = options[:app] || RunLoop::Environment.bundle_id || RunLoop::Environment.path_to_app_bundle
+
+      unless bundle_dir_or_bundle_id
+        raise 'key :app or environment variable APP_BUNDLE_PATH, BUNDLE_ID or APP must be specified as path to app bundle (simulator) or bundle id (device)'
+      end
+
+      if device_target.nil? || device_target.empty? || device_target == 'simulator'
+        device_target = self.default_simulator(xcode)
+      end
+      udid = device_target
+
+      unless self.simulator_target?(options)
+        bundle_dir_or_bundle_id = options[:bundle_id] if options[:bundle_id]
+      end
+      return udid, bundle_dir_or_bundle_id
     end
 
     # @deprecated 1.0.5

--- a/lib/run_loop/detect_aut/detect.rb
+++ b/lib/run_loop/detect_aut/detect.rb
@@ -10,13 +10,13 @@ module RunLoop
         {
           :app => app,
           :bundle_id => app.bundle_identifier,
-          :ipa => app.is_a?(RunLoop::Ipa)
+          :is_ipa => app.is_a?(RunLoop::Ipa)
         }
       else
         {
           :app => nil,
           :bundle_id => app,
-          :ipa => false
+          :is_ipa => false
         }
       end
     end

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -48,6 +48,11 @@ module RunLoop
       end
     end
 
+    # Should the app data be reset between Scenarios?
+    def self.reset_between_scenarios?
+      ENV["RESET_BETWEEN_SCENARIOS"] == "1"
+    end
+
     # Returns the value of XCODEPROJ which can be used to specify an Xcode
     # project directory (my.xcodeproj).
     #

--- a/lib/run_loop/instruments.rb
+++ b/lib/run_loop/instruments.rb
@@ -300,29 +300,7 @@ module RunLoop
       array = ['instruments']
       array << '-w'
 
-      # Xcode 7 simulators must be launched with UDID to avoid
-      # Ambiguous device name/identifier errors (from instruments)
-      if xcode.version_gte_7?
-        udid = options[:udid]
-
-        if udid[DEVICE_UDID_REGEX, 0]
-          array << udid
-        else
-          match = simulators.find do |simulator|
-            [simulator.name == udid,
-             simulator.udid == udid,
-             simulator.instruments_identifier(xcode) == udid].any?
-          end
-
-          if match
-            array << match.udid
-          else
-            array << udid
-          end
-        end
-      else
-        array << options[:udid]
-      end
+      array << options[:udid]
 
       trace = options[:results_dir_trace]
       if trace
@@ -333,7 +311,7 @@ module RunLoop
       array << '-t'
       array << automation_template
 
-      array << options[:bundle_dir_or_bundle_id]
+      array << options[:bundle_id]
 
       {
             'UIARESULTSPATH' => options[:results_dir],

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -165,34 +165,6 @@ describe RunLoop::Core do
     end
   end
 
-  describe '.udid_and_bundle_for_launcher' do
-    let(:options) { {:app => Resources.shared.cal_app_bundle_path} }
-    let(:app) { options[:app] }
-
-    before do
-      expect(RunLoop::Core).to receive(:default_simulator).with(xcode).and_return 'Simulator'
-    end
-
-
-    it 'target is nil' do
-      udid, app_bundle = RunLoop::Core.udid_and_bundle_for_launcher(nil, options, sim_control)
-      expect(udid).to be == 'Simulator'
-      expect(app_bundle).to be == app
-    end
-
-    it "target is ''" do
-      udid, app_bundle = RunLoop::Core.udid_and_bundle_for_launcher('', options, sim_control)
-      expect(udid).to be == 'Simulator'
-      expect(app_bundle).to be == app
-    end
-
-    it "target is 'simulator'" do
-      udid, app_bundle = RunLoop::Core.udid_and_bundle_for_launcher('simulator', options, sim_control)
-      expect(udid).to be == 'Simulator'
-      expect(app_bundle).to be == app
-    end
-  end
-
   describe '.above_or_eql_version?' do
     subject(:a) { RunLoop::Version.new('5.1.1') }
     subject(:b) { RunLoop::Version.new('6.0') }

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -391,4 +391,50 @@ describe RunLoop::Core do
       end.not_to raise_error
     end
   end
+
+  describe ".detect_reset_options" do
+    let(:options) { {reset: true, reset_app_sandbox: true} }
+
+    describe ":reset" do
+      it "true" do
+        expect(RunLoop::Core.detect_reset_options(options)).to be_truthy
+      end
+
+      it "false" do
+        options[:reset] = false
+        expect(RunLoop::Core.detect_reset_options(options)).to be_falsey
+      end
+    end
+
+    describe ":reset_app_sandbox" do
+      before { options.delete(:reset) }
+      it "true" do
+        expect(RunLoop::Core.detect_reset_options(options)).to be_truthy
+      end
+
+      it "false" do
+        options[:reset_app_sandbox] = false
+        expect(RunLoop::Core.detect_reset_options(options)).to be_falsey
+      end
+    end
+
+    describe "RESET_BETWEEN_SCENARIOS" do
+      before do
+        options.delete(:reset)
+        options.delete(:reset_app_sandbox)
+      end
+
+      it "'1'" do
+        expect(RunLoop::Environment).to receive(:reset_between_scenarios?).and_return(true)
+
+        expect(RunLoop::Core.detect_reset_options(options)).to be_truthy
+      end
+
+      it "not '1'" do
+        expect(RunLoop::Environment).to receive(:reset_between_scenarios?).and_return(false)
+
+        expect(RunLoop::Core.detect_reset_options(options)).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/lib/detect_aut/detect_spec.rb
+++ b/spec/lib/detect_aut/detect_spec.rb
@@ -390,7 +390,7 @@ describe RunLoop::DetectAUT::Detect do
 
             expect(hash[:app]).to be == app
             expect(hash[:bundle_id]).to be == app_bundle_id
-            expect(hash[:ipa]).to be == false
+            expect(hash[:is_ipa]).to be == false
           end
 
           it "Ipa" do
@@ -400,7 +400,7 @@ describe RunLoop::DetectAUT::Detect do
 
             expect(hash[:app]).to be == ipa
             expect(hash[:bundle_id]).to be == ipa_bundle_id
-            expect(hash[:ipa]).to be == true
+            expect(hash[:is_ipa]).to be == true
           end
         end
 
@@ -411,7 +411,7 @@ describe RunLoop::DetectAUT::Detect do
 
           expect(hash[:app]).to be == nil
           expect(hash[:bundle_id]).to be == app_bundle_id
-          expect(hash[:ipa]).to be == false
+          expect(hash[:is_ipa]).to be == false
         end
       end
     end

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -91,6 +91,20 @@ describe RunLoop::Environment do
     end
   end
 
+  describe ".reset_between_scenarios?" do
+    it "true" do
+      stub_env({"RESET_BETWEEN_SCENARIOS" => "1"})
+      expect(RunLoop::Environment.reset_between_scenarios?).to be_truthy
+    end
+
+    it "false" do
+      stub_env({"RESET_BETWEEN_SCENARIOS" => ""})
+      expect(RunLoop::Environment.reset_between_scenarios?).to be_falsey
+
+      stub_env({"RESET_BETWEEN_SCENARIOS" => 1})
+      expect(RunLoop::Environment.reset_between_scenarios?).to be_falsey
+    end
+  end
 
   describe '.trace_template' do
     it "returns TRACE_TEMPLATE expanded" do

--- a/spec/lib/instruments_spec.rb
+++ b/spec/lib/instruments_spec.rb
@@ -218,103 +218,36 @@ describe RunLoop::Instruments do
   describe '#spawn_arguments' do
     let(:xcode) { instruments.xcode }
     let(:automation_template) { 'Automation' }
+    let(:simulator) { Resources.shared.simulator }
+    let(:device) { Resources.shared.device }
+
     let (:launch_options) do
       {
-            :app => '/path/to/my.app',
-            :script => 'run_loop.js',
-            :udid => 'iPhone 5s (8.1 Simulator)',
-            :results_dir_trace => 'trace',
-            :bundle_dir_or_bundle_id => '/path/to/my.app',
-            :results_dir => 'result',
-            :args => ['-NSDoubleLocalizedStrings', 'YES']
+        :app => '/path/to/my.app',
+        :script => 'run_loop.js',
+        :udid => simulator.udid,
+        :results_dir_trace => 'trace',
+        :bundle_id => '/path/to/my.app',
+        :results_dir => 'result',
+        :args => ['-NSDoubleLocalizedStrings', 'YES']
       }
     end
 
-    it 'Xcode < 7' do
-      expect(xcode).to receive(:version).at_least(:once).and_return(xcode.v64)
-
+    it "conses up an array" do
       actual = instruments.send(:spawn_arguments, automation_template, launch_options)
       expected =
-            [
-                  'instruments',
-                  '-w', launch_options[:udid],
-                  '-D', launch_options[:results_dir_trace],
-                  '-t', automation_template,
-                  launch_options[:bundle_dir_or_bundle_id],
-                  '-e', 'UIARESULTSPATH', launch_options[:results_dir],
-                  '-e', 'UIASCRIPT', launch_options[:script],
-                  '-NSDoubleLocalizedStrings',
-                  'YES'
-            ]
+        [
+          'instruments',
+          '-w', launch_options[:udid],
+          '-D', launch_options[:results_dir_trace],
+          '-t', automation_template,
+          launch_options[:bundle_id],
+          '-e', 'UIARESULTSPATH', launch_options[:results_dir],
+          '-e', 'UIASCRIPT', launch_options[:script],
+          '-NSDoubleLocalizedStrings',
+          'YES'
+        ]
       expect(actual).to be == expected
-    end
-
-    describe 'Xcode > 7.0' do
-      it 'physical device - pass the udid through' do
-        launch_options[:udid] = '43be3f89d9587e9468c24672777ff6211bd91124'
-        launch_options[:bundle_dir_or_bundle_id] = 'sh.calaba.CalSmoke-cal'
-
-
-        expect(xcode).to receive(:version).at_least(:once).and_return(xcode.v70)
-
-        actual = instruments.send(:spawn_arguments, automation_template, launch_options)
-        expected =
-              [
-                    'instruments',
-                    '-w', launch_options[:udid],
-                    '-D', launch_options[:results_dir_trace],
-                    '-t', automation_template,
-                    launch_options[:bundle_dir_or_bundle_id],
-                    '-e', 'UIARESULTSPATH', launch_options[:results_dir],
-                    '-e', 'UIASCRIPT', launch_options[:script],
-                    '-NSDoubleLocalizedStrings',
-                    'YES'
-              ]
-        expect(actual).to be == expected
-      end
-
-      it 'matched simulator - substitute the device udid' do
-        expect(xcode).to receive(:version).at_least(:once).and_return(xcode.v70)
-
-        launch_options[:udid] = 'iPhone 6 (9.0)'
-        device = RunLoop::Device.new('iPhone 6', '9.0', '6E43E3CF-25F5-41CC-A833-588F043AE749')
-        expect(instruments).to receive(:simulators).and_return([device])
-
-        actual = instruments.send(:spawn_arguments, automation_template, launch_options)
-        expected =
-              [
-                    'instruments',
-                    '-w', device.udid,
-                    '-D', launch_options[:results_dir_trace],
-                    '-t', automation_template,
-                    launch_options[:bundle_dir_or_bundle_id],
-                    '-e', 'UIARESULTSPATH', launch_options[:results_dir],
-                    '-e', 'UIASCRIPT', launch_options[:script],
-                    '-NSDoubleLocalizedStrings',
-                    'YES'
-              ]
-        expect(actual).to be == expected
-      end
-
-      it 'unmatched simulator - pass the udid through' do
-        expect(xcode).to receive(:version).at_least(:once).and_return(xcode.v70)
-        expect(instruments).to receive(:simulators).and_return([])
-
-        actual = instruments.send(:spawn_arguments, automation_template, launch_options)
-        expected =
-              [
-                    'instruments',
-                    '-w', launch_options[:udid],
-                    '-D', launch_options[:results_dir_trace],
-                    '-t', automation_template,
-                    launch_options[:bundle_dir_or_bundle_id],
-                    '-e', 'UIARESULTSPATH', launch_options[:results_dir],
-                    '-e', 'UIASCRIPT', launch_options[:script],
-                    '-NSDoubleLocalizedStrings',
-                    'YES'
-              ]
-        expect(actual).to be == expected
-      end
     end
   end
 


### PR DESCRIPTION
### Motivation

RunLoop is now responsible for inferring the App Under Test and Device Under Test by inspecting the options passed to `Core.run_with_options` _and_ the ENV.

This relieves the clients (Calabash iOS and Calabash 2.0) from having to do any inference at all to try to deduce what the user wants to do.

Clients can now simply pass a Hash of launch options to `RunLoop.run` - there is no need for Calabash to try to rationalize the launch arguments and ENV.

This work is in the context of preparing for XCUITest/CBXDriver support.