### PR TITLE
Filter new Xcode 7.3 simctl stderr output from `simctl list devices`

### DIFF
--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -1146,7 +1146,10 @@ module RunLoop
           line[/Apple Watch/, 0],
           line[/watchOS/, 0],
           line[/Apple TV/, 0],
-          line[/tvOS/, 0]
+          line[/tvOS/, 0],
+          line[/Devices/, 0],
+          line[/CoreSimulatorService/, 0],
+          line[/simctl\[.+\]/, 0]
         ].any?
 
         if not_ios

--- a/spec/resources/simctl_json_devices.rb
+++ b/spec/resources/simctl_json_devices.rb
@@ -2,7 +2,14 @@ module RunLoop
   module RSpec
     module Simctl
 
-      SIMCTL_DEVICE_JSON_XCODE7 = %q[{"devices" : {
+      SIMCTL_DEVICE_JSON_XCODE7 =
+%q[2016-04-11 16:17:48.474 simctl[98400:32684208] CoreSimulator is attempting to unload a stale CoreSimulatorService job.  Existing job (com.apple.CoreSimulator.CoreSimulatorService.117.15.1.lkhDXxRPp5yy) is from an older version and is being removed to prevent problems.
+2016-04-11 16:17:48.732 simctl[98400:32684208] CoreSimulator is attempting to unload a stale CoreSimulatorService job.  Existing job (com.apple.CoreSimulator.CoreSimulatorService.117.15.1.dltcnwGXJZL4) is from an older version and is being removed to prevent problems.
+2016-04-11 16:17:48.988 simctl[98400:32684208] CoreSimulator is attempting to unload a stale CoreSimulatorService job.  Existing job (com.apple.CoreSimulator.CoreSimulatorService.179.1.E8ttyeDeVgWK) is from an older version and is being removed to prevent problems.
+2016-04-11 16:17:49.245 simctl[98400:32684208] CoreSimulator is attempting to unload a stale CoreSimulatorService job.  Existing job (com.apple.CoreSimulator.CoreSimulatorService.191.4.1.sUuqCSHdtoM8) is from an older version and is being removed to prevent problems.
+2016-04-11 16:17:49.512 simctl[98400:32684208] CoreSimulator is attempting to unload a stale CoreSimulatorService job.  Detected Xcode.app relocation or CoreSimulatorService version change.  Framework path (/Xcode/7.3/Xcode.app/Contents/Developer/Library/PrivateFrameworks/CoreSimulator.framework) and version (209.19) does not match existing job path (/Xcode/7.2.1/Xcode.app/Contents/Developer/Library/PrivateFrameworks/CoreSimulator.framework/Versions/A/XPCServices/com.apple.CoreSimulator.CoreSimulatorService.xpc/Contents/MacOS/com.apple.CoreSimulator.CoreSimulatorService) and version (201.3).
+2016-04-11 16:17:49.770 simctl[98400:32684208] Failed to locate a valid instance of CoreSimulatorService in the bootstrap.  Adding it now.
+{"devices" : {
     "iOS 8.1" : [
       {
         "state" : "Shutdown",


### PR DESCRIPTION
### Motivation

Starting Xcode 7.3, simctl can output stderr logs.  `command_runner_ng` combines stderr and stdout (for better or worse).

Fixes **udid variable in device.rb is nil on first launch** [#1058](https://github.com/calabash/calabash-ios/issues/1058)



