### PR TITLE
Gem: bump version to 2.1.1.pre5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 2.1.1
 
+* Replace SimControl with Simctl #441
 * Fixing syntax error in host script #438 @garyjohnson
 * Improve retry strategy for app launch on simulators #436
 * Fix instruments CLI rspec tests. #416

--- a/lib/run_loop/version.rb
+++ b/lib/run_loop/version.rb
@@ -1,5 +1,5 @@
 module RunLoop
-  VERSION = "2.1.1.pre4"
+  VERSION = "2.1.1.pre5"
 
   # A model of a software release version that can be used to compare two versions.
   #


### PR DESCRIPTION
### 2.1.1

* Replace SimControl with Simctl #441
* Fixing syntax error in host script #438 @garyjohnson
* Improve retry strategy for app launch on simulators #436
* Fix instruments CLI rspec tests. #416
* CoreSim#launch: improve retrying #434
* Filter new Xcode 7.3 simctl stderr output from `simctl list devices`
  #433
* Simctl is responsible for collecting devices on Xcode > 6
* CoreSim: patch retry on failed app launch 5300542
* Restore UIALogger flushing and ensure variables are substituted
  properly. #430
* DotDir: symlink to current result #429
* Relax deprecation warnings @TeresaP, @jane-openreply, and others
* RESET\_BETWEEN\_SCENARIOS has stopped working #426 @ankurgamit