### PR TITLE
Expose color methods as public API

### DIFF
--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -13,6 +13,11 @@ module RunLoop
       end
     end
 
+    # Returns true if Windows environment
+    def self.windows_env?
+      RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+    end
+
     # Returns true if debugging is enabled.
     def self.debug?
       ENV['DEBUG'] == '1'

--- a/lib/run_loop/logging.rb
+++ b/lib/run_loop/logging.rb
@@ -43,73 +43,69 @@ module RunLoop
   # cyan
   def self.log_unix_cmd(msg)
     if RunLoop::Environment.debug?
-      puts self.cyan("EXEC: #{msg}") if msg
+      puts Color.cyan("EXEC: #{msg}") if msg
     end
   end
 
   # blue
   def self.log_warn(msg)
-    puts self.blue("WARN: #{msg}") if msg
+    puts Color.blue("WARN: #{msg}") if msg
   end
 
   # magenta
   def self.log_debug(msg)
     if RunLoop::Environment.debug?
-      puts self.magenta("DEBUG: #{msg}") if msg
+      puts Color.magenta("DEBUG: #{msg}") if msg
     end
   end
 
   # .log_info is already taken by the XTC logger. (>_O)
   # green
   def self.log_info2(msg)
-    puts self.green("INFO: #{msg}") if msg
+    puts Color.green("INFO: #{msg}") if msg
   end
 
   # red
   def self.log_error(msg)
-    puts self.red("ERROR: #{msg}") if msg
+    puts Color.red("ERROR: #{msg}") if msg
   end
 
-  private
+  module Color
+    # @!visibility private
+    def self.colorize(string, color)
+      if RunLoop::Environment.windows_env?
+        string
+      elsif RunLoop::Environment.xtc?
+        string
+      else
+        "\033[#{color}m#{string}\033[0m"
+      end
+    end
 
-  # @!visibility private
-  def self.windows_env?
-    RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
-  end
+    # @!visibility private
+    def self.red(string)
+      colorize(string, 31)
+    end
 
-  # @!visibility private
-  def self.colorize(string, color)
-    if self.windows_env?
-      string
-    elsif RunLoop::Environment.xtc?
-      string
-    else
-      "\033[#{color}m#{string}\033[0m"
+    # @!visibility private
+    def self.blue(string)
+      colorize(string, 34)
+    end
+
+    # @!visibility private
+    def self.magenta(string)
+      colorize(string, 35)
+    end
+
+    # @!visibility private
+    def self.cyan(string)
+      colorize(string, 36)
+    end
+
+    # @!visibility private
+    def self.green(string)
+      colorize(string, 32)
     end
   end
-
-  # @!visibility private
-  def self.red(string)
-    colorize(string, 31)
-  end
-
-  # @!visibility private
-  def self.blue(string)
-    colorize(string, 34)
-  end
-
-  # @!visibility private
-  def self.magenta(string)
-    colorize(string, 35)
-  end
-
-  # @!visibility private
-  def self.cyan(string)
-    colorize(string, 36)
-  end
-
-  # @!visibility private
-  def self.green(string)
-    colorize(string, 32)
-  end
 end
+

--- a/spec/lib/logging_spec.rb
+++ b/spec/lib/logging_spec.rb
@@ -3,7 +3,7 @@ describe RunLoop do
     it 'does nothing in win32 environments' do
       expect(RunLoop::Environment).to receive(:windows_env?).and_return true
 
-      actual = RunLoop.send(:colorize, 'string', 32)
+      actual = RunLoop::Color.send(:colorize, 'string', 32)
       expect(actual).to be == 'string'
     end
 
@@ -11,7 +11,7 @@ describe RunLoop do
       expect(RunLoop::Environment).to receive(:windows_env?).and_return false
       expect(RunLoop::Environment).to receive(:xtc?).and_return true
 
-      actual = RunLoop.send(:colorize, 'string', 32)
+      actual = RunLoop::Color.send(:colorize, 'string', 32)
       expect(actual).to be == 'string'
     end
 
@@ -19,7 +19,7 @@ describe RunLoop do
       expect(RunLoop::Environment).to receive(:windows_env?).and_return false
       expect(RunLoop::Environment).to receive(:xtc?).and_return false
 
-      actual = RunLoop.send(:colorize, 'string', 32)
+      actual = RunLoop::Color.send(:colorize, 'string', 32)
       expect(actual[/32/, 0]).not_to be == nil
     end
   end

--- a/spec/lib/logging_spec.rb
+++ b/spec/lib/logging_spec.rb
@@ -1,15 +1,14 @@
 describe RunLoop do
-
   describe '.colorize' do
     it 'does nothing in win32 environments' do
-      expect(RunLoop).to receive(:windows_env?).and_return true
+      expect(RunLoop::Environment).to receive(:windows_env?).and_return true
 
       actual = RunLoop.send(:colorize, 'string', 32)
       expect(actual).to be == 'string'
     end
 
     it 'does nothing on the XTC' do
-      expect(RunLoop).to receive(:windows_env?).and_return false
+      expect(RunLoop::Environment).to receive(:windows_env?).and_return false
       expect(RunLoop::Environment).to receive(:xtc?).and_return true
 
       actual = RunLoop.send(:colorize, 'string', 32)
@@ -17,7 +16,7 @@ describe RunLoop do
     end
 
     it 'applies the color' do
-      expect(RunLoop).to receive(:windows_env?).and_return false
+      expect(RunLoop::Environment).to receive(:windows_env?).and_return false
       expect(RunLoop::Environment).to receive(:xtc?).and_return false
 
       actual = RunLoop.send(:colorize, 'string', 32)


### PR DESCRIPTION
### Motivation

Calabash wants to use these.

**Added draft tree feature for console** [#1070](https://github.com/calabash/calabash-ios/pull/1070)

ATTN: @ark-konopacki 