### PR TITLE
SpringBoard cannot detect app installed by simctl on iPad

### DIFF
--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -1,6 +1,7 @@
 module RunLoop
   class Device
 
+    require 'securerandom'
     include RunLoop::Regex
 
     # Starting in Xcode 7, iOS 9 simulators have a new "booting" state.
@@ -605,8 +606,6 @@ version: #{version}
 
     # @!visibility private
     def simulator_data_directory_sha
-      require 'securerandom'
-
       path = File.join(simulator_root_dir, 'data')
       begin
         # Typically, this returns in < 0.3 seconds.
@@ -618,6 +617,23 @@ version: #{version}
       rescue => _
         SecureRandom.uuid
       end
+    end
+
+    # @!visibility private
+    def simulator_log_file_sha
+      file = simulator_log_file_path
+
+      return nil if !File.exist?(file)
+
+      sha = OpenSSL::Digest::SHA256.new
+
+      begin
+        sha << File.read(file)
+      rescue => _
+        sha = SecureRandom.uuid
+      end
+
+      sha
     end
 
     # @!visibility private

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -604,6 +604,23 @@ version: #{version}
     end
 
     # @!visibility private
+    def simulator_data_directory_sha
+      require 'securerandom'
+
+      path = File.join(simulator_root_dir, 'data')
+      begin
+        # Typically, this returns in < 0.3 seconds.
+        Timeout.timeout(10, TimeoutError) do
+          # Errors are ignorable and users are confused by the messages.
+          options = { :handle_errors_by => :ignoring }
+          RunLoop::Directory.directory_digest(path, options)
+        end
+      rescue => _
+        SecureRandom.uuid
+      end
+    end
+
+    # @!visibility private
     # Value of <UDID>/.device.plist 'deviceType' key.
     def simulator_device_type
       plist = File.join(simulator_device_plist)

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -506,33 +506,6 @@ version: #{version}
     private
 
     # @!visibility private
-    # TODO write a unit test.
-    def last_line_from_simulator_log_file
-      file = simulator_log_file_path
-
-      return nil if !File.exist?(file)
-
-      debug = RunLoop::Environment.debug?
-
-      begin
-        io = File.open(file, 'r')
-        io.seek(-100, IO::SEEK_END)
-
-        line = io.readline
-      rescue StandardError => e
-        RunLoop.log_error("Caught #{e} while reading simulator log file") if debug
-      ensure
-        io.close if io && !io.closed?
-      end
-
-      if line
-        line.chomp
-      else
-        line
-      end
-    end
-
-    # @!visibility private
     def xcrun
       RunLoop::Xcrun.new
     end

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -319,6 +319,11 @@ version: #{version}
     end
 
     # @!visibility private
+    end
+
+    # @!visibility private
+    end
+
     #
     # Waits for three conditions:
     #
@@ -596,6 +601,18 @@ version: #{version}
         `killall udidetect &> /dev/null`
       end
       udid
+    end
+
+    # @!visibility private
+    # Value of <UDID>/.device.plist 'deviceType' key.
+    def simulator_device_type
+      plist = File.join(simulator_device_plist)
+      pbuddy.plist_read("deviceType", plist)
+    end
+
+    # @!visibility private
+    def simulator_is_ipad?
+      simulator_device_type[/iPad/, 0]
     end
 
     # @!visibility private

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -345,19 +345,28 @@ version: #{version}
       # Shorter than this gives false positives.
       delay = 0.5
 
-      # How many times to wait for stable state
+      # How many times to wait for stable state.
       max_stable_count = 3
 
-      # How long to wait for iOS 9 boot screen
+      # How long to wait for iOS 9 boot screen.
       boot_screen_wait_options = {
         :max_boot_screen_wait => 10,
         :raise_on_timeout => false
       }
 
+      # How much additional time to wait for iOS 9+ iPads.
+      #
+      # Installing and launching on iPads is problematic.
+      # Sometimes the app is installed, but SpringBoard does
+      # not recognize that the app is installed even though
+      # simctl says that it is.
+      additional_ipad_delay = delay * 2
+
       # Adjust for CI environments
       if RunLoop::Environment.ci?
         max_stable_count = 5
         boot_screen_wait_options[:max_boot_screen_wait] = 20
+        additional_ipad_delay = delay * 4
       end
 
       # iOS 9 simulators have an additional boot screen.
@@ -396,6 +405,7 @@ version: #{version}
               stable_count = 0
             elsif is_gte_ios9 && is_ipad && !waited_for_ipad
               RunLoop.log_debug("Waiting additional time for iOS 9 iPad to stabilize")
+              sleep(additional_ipad_delay)
               waited_for_ipad = true
               stable_count = 0
             else

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -319,31 +319,6 @@ version: #{version}
     end
 
     # @!visibility private
-    # Is this the first launch of this Simulator?
-    #
-    # TODO Needs unit and integration tests.
-    def simulator_first_launch?
-      megabytes = simulator_data_dir_size
-
-      if version >= RunLoop::Version.new('9.0')
-        megabytes < 20
-      elsif version >= RunLoop::Version.new('8.0')
-        megabytes < 12
-      else
-        megabytes < 8
-      end
-    end
-
-    # @!visibility private
-    # The size of the simulator data/ directory.
-    #
-    # TODO needs unit tests.
-    def simulator_data_dir_size
-      path = File.join(simulator_root_dir, 'data')
-      RunLoop::Directory.size(path, :mb)
-    end
-
-    # @!visibility private
     #
     # Waits for three conditions:
     #

--- a/spec/integration/core_simulator_spec.rb
+++ b/spec/integration/core_simulator_spec.rb
@@ -1,5 +1,8 @@
 describe RunLoop::CoreSimulator do
-  let(:simulator) { Resources.shared.default_simulator }
+  let(:simulator) do
+    Resources.shared.simctl.simulators.sample
+  end
+
   let(:app) { RunLoop::App.new(Resources.shared.cal_app_bundle_path) }
   let(:xcrun) { RunLoop::Xcrun.new }
 
@@ -39,7 +42,7 @@ describe RunLoop::CoreSimulator do
       expect(pid).to be == running
     end
 
-    it 'it does not relaunch if the simulator is already running' do
+    it 'does not relaunch if the simulator is already running' do
       core_sim.launch_simulator
 
       expect(Process).not_to receive(:spawn)

--- a/spec/integration/core_simulator_spec.rb
+++ b/spec/integration/core_simulator_spec.rb
@@ -13,7 +13,7 @@ describe RunLoop::CoreSimulator do
 
   after do
     RunLoop::CoreSimulator.terminate_core_simulator_processes
-    sleep 2
+    sleep(2)
   end
 
   describe ".erase" do
@@ -72,7 +72,6 @@ describe RunLoop::CoreSimulator do
     before do
       args = ['simctl', 'erase', simulator.udid]
       xcrun.exec(args, {:log_cmd => true })
-      simulator.simulator_wait_for_stable_state
     end
 
     it "launches the app" do
@@ -102,8 +101,6 @@ describe RunLoop::CoreSimulator do
   it 'install with simctl' do
     args = ['simctl', 'erase', simulator.udid]
     xcrun.exec(args, {:log_cmd => true })
-
-    simulator.simulator_wait_for_stable_state
 
     expect(core_sim.install)
     expect(core_sim.launch)

--- a/spec/lib/device_spec.rb
+++ b/spec/lib/device_spec.rb
@@ -422,6 +422,40 @@ describe RunLoop::Device do
     end
   end
 
+  describe "simulator stable state" do
+
+    let(:simulator) { RunLoop::Device.new("denis", "9.0", "udid") }
+
+    describe "#simulator_data_directory_sha" do
+      let(:dir) { "path/to" }
+      let(:path) { "path/to/data" }
+      let(:options) { {:handle_errors_by => :ignoring} }
+
+      before do
+        expect(simulator).to receive(:simulator_root_dir).and_return(dir)
+      end
+      it "returns a sha" do
+        expect(RunLoop::Directory).to receive(:directory_digest).with(path, options).and_return(:sha)
+
+        actual = simulator.send(:simulator_data_directory_sha)
+        expect(actual).to be == :sha
+      end
+
+      it "returns a random udid" do
+        error = RuntimeError.new("sha error")
+        expect(RunLoop::Directory).to receive(:directory_digest).with(path, options).and_raise(error)
+        expect(SecureRandom).to receive(:uuid).and_return(:random)
+
+        actual = simulator.send(:simulator_data_directory_sha)
+        expect(actual).to be == :random
+      end
+    end
+
+    describe "#simulator_log_file_sha" do
+
+    end
+  end
+
   describe 'updating the device state' do
 
     before do

--- a/spec/lib/device_spec.rb
+++ b/spec/lib/device_spec.rb
@@ -282,6 +282,36 @@ describe RunLoop::Device do
       end
     end
 
+    it "#simulator_device_type" do
+      plist = "path/to/udid/data/device.plist"
+      expect(simulator).to receive(:simulator_device_plist).and_return(plist)
+      pbuddy = RunLoop::PlistBuddy.new
+      expect(simulator).to receive(:pbuddy).and_return(pbuddy)
+      expect(pbuddy).to receive(:plist_read).with("deviceType", plist).and_return(:type)
+
+      actual = simulator.send(:simulator_device_type)
+      expect(actual).to be == :type
+    end
+
+    describe "#simulator_is_ipad?" do
+      let(:ipad) { "com.apple.CoreSimulator.SimDeviceType.iPad-Retina" }
+      let(:iphone) { "com.apple.CoreSimulator.SimDeviceType.iPhone-4s" }
+
+      it "false" do
+       expect(simulator).to receive(:simulator_device_type).and_return(iphone)
+
+       actual = simulator.send(:simulator_is_ipad?)
+       expect(actual).to be_falsey
+      end
+
+      it "true" do
+       expect(simulator).to receive(:simulator_device_type).and_return(ipad)
+
+       actual = simulator.send(:simulator_is_ipad?)
+       expect(actual).to be_truthy
+      end
+    end
+
     describe "#simulator_global_preferences_path" do
       it "is nil if a physical device" do
         expect(physical.simulator_global_preferences_path).to be_falsey

--- a/spec/lib/device_spec.rb
+++ b/spec/lib/device_spec.rb
@@ -452,7 +452,40 @@ describe RunLoop::Device do
     end
 
     describe "#simulator_log_file_sha" do
+      let(:log) { "path/to/log/file" }
 
+      before do
+        expect(simulator).to receive(:simulator_log_file_path).and_return(log)
+      end
+
+      it "returns nil if log file does not exist" do
+        expect(File).to receive(:exist?).and_return(false)
+
+        actual = simulator.send(:simulator_log_file_sha)
+        expect(actual).to be == nil
+      end
+
+      describe "log exists" do
+        before do
+          expect(File).to receive(:exist?).with(log).and_return(true)
+        end
+
+        it "return random udid if File.read errors" do
+          error = RuntimeError.new("file read error")
+          expect(File).to receive(:read).with(log).and_raise(error)
+          expect(SecureRandom).to receive(:uuid).and_return(:random)
+
+          actual = simulator.send(:simulator_log_file_sha)
+          expect(actual).to be == :random
+        end
+
+        it "returns sha" do
+          expect(File).to receive(:read).with(log).and_return("sha!")
+
+          actual = simulator.send(:simulator_log_file_sha)
+          expect(actual.to_s).to be == "0c3115eb0d6c2d05a964415fada251e49f9bebe3cfa76a9c38d56648783c92d6"
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Motivation

Progress on:

* **`simctl install` on iPad Simulators installs an app that is not recognized by Springboard or simctl** #435
* **Testing on iOS Simulators is slow in Xcode 7** [#41](https://github.com/xamarinhq/test-cloud-frameworks/issues/41)

I rewrote the "simulator stable" algorithm.  It is now much easier to explain and has consistent behavior.  The notion of "quiet time" in the previous version was not really working.

The bad news is that I am still seeing failures on iOS 9 iPads.  The good new is that they happen less frequently.