### PR TITLE
Shell: a mixin for executing shell commands safely

### DIFF
--- a/lib/run_loop.rb
+++ b/lib/run_loop.rb
@@ -1,7 +1,8 @@
 require 'run_loop/regex'
 require 'run_loop/directory'
-require 'run_loop/environment'
 require "run_loop/encoding"
+require "run_loop/shell"
+require 'run_loop/environment'
 require 'run_loop/logging'
 require 'run_loop/dot_dir'
 require 'run_loop/xcrun'

--- a/lib/run_loop/shell.rb
+++ b/lib/run_loop/shell.rb
@@ -1,0 +1,103 @@
+module RunLoop
+  module Shell
+
+    require "command_runner"
+    require "run_loop/encoding"
+    include RunLoop::Encoding
+
+    # Controls the behavior of Shell#exec.
+    #
+    # You can override these values if they do not work in your environment.
+    #
+    # For cucumber users, the best place to override would be in your
+    # features/support/env.rb.
+    #
+    # For example:
+    #
+    # RunLoop::Shell::DEFAULT_OPTIONS[:timeout] = 60
+    DEFAULT_OPTIONS = {
+      :timeout => 30,
+      :log_cmd => false
+    }
+
+    # Raised when shell command fails.
+    class Error < RuntimeError; end
+
+    # Raised when shell command times out.
+    class TimeoutError < RuntimeError; end
+
+    def exec(args, options={})
+
+      merged_options = DEFAULT_OPTIONS.merge(options)
+
+      timeout = merged_options[:timeout]
+
+      unless args.is_a?(Array)
+        raise ArgumentError,
+              "Expected args '#{args}' to be an Array, but found '#{args.class}'"
+      end
+
+      args.each do |arg|
+        unless arg.is_a?(String)
+          raise ArgumentError,
+%Q{Expected arg '#{arg}' to be a String, but found '#{arg.class}'
+IO.popen requires all arguments to be Strings.
+}
+        end
+      end
+
+      cmd = "#{args.join(' ')}"
+
+      # Don't see your log?
+      # Commands are only logged when debugging.
+      RunLoop.log_unix_cmd(cmd) if merged_options[:log_cmd]
+
+      hash = {}
+
+      begin
+
+        start_time = Time.now
+        command_output = CommandRunner.run(args, timeout: timeout)
+
+        out = ensure_command_output_utf8(command_output[:out], cmd)
+        process_status = command_output[:status]
+
+        hash =
+              {
+                    :out => out,
+                    :pid => process_status.pid,
+                    # nil if process was killed before completion
+                    :exit_status => process_status.exitstatus
+              }
+
+      rescue RunLoop::Encoding::UTF8Error => e
+        raise e
+      rescue => e
+        elapsed = "%0.2f" % (Time.now - start_time)
+        raise Error,
+%Q{Encountered an error after #{elapsed} seconds:
+
+#{e.message}
+
+executing this command:
+
+#{cmd}
+}
+      end
+
+      if hash[:exit_status].nil?
+        elapsed = "%0.2f" % (Time.now - start_time)
+        raise TimeoutError,
+%Q{Timed out after #{elapsed} seconds executing
+
+#{cmd}
+
+with a timeout of #{timeout}
+}
+      end
+
+      hash
+    end
+  end
+end
+

--- a/spec/lib/shell_spec.rb
+++ b/spec/lib/shell_spec.rb
@@ -1,0 +1,87 @@
+describe RunLoop::Shell do
+
+  let(:object) do
+    Class.new do
+      include RunLoop::Shell
+    end.new
+  end
+
+
+  let(:process_status) do
+    # It is not possible call Process::Status.new
+    `echo`
+    $?
+  end
+
+  let(:command_output) do
+    {
+          :out => "",
+          :status => process_status
+    }
+  end
+
+  describe "#exec" do
+    it "raises an error if arg is not an Array" do
+      expect do
+        object.exec("simctl list devices")
+      end.to raise_error ArgumentError, /Expected args/
+    end
+
+    it "raises an error if any arg is not a string" do
+      expect do
+        object.exec(["sleep", 5])
+      end.to raise_error ArgumentError,
+      /Expected arg '5' to be a String, but found 'Fixnum'/
+    end
+
+    it "re-raises error if UTF8 encoding fails" do
+      error = RunLoop::Encoding::UTF8Error.new("complex message")
+      expect(object).to receive(:ensure_command_output_utf8).and_raise(error)
+
+      expect do
+        object.exec(["sleep", "0.5"])
+      end.to raise_error RunLoop::Encoding::UTF8Error, /complex message/
+    end
+
+    it "re-raises error thrown by CommandRunner" do
+      expect(CommandRunner).to receive(:run).and_raise RuntimeError, "Some error"
+
+      expect do
+        object.exec(["sleep", "0.5"])
+      end.to raise_error RunLoop::Shell::Error, /Some error/
+    end
+
+    describe "raises timeout error if CommandRunner timed out" do
+      it "mocked" do
+        expect(process_status).to receive(:exitstatus).and_return(nil)
+        expect(CommandRunner).to receive(:run).and_return(command_output)
+
+        expect do
+          object.exec(["sleep", "0.5"])
+        end.to raise_error RunLoop::Shell::TimeoutError, /Timed out after/
+      end
+
+      it "actual" do
+        expect do
+          object.exec(["sleep", "0.5"], timeout: 0.05)
+        end.to raise_error RunLoop::Shell::TimeoutError, /Timed out after/
+      end
+    end
+
+    describe "contents of returned hash" do
+      it "mocked" do
+        expect(process_status).to receive(:exitstatus).and_return(256)
+        expect(process_status).to receive(:pid).and_return(3030)
+        command_output[:out] = "mocked"
+        expect(CommandRunner).to receive(:run).and_return(command_output)
+
+        hash = object.exec(["sleep", "0.1"])
+
+        expect(hash[:out]).to be == "mocked"
+        expect(hash[:pid]).to be == 3030
+        expect(hash[:exit_status]).to be == 256
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
### Motivation

I want a mixin to provide safe execution of shell commands.

Progress on:

* Pass all `read` calls through utf-8 filter #230
* run all shell commands through Xcrun #285
