### PR TITLE
XCUITest: rename the xcodebuild log file

### DIFF
--- a/lib/run_loop/xcuitest.rb
+++ b/lib/run_loop/xcuitest.rb
@@ -44,12 +44,9 @@ module RunLoop
     end
 
     # @!visibility private
-    def self.log_file
-      path = File.join(XCUITest.dot_dir, "xcuitest.log")
-
-      if !File.exist?(path)
-        FileUtils.touch(path)
-      end
+    def self.xcodebuild_log_file
+      path = File.join(XCUITest.dot_dir, "xcodebuild.log")
+      FileUtils.touch(path) if !File.exist?(path)
       path
     end
 
@@ -314,7 +311,7 @@ module RunLoop
         "test"
       ]
 
-      log_file = XCUITest.log_file
+      log_file = XCUITest.xcodebuild_log_file
 
       options = {
         :out => log_file,

--- a/spec/lib/xcuitest_spec.rb
+++ b/spec/lib/xcuitest_spec.rb
@@ -216,8 +216,5 @@ describe RunLoop::XCUITest do
         expect(RunLoop::XCUITest.xcodebuild_log_file).to be == path
       end
     end
-      end
-    end
   end
 end
-

--- a/spec/lib/xcuitest_spec.rb
+++ b/spec/lib/xcuitest_spec.rb
@@ -197,23 +197,25 @@ describe RunLoop::XCUITest do
       end
     end
 
-    describe ".log_file" do
+    describe ".xcodebuild_log_file" do
       before do
         FileUtils.mkdir_p(xcuitest_dir)
       end
 
-      let(:path) { File.join(xcuitest_dir, "xcuitest.log") }
+      let(:path) { File.join(xcuitest_dir, "xcodebuild.log") }
 
       it "creates a file" do
         FileUtils.rm_rf(path)
 
-        expect(RunLoop::XCUITest.log_file).to be == path
+        expect(RunLoop::XCUITest.xcodebuild_log_file).to be == path
         expect(File.exist?(path)).to be_truthy
       end
 
       it "returns existing file path" do
         FileUtils.touch(path)
-        expect(RunLoop::XCUITest.log_file).to be == path
+        expect(RunLoop::XCUITest.xcodebuild_log_file).to be == path
+      end
+    end
       end
     end
   end


### PR DESCRIPTION
### Motivation

`xcuitest.log` was confusing.