### PR TITLE
App and Ipa can return version info

### DIFF
--- a/lib/run_loop/app.rb
+++ b/lib/run_loop/app.rb
@@ -130,6 +130,67 @@ Bundle must:
       RunLoop::Codesign.distribution?(path)
     end
 
+    # Returns the CFBundleShortVersionString of the app as Version instance.
+    #
+    # Apple docs:
+    #
+    # CFBundleShortVersionString specifies the release version number of the
+    # bundle, which identifies a released iteration of the app. The release
+    # version number is a string comprised of three period-separated integers.
+    #
+    # The first integer represents major revisions to the app, such as revisions
+    # that implement new features or major changes. The second integer denotes
+    # revisions that implement less prominent features. The third integer
+    # represents maintenance releases.
+    #
+    # The value for this key differs from the value for CFBundleVersion, which
+    # identifies an iteration (released or unreleased) of the app. This key can
+    # be localized by including it in your InfoPlist.strings files.
+    #
+    # @return [RunLoop::Version, nil] Returns a Version instance if the
+    #  CFBundleShortVersion string is well formed and nil if not.
+    def marketing_version
+      string = plist_buddy.plist_read("CFBundleShortVersionString", info_plist_path)
+      begin
+        version = RunLoop::Version.new(string)
+      rescue
+        RunLoop.log_debug("Could not create Version instance from #{string}.")
+        version = nil
+      end
+      version
+    end
+
+    # See #marketing_version
+    alias_method :short_bundle_version, :marketing_version
+
+    # Returns the CFBundleVersionString of the app as Version instance.
+    #
+    # Apple docs:
+    #
+    # CFBundleVersion specifies the build version number of the bundle, which
+    # identifies an iteration (released or unreleased) of the bundle. The build
+    # version number should be a string comprised of three non-negative,
+    # period-separated integers with the first integer being greater than zero.
+    # The string should only contain numeric (0-9) and period (.) characters.
+    # Leading zeros are truncated from each integer and will be ignored (that
+    # is, 1.02.3 is equivalent to 1.2.3).
+    #
+    # @return [RunLoop::Version, nil] Returns a Version instance if the
+    #  CFBundleVersion string is well formed and nil if not.
+    def build_version
+      string = plist_buddy.plist_read("CFBundleVersionString", info_plist_path)
+      begin
+        version = RunLoop::Version.new(string)
+      rescue
+        RunLoop.log_debug("Could not create Version instance from #{string}.")
+        version = nil
+      end
+      version
+    end
+
+    # See #build_version
+    alias_method :bundle_version, :build_version
+
     # @!visibility private
     # Collects the paths to executables in the bundle.
     def executables

--- a/lib/run_loop/app.rb
+++ b/lib/run_loop/app.rb
@@ -33,7 +33,20 @@ Bundle must:
 
     # @!visibility private
     def to_s
-      "#<APP: #{path}>"
+      cf_bundle_version = bundle_version
+      cf_bundle_short_version = short_bundle_version
+
+      if cf_bundle_version && cf_bundle_short_version
+        version = "#{cf_bundle_version.to_s} / #{cf_bundle_short_version}"
+      elsif cf_bundle_version
+        version = cf_bundle_version.to_s
+      elsif cf_bundle_short_version
+        version = cf_bundle_short_version
+      else
+        version = ""
+      end
+
+      "#<APP #{bundle_identifier} #{version} #{path}>"
     end
 
     # @!visibility private
@@ -154,7 +167,11 @@ Bundle must:
       begin
         version = RunLoop::Version.new(string)
       rescue
-        RunLoop.log_debug("Could not create Version instance from #{string}.")
+        if string && string != ""
+          RunLoop.log_debug("CFBundleShortVersionString: '#{string}' is not a well formed version string")
+        else
+          RunLoop.log_debug("CFBundleShortVersionString is not defined in Info.plist")
+        end
         version = nil
       end
       version
@@ -182,7 +199,11 @@ Bundle must:
       begin
         version = RunLoop::Version.new(string)
       rescue
-        RunLoop.log_debug("Could not create Version instance from #{string}.")
+        if string && string != ""
+          RunLoop.log_debug("CFBundleVersionString: '#{string}' is not a well formed version string")
+        else
+          RunLoop.log_debug("CFBundleVersionString is not defined in Info.plist")
+        end
         version = nil
       end
       version

--- a/lib/run_loop/ipa.rb
+++ b/lib/run_loop/ipa.rb
@@ -25,7 +25,20 @@ module RunLoop
 
     # @!visibility private
     def to_s
-      "#<IPA: #{bundle_identifier}: '#{path}'>"
+      cf_bundle_version = bundle_version
+      cf_bundle_short_version = short_bundle_version
+
+      if cf_bundle_version && cf_bundle_short_version
+        version = "#{cf_bundle_version.to_s}/#{cf_bundle_short_version}"
+      elsif cf_bundle_version
+        version = cf_bundle_version.to_s
+      elsif cf_bundle_short_version
+        version = cf_bundle_short_version
+      else
+        version = ""
+      end
+
+      "#<IPA #{bundle_identifier} #{version} #{path}>"
     end
 
     # @!visibility private

--- a/lib/run_loop/ipa.rb
+++ b/lib/run_loop/ipa.rb
@@ -71,6 +71,22 @@ module RunLoop
       app.distribution_signed?
     end
 
+    # @!visibility private
+    def marketing_version
+      app.marketing_version
+    end
+
+    # See #marketing_version
+    alias_method :short_bundle_version, :marketing_version
+
+    # @!visibility private
+    def build_version
+      app.build_version
+    end
+
+    # See #build_version
+    alias_method :bundle_version, :build_version
+
     private
 
     # @!visibility private

--- a/spec/lib/app_spec.rb
+++ b/spec/lib/app_spec.rb
@@ -208,6 +208,50 @@ describe RunLoop::App do
     end
   end
 
+  describe "#marketing_version" do
+    let(:pbuddy) { RunLoop::PlistBuddy.new }
+    let(:args) { ["CFBundleShortVersionString", app.info_plist_path] }
+
+    before do
+      allow(app).to receive(:plist_buddy).and_return(pbuddy)
+    end
+
+    it "valid CFBundleShortVersionString" do
+      expect(pbuddy).to receive(:plist_read).with(*args).twice.and_return("8.0")
+
+      expect(app.marketing_version).to be == RunLoop::Version.new("8.0")
+      expect(app.short_bundle_version).to be == RunLoop::Version.new("8.0")
+    end
+
+    it "invalid CFBundleShortVersionString" do
+      expect(pbuddy).to receive(:plist_read).with(*args).and_return("a.b.c")
+
+      expect(app.marketing_version).to be == nil
+    end
+  end
+
+  describe "#build_version" do
+    let(:pbuddy) { RunLoop::PlistBuddy.new }
+    let(:args) { ["CFBundleVersionString", app.info_plist_path] }
+
+    before do
+      allow(app).to receive(:plist_buddy).and_return(pbuddy)
+    end
+
+    it "valid CFBundleVersionString" do
+      expect(pbuddy).to receive(:plist_read).with(*args).twice.and_return("8.0")
+
+      expect(app.build_version).to be == RunLoop::Version.new("8.0")
+      expect(app.bundle_version).to be == RunLoop::Version.new("8.0")
+    end
+
+    it "invalid CFBundleShortVersionString" do
+      expect(pbuddy).to receive(:plist_read).with(*args).and_return("a.b.c")
+
+      expect(app.build_version).to be == nil
+    end
+  end
+
   describe "#simulator_app?" do
     it "false" do
       expect(app).to receive(:arches).twice.and_return(["arm64", "armv7"])

--- a/spec/lib/ipa_spec.rb
+++ b/spec/lib/ipa_spec.rb
@@ -69,6 +69,23 @@ describe RunLoop::Ipa do
     end
   end
 
+  describe "version info" do
+    let(:app) { ipa.send(:app) }
+    let(:version) { RunLoop::Version.new("1.2.3") }
+
+    it "#marketing_version" do
+      expect(app).to receive(:marketing_version).and_return(version)
+
+      expect(ipa.marketing_version).to be == version
+    end
+
+    it "#build_version" do
+      expect(app).to receive(:build_version).and_return(version)
+
+      expect(ipa.build_version).to be == version
+    end
+  end
+
   describe 'private' do
     it '#tmpdir' do
       tmp_dir = ipa.send(:tmpdir)


### PR DESCRIPTION
### Motivation

This information can be used to determine the provenance of a .app and .ipa to ensure that you are testing the correct binary. 

* #marketing_version <= CFBundleShortVersionString
* #build_version <= CFBundleVersionString