### PR TITLE
Encoding: extract uft8 coercion method from Xcrun

### DIFF
--- a/lib/run_loop.rb
+++ b/lib/run_loop.rb
@@ -1,6 +1,7 @@
 require 'run_loop/regex'
 require 'run_loop/directory'
 require 'run_loop/environment'
+require "run_loop/encoding"
 require 'run_loop/logging'
 require 'run_loop/dot_dir'
 require 'run_loop/xcrun'

--- a/lib/run_loop/encoding.rb
+++ b/lib/run_loop/encoding.rb
@@ -1,0 +1,39 @@
+
+module RunLoop
+  module Encoding
+
+    # Raised when a string cannot be coerced to UTF8
+    class UTF8Error < RuntimeError; end
+
+    # @!visibility private
+    def ensure_command_output_utf8(string, command)
+      return '' if !string
+
+      utf8 = string.force_encoding("UTF-8").chomp
+
+      return utf8 if utf8.valid_encoding?
+
+      encoded = utf8.encode("UTF-8", "UTF-8",
+                            invalid: :replace,
+                            undef: :replace,
+                            replace: "")
+
+      return encoded if encoded.valid_encoding?
+
+      raise UTF8Error, %Q{
+Could not force UTF-8 encoding on this string:
+
+#{string}
+
+which is the output of this command:
+
+#{command}
+
+Please file an issue with a stacktrace and the text of this error.
+
+https://github.com/calabash/run_loop/issues
+      }
+    end
+  end
+end
+

--- a/lib/run_loop/xcrun.rb
+++ b/lib/run_loop/xcrun.rb
@@ -1,7 +1,8 @@
 module RunLoop
   class Xcrun
 
-    require 'command_runner'
+    require "command_runner"
+    include RunLoop::Encoding
 
     # Controls the behavior of Xcrun#exec.
     #
@@ -20,9 +21,6 @@ module RunLoop
 
     # Raised when Xcrun fails.
     class Error < RuntimeError; end
-
-    # Raised when the output of the command cannot be coerced to UTF8
-    class UTF8Error < RuntimeError; end
 
     # Raised when Xcrun times out.
     class TimeoutError < RuntimeError; end
@@ -60,7 +58,7 @@ IO.popen requires all arguments to be Strings.
         start_time = Time.now
         command_output = CommandRunner.run(['xcrun'] + args, timeout: timeout)
 
-        out = encode_utf8_or_raise(command_output[:out], cmd)
+        out = ensure_command_output_utf8(command_output[:out], cmd)
         process_status = command_output[:status]
 
         hash =
@@ -71,7 +69,7 @@ IO.popen requires all arguments to be Strings.
                     :exit_status => process_status.exitstatus
               }
 
-      rescue UTF8Error => e
+      rescue RunLoop::Encoding::UTF8Error => e
         raise e
       rescue => e
         elapsed = "%0.2f" % (Time.now - start_time)
@@ -98,35 +96,6 @@ with a timeout of #{timeout}
       end
 
       hash
-    end
-
-    private
-
-    # @!visibility private
-    def encode_utf8_or_raise(string, command)
-      return '' if !string
-
-      utf8 = string.force_encoding("UTF-8").chomp
-
-      return utf8 if utf8.valid_encoding?
-
-      encoded = utf8.encode('UTF-8', 'UTF-8', invalid: :replace, undef: :replace, replace: '')
-
-      return encoded if encoded.valid_encoding?
-
-        raise UTF8Error, %Q{
-Could not force UTF-8 encoding on this string:
-
-#{string}
-
-which is the output of this command:
-
-#{command}
-
-Please file an issue with a stacktrace and the text of this error.
-
-https://github.com/calabash/run_loop/issues
-}
     end
   end
 end

--- a/spec/lib/encoding_spec.rb
+++ b/spec/lib/encoding_spec.rb
@@ -1,0 +1,85 @@
+describe RunLoop::Encoding do
+
+  let(:object) do
+    Class.new do
+      include RunLoop::Encoding
+    end.new
+  end
+
+  describe "ensure_command_output_utf8" do
+    let(:string) { "string" }
+    let(:encoded) { "encoded" }
+    let(:forced) { "forced" }
+    let(:command) { "command" }
+
+    it "returns '' if string arg is falsey" do
+      expect(object.ensure_command_output_utf8(nil, command)).to be == ''
+    end
+
+    it "returns utf8 encoding" do
+      expect(string).to receive(:force_encoding).with("UTF-8").and_return(encoded)
+      expect(encoded).to receive(:chomp).and_return(encoded)
+      expect(encoded).to receive(:valid_encoding?).and_return(true)
+
+      expect(object.ensure_command_output_utf8(string, command)).to be == encoded
+    end
+
+    it "forces utf8 encoding" do
+      expect(string).to receive(:force_encoding).with("UTF-8").and_return(encoded)
+      expect(encoded).to receive(:chomp).and_return(encoded)
+      expect(encoded).to receive(:valid_encoding?).and_return(false)
+      expect(encoded).to receive(:encode).and_return(forced)
+      expect(forced).to receive(:valid_encoding?).and_return(true)
+
+      expect(object.ensure_command_output_utf8(string, command)).to be == forced
+    end
+
+    it "raises an error if string cannot be coerced to UTF8" do
+      expect(string).to receive(:force_encoding).with("UTF-8").and_return(encoded)
+      expect(encoded).to receive(:chomp).and_return(encoded)
+      expect(encoded).to receive(:valid_encoding?).and_return(false)
+      expect(encoded).to receive(:encode).and_return(forced)
+      expect(forced).to receive(:valid_encoding?).and_return(false)
+
+      expect do
+        object.ensure_command_output_utf8(string, command)
+      end.to raise_error RunLoop::Encoding::UTF8Error,
+      /Could not force UTF-8 encoding on this string:/
+    end
+
+    it "handles string with non-UTF8 characters" do
+      file = "spec/resources/ps-with-non-utf8.log"
+      string = File.read(file)
+
+      version = RunLoop::Version.new(RUBY_VERSION)
+      if version < RunLoop::Version.new("2.1.0")
+        expect do
+          object.ensure_command_output_utf8(string, command)
+        end.to raise_error RunLoop::Encoding::UTF8Error
+      else
+        actual = object.ensure_command_output_utf8(string, command)
+        split = actual.split($-0)
+
+        expect(split[0]).to be == "  PID COMMAND"
+        expect(split[1]).to be == "  324 /usr/libexec/UserEventAgent (Aqua)"
+        expect(split[2]).to be == "  403 /Applications/M^\\M^IM^AM^SM^MM^E.app/Contents/MacOS/M^\\M^IM^AM^SM^MM^E"
+        expect(split[3]).to be == " 1497 irb"
+      end
+    end
+
+    it "handles UTF-8 strings" do
+      # Force C (non UTF-8 encoding)
+      stub_env({'LC_ALL' => 'C'})
+      args = ['cat', 'spec/resources/encoding.txt']
+
+      # Confirm that the string is read as ASCII-US8BIT
+      command_runner_hash = CommandRunner.run(args, timeout: 0.2)
+      command_runner_out = command_runner_hash[:out]
+      expect(command_runner_out.length).to be == 22
+
+      actual = object.ensure_command_output_utf8(command_runner_out, command)
+      expect(actual).to be == 'ITZVÓÃ ●℆❡♡'
+    end
+  end
+end
+

--- a/spec/lib/xcrun_spec.rb
+++ b/spec/lib/xcrun_spec.rb
@@ -32,12 +32,12 @@ describe RunLoop::Xcrun do
     end
 
     it "re-raises error if UTF8 encoding fails" do
-      error = RunLoop::Xcrun::UTF8Error.new("complex message")
-      expect(xcrun).to receive(:encode_utf8_or_raise).and_raise(error)
+      error = RunLoop::Encoding::UTF8Error.new("complex message")
+      expect(xcrun).to receive(:ensure_command_output_utf8).and_raise(error)
 
       expect do
         xcrun.exec(["sleep", "0.5"])
-      end.to raise_error RunLoop::Xcrun::UTF8Error, /complex message/
+      end.to raise_error RunLoop::Encoding::UTF8Error, /complex message/
     end
 
     it 're-raises error thrown by CommandRunner' do
@@ -65,81 +65,6 @@ describe RunLoop::Xcrun do
       end
     end
 
-    describe "#encode_utf8_or_raise" do
-      let(:string) { "string" }
-      let(:encoded) { "encoded" }
-      let(:forced) { "forced" }
-      let(:command) { "command" }
-
-      it "returns '' if string arg is falsey" do
-        expect(xcrun.send(:encode_utf8_or_raise, nil, command)).to be == ''
-      end
-
-      it "returns utf8 encoding" do
-        expect(string).to receive(:force_encoding).with("UTF-8").and_return(encoded)
-        expect(encoded).to receive(:chomp).and_return(encoded)
-        expect(encoded).to receive(:valid_encoding?).and_return(true)
-
-        expect(xcrun.send(:encode_utf8_or_raise, string, command)).to be == encoded
-      end
-
-      it "forces utf8 encoding" do
-        expect(string).to receive(:force_encoding).with("UTF-8").and_return(encoded)
-        expect(encoded).to receive(:chomp).and_return(encoded)
-        expect(encoded).to receive(:valid_encoding?).and_return(false)
-        expect(encoded).to receive(:encode).and_return(forced)
-        expect(forced).to receive(:valid_encoding?).and_return(true)
-
-        expect(xcrun.send(:encode_utf8_or_raise, string, command)).to be == forced
-      end
-
-      it "raises an error if string cannot be coerced to UTF8" do
-        expect(string).to receive(:force_encoding).with("UTF-8").and_return(encoded)
-        expect(encoded).to receive(:chomp).and_return(encoded)
-        expect(encoded).to receive(:valid_encoding?).and_return(false)
-        expect(encoded).to receive(:encode).and_return(forced)
-        expect(forced).to receive(:valid_encoding?).and_return(false)
-
-        expect do
-          xcrun.send(:encode_utf8_or_raise, string, command)
-        end.to raise_error RunLoop::Xcrun::UTF8Error,
-        /Could not force UTF-8 encoding on this string:/
-      end
-
-      it "handles string with non-UTF8 characters" do
-        file = "spec/resources/ps-with-non-utf8.log"
-        string = File.read(file)
-
-        version = RunLoop::Version.new(RUBY_VERSION)
-        if version < RunLoop::Version.new("2.1.0")
-           expect do
-             xcrun.send(:encode_utf8_or_raise, string, command)
-           end.to raise_error RunLoop::Xcrun::UTF8Error
-        else
-          actual = xcrun.send(:encode_utf8_or_raise, string, command)
-          split = actual.split($-0)
-
-          expect(split[0]).to be == "  PID COMMAND"
-          expect(split[1]).to be == "  324 /usr/libexec/UserEventAgent (Aqua)"
-          expect(split[2]).to be == "  403 /Applications/M^\\M^IM^AM^SM^MM^E.app/Contents/MacOS/M^\\M^IM^AM^SM^MM^E"
-          expect(split[3]).to be == " 1497 irb"
-        end
-      end
-
-      it "handles UTF-8 strings" do
-        # Force C (non UTF-8 encoding)
-        stub_env({'LC_ALL' => 'C'})
-        args = ['cat', 'spec/resources/encoding.txt']
-
-        # Confirm that the string is read as ASCII-US8BIT
-        command_runner_hash = CommandRunner.run(args, timeout: 0.2)
-        command_runner_out = command_runner_hash[:out]
-        expect(command_runner_out.length).to be == 22
-
-        actual = xcrun.send(:encode_utf8_or_raise, command_runner_out, command)
-        expect(actual).to be == 'ITZVÓÃ ●℆❡♡'
-      end
-    end
 
     describe 'contents of returned hash' do
       it 'mocked' do


### PR DESCRIPTION
### Motivation

We need the coercion method in other places.

This is a strict rename + extract refactor.