### PR TITLE
CoreSim#installed_app_bundle_dir stop using 'simctl'

### DIFF
--- a/lib/run_loop/simctl.rb
+++ b/lib/run_loop/simctl.rb
@@ -53,6 +53,14 @@ module RunLoop
     #
     # This method is not supported on Xcode < 7 - returns nil.
     #
+    # Simulator must be booted in El Cap, which makes this method useless for us
+    # because we have to do a bunch of pre-launch checks for sandbox resetting.
+    #
+    # Testing has shown that moving the device in and out of the booted state
+    # takes a long time (seconds) and is unpredictable.
+    #
+    # TODO ensure a booted state.
+    #
     # @param [String] bundle_id The CFBundleIdentifier of the app.
     # @return [String] The path to the .app bundle if it exists; nil otherwise.
     def app_container(bundle_id)

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -438,6 +438,106 @@ describe RunLoop::CoreSimulator do
         end
       end
 
+      describe "#complete_app_install" do
+        let(:tmp) { Resources.shared.local_tmp_dir }
+        let(:working_dir) { File.join(tmp, "complete-app-install") }
+        let(:app_bundle) { File.join(working_dir, "My.app") }
+        let(:plist) { File.join(working_dir,  RunLoop::CoreSimulator::METADATA_PLIST) }
+
+        before do
+          [working_dir, app_bundle].each do |path|
+            FileUtils.rm_rf(path)
+            FileUtils.mkdir_p(path)
+          end
+
+          FileUtils.touch(plist)
+        end
+
+        it "true" do
+          expect(core_sim.send(:complete_app_install?, app_bundle)).to be_truthy
+        end
+
+        it "false" do
+          FileUtils.rm_rf(plist)
+          expect(core_sim.send(:complete_app_install?, app_bundle)).to be_falsey
+        end
+      end
+
+      describe "#ensure_complete_app_installation" do
+        let(:tmp) { Resources.shared.local_tmp_dir }
+        let(:working_dir) { File.join(tmp, "ensure-complete-app-install") }
+        let(:app_bundle) { File.join(working_dir, "My.app") }
+        let(:plist) { File.join(working_dir,  RunLoop::CoreSimulator::METADATA_PLIST) }
+
+        before do
+          [working_dir, app_bundle].each do |path|
+            FileUtils.rm_rf(path)
+            FileUtils.mkdir_p(path)
+          end
+
+          FileUtils.touch(plist)
+        end
+
+        it "bundle is nil" do
+          actual = core_sim.send(:ensure_complete_app_installation, nil)
+          expect(actual).to be == nil
+        end
+
+        it "complete" do
+          expect(core_sim).to receive(:complete_app_install?).with(app_bundle).and_return(true)
+
+          actual = core_sim.send(:ensure_complete_app_installation, app_bundle)
+          expect(actual).to be == app_bundle
+        end
+
+        it "incomplete" do
+          expect(core_sim).to receive(:complete_app_install?).with(app_bundle).and_return(false)
+          expect(core_sim).to receive(:remove_stale_data_containers).and_return(true)
+
+          actual = core_sim.send(:ensure_complete_app_installation, app_bundle)
+          expect(actual).to be == nil
+          expect(File.exist?(working_dir)).to be_falsey
+        end
+      end
+
+      describe "#remove_stale_data_containers" do
+        let(:tmp) { Resources.shared.local_tmp_dir }
+        let(:working_dir) { File.join(tmp, "remove-stale-data-containers") }
+        let(:container_a) { File.join(working_dir, "Containers", "Data", "Application", "A") }
+        let(:plist_a) { File.join(container_a,  RunLoop::CoreSimulator::METADATA_PLIST) }
+        let(:container_b) { File.join(working_dir, "Containers", "Data", "Application", "B") }
+        let(:plist_b) { File.join(container_b,  RunLoop::CoreSimulator::METADATA_PLIST) }
+        let(:container_c) { File.join(working_dir, "Containers", "Data", "Application", "C") }
+        let(:plist_c) { File.join(container_c,  RunLoop::CoreSimulator::METADATA_PLIST) }
+        let(:pbuddy) { RunLoop::PlistBuddy.new }
+        let(:bundle_id) { "com.example.MyApp" }
+
+        before do
+          [working_dir, container_a, container_b, container_c].each do |path|
+            FileUtils.rm_rf(path)
+            FileUtils.mkdir_p(path)
+          end
+
+          [plist_a, plist_b, plist_c].each do |path|
+            FileUtils.touch(path)
+          end
+
+          allow(core_sim).to receive(:pbuddy).and_return(pbuddy)
+          allow(core_sim.app).to receive(:bundle_identifier).and_return(bundle_id)
+          allow(core_sim).to receive(:device_data_dir).and_return(working_dir)
+          expect(pbuddy).to receive(:plist_read).with("MCMMetadataIdentifier", plist_a).and_return(bundle_id)
+          expect(pbuddy).to receive(:plist_read).with("MCMMetadataIdentifier", plist_b).and_return("com.does.not.match")
+          expect(pbuddy).to receive(:plist_read).with("MCMMetadataIdentifier", plist_c).and_return(bundle_id)
+        end
+
+        it "clears matching data containers" do
+          core_sim.send(:remove_stale_data_containers)
+          expect(File.exist?(container_a)).to be_falsey
+          expect(File.exist?(container_b)).to be_truthy
+          expect(File.exist?(container_c)).to be_falsey
+        end
+      end
+
       describe "#installed_app_bundle_dir" do
         let(:app_dir) do
           path = File.join(Resources.shared.local_tmp_dir, "Containers/Bundle/Application")
@@ -445,60 +545,14 @@ describe RunLoop::CoreSimulator do
           path
         end
 
-        let(:bundle_id) { app.bundle_identifier }
-
         before do
           expect(core_sim).to receive(:device_applications_dir).and_return(app_dir)
-          allow(core_sim).to receive(:xcode).and_return(xcode)
         end
 
         it "device applications dir does not exist" do
           expect(File).to receive(:exist?).with(app_dir).and_return(false)
 
           expect(core_sim.send(:installed_app_bundle_dir)).to be == nil
-        end
-
-        describe "Xcode >= 7" do
-
-          before do
-            expect(xcode).to receive(:version_gte_7?).and_return(true)
-          end
-
-          it "app installed" do
-            expect(RunLoop::Simctl).to receive(:new).with(device).and_return(simctl)
-            expect(simctl).to receive(:app_container).with(bundle_id).and_return(:path)
-
-            expect(core_sim.send(:installed_app_bundle_dir)).to be == :path
-          end
-
-          it "app not installed" do
-            expect(RunLoop::Simctl).to receive(:new).with(device).and_return(simctl)
-            expect(simctl).to receive(:app_container).with(bundle_id).and_return(nil)
-
-            expect(core_sim.send(:installed_app_bundle_dir)).to be == nil
-          end
-        end
-
-        describe "Xcode < 7" do
-          let(:glob) { "#{app_dir}/**/*.app" }
-
-          before do
-            expect(xcode).to receive(:version_gte_7?).and_return(false)
-          end
-
-          it "app not installed" do
-            expect(Dir).to receive(:glob).with(glob).and_return([])
-
-            expect(core_sim.send(:installed_app_bundle_dir)).to be == nil
-          end
-
-          it "app is installed" do
-            FileUtils.cp_r(app.path, app_dir)
-
-            actual = core_sim.send(:installed_app_bundle_dir)
-            expected = "#{app_dir}/#{File.basename(app.path)}"
-            expect(actual).to be == expected
-          end
         end
       end
 


### PR DESCRIPTION
### Motivation

Fixes **RESET_BETWEEN_SCENARIOS has stopped working** #426

`simctl get_app_container` requires the device to be booted on El Cap.  On Yosemite, it works without the device being booted.  Testing shows that moving the device in and out of the booted state is problematic.

To address incomplete app installations (the reason for changing over to simctl), #installed_app_bundle_dir  verifies the correctness of an app installation and cleans up if it encounters an incomplete install.