### PR TITLE
Improve retry strategy for app launch on simulators

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -647,6 +647,8 @@ Command had no output
       # Simulator is probably in a bad state.  Terminates the
       # CoreSimulatorService.  Restarting this service is expensive!
       RunLoop::CoreSimulator.terminate_core_simulator_processes
+      Kernel.sleep(0.5)
+      launch_simulator
     end
     hash
   end

--- a/spec/integration/core_simulator_spec.rb
+++ b/spec/integration/core_simulator_spec.rb
@@ -1,5 +1,5 @@
 describe RunLoop::CoreSimulator do
-  let(:simulator) { RunLoop::SimControl.new.simulators.sample }
+  let(:simulator) { Resources.shared.default_simulator }
   let(:app) { RunLoop::App.new(Resources.shared.cal_app_bundle_path) }
   let(:xcrun) { RunLoop::Xcrun.new }
 

--- a/spec/integration/core_simulator_spec.rb
+++ b/spec/integration/core_simulator_spec.rb
@@ -92,6 +92,13 @@ describe RunLoop::CoreSimulator do
     end
   end
 
+  it "retries app launching" do
+    expect(core_sim).to receive(:launch_app_with_simctl).twice.and_raise(RunLoop::Xcrun::TimeoutError)
+    expect(core_sim).to receive(:launch_app_with_simctl).and_call_original
+
+    expect(core_sim.launch).to be == true
+  end
+
   it 'install with simctl' do
     args = ['simctl', 'erase', simulator.udid]
     xcrun.exec(args, {:log_cmd => true })

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -853,6 +853,8 @@ describe RunLoop::CoreSimulator do
       it "timeout error" do
         expect(core_sim).to receive(:launch_app_with_simctl).and_raise(error)
         expect(RunLoop::CoreSimulator).to receive(:terminate_core_simulator_processes).and_return(true)
+        expect(core_sim).to receive(:launch_simulator).and_return(true)
+        expect(Kernel).to receive(:sleep).with(0.5).and_return(true)
 
         actual = core_sim.send(:attempt_to_launch_app_with_simctl)
         expect(actual).to be == hash


### PR DESCRIPTION
### Motivation

After an app launch times out:

1. terminate the CoreSimulator processes,
2. launch the app,
3 and then sleep.

Progress on:

* **Catch iOS Simulator errors when launching and retry** #242
* **`simctl install` on iPad Simulators installs an app that is not recognized by Springboard or simctl* #435 - possible Apple bug.

There is now an integration test that checks the retry logic and heuristics.

