### PR TITLE
Restore UIALogger flushing and ensure variables are substituted properly.

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -663,6 +663,31 @@ Logfile: #{log_file}
 
     # @!visibility private
     #
+    # UIAutomation buffers log output in some very strange ways.  RunLoop
+    # attempts to work around this buffering by forcing characters onto the
+    # UIALogger buffer.  Once the buffer is full, UIAutomation will dump its
+    # contents.  It is essential that the communication between UIAutomation
+    # and RunLoop be synchronized.
+    #
+    # Casual users should never set the :flush_uia_logs key; they should use the
+    # defaults.
+    #
+    # :no_flush is supported (for now) as alternative key.
+    #
+    # @param [Hash] options The launch options passed to .run_with_options
+    def self.detect_flush_uia_log_option(options)
+      if options.has_key?(:no_flush)
+        # Confusing.
+        # :no_flush == false means, flush the logs.
+        # :no_flush == true means, don't flush the logs.
+        return !options[:no_flush]
+      end
+
+      return options.fetch(:flush_uia_logs, true)
+    end
+
+    # @!visibility private
+    #
     # @param [Hash] options The launch options passed to .run_with_options
     def self.detect_reset_options(options)
       return options[:reset] if options.has_key?(:reset)

--- a/lib/run_loop/template.rb
+++ b/lib/run_loop/template.rb
@@ -9,7 +9,8 @@ module RunLoop
     # @!visibility private
     def initialize(template_root, template_relative_path)
       @template_root = template_root
-      @template = File.read(File.join(@template_root, template_relative_path)).force_encoding("utf-8")
+      template_path = File.join(@template_root, template_relative_path)
+      @template = File.read(template_path).force_encoding("utf-8")
       super(@template)
     end
 
@@ -21,6 +22,40 @@ module RunLoop
     # @!visibility private
     def result
       super(binding)
+    end
+
+    # @!visibility private
+    def self.sub_path_var!(javascript, results_dir)
+      self.substitute_variable!(javascript, "PATH", results_dir)
+    end
+
+    # @!visibility private
+    def self.sub_read_script_path_var!(javascript, read_cmd_sh)
+      self.substitute_variable!(javascript, "READ_SCRIPT_PATH", read_cmd_sh)
+    end
+
+    # @!visibility private
+    def self.sub_timeout_script_path_var!(javascript, timeout_sh)
+      self.substitute_variable!(javascript, "TIMEOUT_SCRIPT_PATH", timeout_sh)
+    end
+
+    # @!visibility private
+    def self.sub_flush_uia_logs_var!(javascript, value)
+      self.substitute_variable!(javascript, "FLUSH_LOGS", value)
+    end
+
+    # @!visibility private
+    #
+    # Legacy and XTC - related to :no_flush which is a deprecated option.
+    #
+    # Replaced with :flush_uia_logs
+    def self.sub_mode_var!(javascript, value)
+      self.substitute_variable!(javascript, "MODE", value)
+    end
+
+    # @!visibility private
+    def self.substitute_variable!(javascript, variable, value)
+      javascript.gsub!(/\$#{variable}/, value)
     end
   end
 end

--- a/scripts/lib/log.js
+++ b/scripts/lib/log.js
@@ -1,26 +1,26 @@
 var Log = (function () {
-    var forceFlush = [],
-        N = 16384,
-        i = N;
+    var forceFlush = [];
+    var N = "$FLUSH_LOGS" == "FLUSH_LOGS" ? 16384 : 0;
+    var i = N;
     while (i--) {
         forceFlush[i] = "*";
     }
     forceFlush = forceFlush.join('');
 
-    function log_json(object, flush)
+    function log_json(object)
     {
         UIALogger.logMessage("OUTPUT_JSON:\n"+JSON.stringify(object)+"\nEND_OUTPUT");
-        if (flush) {
+        if (forceFlush.length > 0) {
             UIALogger.logMessage(forceFlush);
         }
     }
 
     return {
-        result: function (status, data, flush) {
-            log_json({"status": status, "value": data, "index":_actualIndex}, flush)
+        result: function (status, data) {
+            log_json({"status": status, "value": data, "index":_actualIndex})
         },
-        output: function (msg, flush) {
-            log_json({"output": msg,"last_index":_actualIndex}, flush);
+        output: function (msg) {
+            log_json({"output": msg,"last_index":_actualIndex});
         }
     };
 })();

--- a/scripts/run_loop_basic.js
+++ b/scripts/run_loop_basic.js
@@ -3,7 +3,7 @@
 <%= render_template("lib/on_alert.js"); %>
 
 UIATarget.onAlert = function (alert) {
-    Log.output({"output":"on alert"}, true);
+    Log.output({"output":"on alert"});
     var target = UIATarget.localTarget();
     target.pushTimeout(10);
     function dismissPrivacyAlert(retry_count) {

--- a/scripts/run_loop_fast_uia.js
+++ b/scripts/run_loop_fast_uia.js
@@ -41,6 +41,7 @@ UIATarget.onAlert = function (alert) {
 
     dismissPrivacyAlert(0);
     target.popTimeout();
+
     for (var i=0;i<_RUN_LOOP_MAX_RETRY_AFTER_HANDLER;i++) {
         req = app.preferencesValueForKey(__calabashRequest);
         rsp = app.preferencesValueForKey(__calabashResponse);
@@ -143,7 +144,7 @@ var target = null,
     };
 
 _resetCalabashPreferences();
-Log.result('success',true,true);
+Log.result('success', true);
 target = UIATarget.localTarget();
 while (true) {
     try {
@@ -175,7 +176,7 @@ while (true) {
         }
         catch(err) {
             failureMessage = "Failure: "+ err.toString() + "  " + (err.stack ? err.stack.toString() : "");
-            Log.output({"output":failureMessage}, true);
+            Log.output({"output":failureMessage});
             _failure(err, _actualIndex);
         }
     }

--- a/scripts/run_loop_host.js
+++ b/scripts/run_loop_host.js
@@ -23,7 +23,7 @@ var _expectedIndex = 0,//expected index of next command
 <%= render_template("lib/on_alert.js"); %>
 
 UIATarget.onAlert = function (alert) {
-    Log.output({"output":"on alert"}, true);
+    Log.output({"output":"on alert");
     var target = UIATarget.localTarget();
     target.pushTimeout(10);
     function dismissPrivacyAlert(retry_count) {
@@ -74,7 +74,12 @@ while (true) {
     }
     if (_process.exitCode != 0) {
         if (_process.exitCode != 15) {
-            Log.output("unable to execute: " + timeoutScriptPath + " " +readPipeScriptPath + " " + commandPath + " exitCode " + _process.exitCode + ". Error: " + _process.stderr + _process.stdout);
+            Log.output("unable to execute: " +
+                  timeoutScriptPath + " " +
+                  readPipeScriptPath + " " +
+                  commandPath + " exitCode "
+                  + _process.exitCode + ". Error: " +
+                  _process.stderr + _process.stdout);
         }
     }
     else {
@@ -98,7 +103,9 @@ while (true) {
 
         }
         catch (err) {
-            Log.result("error", "Input: " + (_exp ? _exp.toString() : "null") + ". Error: " + err.toString() + "  " + (err.stack ? err.stack.toString() : ""));
+            Log.result("error", "Input: " + (_exp ? _exp.toString() : "null") +
+                  ". Error: " + err.toString() + "  " +
+                  (err.stack ? err.stack.toString() : ""));
             _expectedIndex++;
             continue;
         }

--- a/scripts/run_loop_shared_element.js
+++ b/scripts/run_loop_shared_element.js
@@ -45,7 +45,7 @@ UIATarget.onAlert = function (alert) {
 };
 
 
-Log.result('success',true,true);
+Log.result('success', true);
 
 var _calabashSharedTextField = null,
     __calabashSharedTextFieldName = '__calabash_uia_channel',
@@ -114,7 +114,7 @@ while (true) {
         }
         catch(err) {
             failureMessage = "Failure: "+ err.toString() + "  " + (err.stack ? err.stack.toString() : "");
-            Log.output({"output":failureMessage}, true);
+            Log.output({"output":failureMessage});
             _failure(err, _actualIndex);
         }
     }

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -340,6 +340,37 @@ describe RunLoop::Core do
     end
   end
 
+  describe ".detect_flush_uia_log_option" do
+    let (:options) { {} }
+    describe ":no_flush legacy key" do
+      it ":no_flush => false" do
+        options[:no_flush] = false
+        expect(RunLoop::Core.send(:detect_flush_uia_log_option, options)).to be_truthy
+      end
+
+      it ":no_flush => true" do
+        options[:no_flush] = true
+        expect(RunLoop::Core.send(:detect_flush_uia_log_option, options)).to be_falsey
+      end
+    end
+
+    describe ":flush_uia_logs" do
+      it "key does not exist" do
+        expect(RunLoop::Core.send(:detect_flush_uia_log_option, options)).to be_truthy
+      end
+
+      it ":flush_uia_logs => true" do
+        options[:flush_uia_logs] = true
+        expect(RunLoop::Core.send(:detect_flush_uia_log_option, options)).to be_truthy
+      end
+
+      it ":flush_uia_logs => false" do
+        options[:flush_uia_logs] = false
+        expect(RunLoop::Core.send(:detect_flush_uia_log_option, options)).to be_falsey
+      end
+    end
+  end
+
   describe '.expect_simulator_compatible_arch' do
     let(:device) { RunLoop::Device.new('Sim', '8.0', 'UDID') }
 

--- a/spec/lib/template_spec.rb
+++ b/spec/lib/template_spec.rb
@@ -1,0 +1,89 @@
+
+describe RunLoop::UIAScriptTemplate do
+
+  let(:javascript) do
+    %q[
+var myVar = "$MY_VAR";
+var commandPath = "$PATH";
+var timeoutScriptPath = "$TIMEOUT_SCRIPT_PATH";
+var readPipeScriptPath = "$READ_SCRIPT_PATH";
+var N = "$FLUSH_LOGS" == "FLUSH_LOGS" ? 16384 : 0;
+var N = "$MODE" == "FLUSH" ? 16384 : 0;
+]
+  end
+
+  let(:replacement) { "REPLACED" }
+
+  describe ".substitute_variable!" do
+    it "replaces variables if they are found" do
+      variable = "MY_VAR"
+      expected = %Q[var myVar = "#{replacement}";]
+
+      RunLoop::UIAScriptTemplate.substitute_variable!(javascript,
+                                                      variable,
+                                                      replacement)
+
+      expect(javascript[/#{expected}/, 0]).to be_truthy
+    end
+
+    it "does nothing otherwise" do
+      variable = "YOUR_VAR"
+      expected = javascript.dup
+      RunLoop::UIAScriptTemplate.substitute_variable!(javascript,
+                                                      variable,
+                                                      replacement)
+
+      expect(javascript).to be == expected
+    end
+
+    it ".sub_flush_uia_logs_var!" do
+      expected = %Q[var N = "#{replacement}" == "FLUSH_LOGS" ? 16384 : 0;]
+
+      RunLoop::UIAScriptTemplate.sub_flush_uia_logs_var!(javascript,
+                                                         replacement)
+
+      actual = javascript.split($-0)[5]
+      expect(actual).to be == expected
+    end
+
+    it ".sub_mode_var!" do
+      expected = %Q[var N = "#{replacement}" == "FLUSH" ? 16384 : 0;]
+
+      RunLoop::UIAScriptTemplate.sub_mode_var!(javascript,
+                                               replacement)
+
+      actual = javascript.split($-0)[6]
+      expect(actual).to be == expected
+    end
+
+    it ".sub_path_var!" do
+      expected = %Q[var commandPath = "#{replacement}";]
+      RunLoop::UIAScriptTemplate.sub_path_var!(javascript,
+                                                              replacement)
+
+      actual = javascript.split($-0)[2]
+      expect(actual).to be == expected
+    end
+
+    it ".sub_read_timeout_script_path_var!" do
+      replacement = "REPLACED"
+      expected = %Q[var timeoutScriptPath = "#{replacement}";]
+      RunLoop::UIAScriptTemplate.sub_timeout_script_path_var!(javascript,
+                                                              replacement)
+
+      actual = javascript.split($-0)[3]
+      expect(actual).to be == expected
+    end
+
+    it ".sub_read_script_path_var!" do
+      replacement = "REPLACED"
+      expected = %Q[var readPipeScriptPath = "#{replacement}";]
+
+      RunLoop::UIAScriptTemplate.sub_read_script_path_var!(javascript,
+                                                           replacement)
+
+      actual = javascript.split($-0)[4]
+      expect(actual).to be == expected
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

While analysing an issue UITest, I stumbled upon a change in behavior introduced by **Extract Logger and onAlert to a single JavaScript file using erb templates** #261.

In a nutshell, RunLoop was no longer flushing the UIALogger buffer.

I took this chance to rename the `:no_flush` option to `:flush_uia_logs`.  The old `:no_flush` option is respected and there is special XTC support. 

- [x] @krukow I need you take a quick look at this.

ATTN: @svevang We missed a spot. :8:

