### PR TITLE
CoreSim#launch - retry on errors

### DIFF
--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -758,6 +758,15 @@ describe RunLoop::CoreSimulator do
       end
     end
 
+    it "#launch_app_with_simctl" do
+      args = ["simctl", "launch", device.udid, app.bundle_identifier]
+      timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:launch_app_timeout]
+      options = { :log_cmd => true, :timeout => timeout }
+      expect(core_sim.xcrun).to receive(:exec).with(args, options).and_return({})
+
+      expect(core_sim.send(:launch_app_with_simctl)).to be == {}
+    end
+
     describe '.wait_for_simulator_state' do
       before do
         stub_const("RunLoop::CoreSimulator::WAIT_FOR_SIMULATOR_STATE_INTERVAL", 0)


### PR DESCRIPTION
### Motivation

Progress on **Catch iOS Simulator errors when launching and retry** #242

At the moment, we sleep between retries, but a failed launch could me that the entire simulator state is bad which would require a `CoreSimulator.terminate_core_simulator_processes`.