### PR TITLE
Gem: bump version to 2.1.1.pre2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 2.1.1
 
+* CoreSim: patch retry on failed app launch 5300542
 * Restore UIALogger flushing and ensure variables are substituted
   properly. #430
 * DotDir: symlink to current result #429

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### 2.1.1
 
+* Restore UIALogger flushing and ensure variables are substituted
+  properly. #430
+* DotDir: symlink to current result #429
 * Relax deprecation warnings @TeresaP, @jane-openreply, and others
 * RESET\_BETWEEN\_SCENARIOS has stopped working #426 @ankurgamit
 

--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -408,6 +408,7 @@ $ bundle exec run-loop simctl manage-processes
       hash = launch_app_with_simctl
       exit_status = hash[:exit_status]
       if exit_status != 0
+        out = hash[:out]
         RunLoop.log_debug("Failed to launch app.")
         out.split($-0).each do |line|
           RunLoop.log_debug("    #{line}")

--- a/lib/run_loop/version.rb
+++ b/lib/run_loop/version.rb
@@ -1,5 +1,5 @@
 module RunLoop
-  VERSION = "2.1.1.pre1"
+  VERSION = "2.1.1.pre2"
 
   # A model of a software release version that can be used to compare two versions.
   #


### PR DESCRIPTION
### 2.1.1

* Restore UIALogger flushing and ensure variables are substituted
  properly. #430
* DotDir: symlink to current result #429
* Relax deprecation warnings @TeresaP, @jane-openreply, and others
* RESET\_BETWEEN\_SCENARIOS has stopped working #426 @ankurgamit