### PR TITLE
Instruments#kill_instruments no longer branches on Xcode version

### DIFF
--- a/lib/run_loop/instruments.rb
+++ b/lib/run_loop/instruments.rb
@@ -124,15 +124,11 @@ module RunLoop
     # Send a kill signal to any running `instruments` processes.
     #
     # Only one instruments process can be running at any one time.
-    #
-    # @param [RunLoop::Xcode] xcode Used to make check the
-    #  active Xcode version.
-    def kill_instruments(xcode = RunLoop::Xcode.new)
-      kill_signal = kill_signal(xcode)
+    def kill_instruments(_=nil)
       instruments_pids.each do |pid|
-        terminator = RunLoop::ProcessTerminator.new(pid, kill_signal, 'instruments')
+        terminator = RunLoop::ProcessTerminator.new(pid, "QUIT", "instruments")
         unless terminator.kill_process
-          terminator = RunLoop::ProcessTerminator.new(pid, 'KILL', 'instruments')
+          terminator = RunLoop::ProcessTerminator.new(pid, "KILL", "instruments")
           terminator.kill_process
         end
       end
@@ -367,29 +363,6 @@ module RunLoop
           nil
         end
       end.compact.sort
-    end
-
-    # @!visibility private
-    # The kill signal should be sent to instruments.
-    #
-    # When testing against iOS 8, sending -9 or 'TERM' causes the ScriptAgent
-    # process on the device to emit the following error until the device is
-    # rebooted.
-    #
-    # ```
-    # MobileGestaltHelper[909] <Error>: libMobileGestalt MobileGestalt.c:273: server_access_check denied access to question UniqueDeviceID for pid 796 
-    # ScriptAgent[796] <Error>: libMobileGestalt MobileGestaltSupport.m:170: pid 796 (ScriptAgent) does not have sandbox access for re6Zb+zwFKJNlkQTUeT+/w and IS NOT appropriately entitled
-    # ScriptAgent[703] <Error>: libMobileGestalt MobileGestalt.c:534: no access to UniqueDeviceID (see <rdar://problem/11744455>)
-    # ```
-    #
-    # @see https://github.com/calabash/run_loop/issues/34
-    #
-    # @param [RunLoop::Xcode] xcode The Xcode tools to use to determine
-    #  what version of Xcode is active.
-    # @return [String] Either 'QUIT' or 'TERM', depending on the Xcode
-    #  version.
-    def kill_signal(xcode = RunLoop::Xcode.new)
-      xcode.version_gte_6? ? 'QUIT' : 'TERM'
     end
 
     # @!visibility private

--- a/spec/integration/instruments_spec.rb
+++ b/spec/integration/instruments_spec.rb
@@ -6,6 +6,7 @@ describe RunLoop::Instruments do
 
   before(:each) do
     Resources.shared.kill_fake_instruments_process
+    allow(RunLoop::Environment).to receive(:debug?).and_return(true)
   end
 
   describe '#kill_instruments' do
@@ -25,7 +26,7 @@ describe RunLoop::Instruments do
         Resources.shared.launch_with_options(options) do |hash|
           expect(hash).not_to be nil
           expect(instruments.instruments_running?).to be == true
-          instruments.kill_instruments(sim_control.xcode)
+          instruments.kill_instruments
           expect(instruments.instruments_running?).to be == false
         end
       end
@@ -48,7 +49,7 @@ describe RunLoop::Instruments do
                 Resources.shared.launch_with_options(options) do |hash|
                   expect(hash).not_to be nil
                   expect(instruments.instruments_running?).to be == true
-                  instruments.kill_instruments(sim_control.xcode)
+                  instruments.kill_instruments
                   expect(instruments.instruments_running?).to be == false
                 end
               end

--- a/spec/lib/instruments_spec.rb
+++ b/spec/lib/instruments_spec.rb
@@ -188,33 +188,6 @@ describe RunLoop::Instruments do
     end
   end
 
-  describe '#kill_signal' do
-    it 'the current Xcode version' do
-      xcode = RunLoop::Xcode.new
-      expected =  xcode.version_gte_6? ? 'QUIT' : 'TERM'
-      expect(instruments.send(:kill_signal, xcode)).to be == expected
-    end
-
-    describe 'regression' do
-      xcode_installs = Resources.shared.alt_xcode_install_paths
-      if xcode_installs.empty?
-        it 'no alternative versions of Xcode found' do
-          expect(true).to be == true
-        end
-      else
-        xcode_installs.each do |developer_dir|
-          it "#{developer_dir}" do
-            Resources.shared.with_developer_dir(developer_dir) do
-              xcode = RunLoop::Xcode.new
-              expected =  xcode.version_gte_6? ? 'QUIT' : 'TERM'
-              expect(instruments.send(:kill_signal, xcode)).to be == expected
-            end
-          end
-        end
-      end
-    end
-  end
-
   describe '#spawn_arguments' do
     let(:xcode) { instruments.xcode }
     let(:automation_template) { 'Automation' }


### PR DESCRIPTION
### Motivation

#kill_instruments branched on Xcode >= 6 to determine which kill signal to seen to `instruments`.   Since we are always executing in Xcode >= 6 environments, we can drop this branching.