### PR TITLE
Physical device app LifeCycle API

### DIFF
--- a/lib/run_loop.rb
+++ b/lib/run_loop.rb
@@ -43,6 +43,7 @@ require "run_loop/http/error"
 require "run_loop/http/server"
 require "run_loop/http/request"
 require "run_loop/http/retriable_client"
+require "run_loop/physical_device/life_cycle"
 
 module RunLoop
 

--- a/lib/run_loop.rb
+++ b/lib/run_loop.rb
@@ -1,3 +1,4 @@
+require "run_loop/abstract"
 require 'run_loop/regex'
 require 'run_loop/directory'
 require "run_loop/encoding"

--- a/lib/run_loop/abstract.rb
+++ b/lib/run_loop/abstract.rb
@@ -1,0 +1,18 @@
+
+module RunLoop
+  module Abstract
+    # @!visibility private
+    class AbstractMethodError < StandardError; end
+
+    # @!visibility private
+    def abstract_method!
+      if Kernel.method_defined?(:caller_locations)
+        method_name = icaller_locations.first.label
+      else
+        method_name = caller.first[/\`(.*)\'/, 1]
+      end
+
+      raise AbstractMethodError.new("Abstract method '#{method_name}'")
+    end
+  end
+end

--- a/lib/run_loop/physical_device/life_cycle.rb
+++ b/lib/run_loop/physical_device/life_cycle.rb
@@ -194,16 +194,10 @@ must be a physical device.]
 
       # Removes a file or directory from the app sandbox.
       #
-      # If the path does not exist, no error will be raised.
-      #
-      # Documents, Library, Preferences, and tmp directories will be
-      # deleted, but then recreated.  For example:
-      #
-      #  remove_file_from_sandbox("Preferences")
-      #
-      # The Preferences directory will be deleted and then recreated.
+      # Behavior TBD.
       def remove_from_sandbox(path)
-        abstract_method!
+        raise NotImplementedError,
+          "The behavior of the remove_from_sandbox method has not been determined"
       end
 
       # @!visibility private

--- a/lib/run_loop/physical_device/life_cycle.rb
+++ b/lib/run_loop/physical_device/life_cycle.rb
@@ -77,7 +77,7 @@ must be a physical device.]
       # no version check is performed.
       #
       # App data is never preserved.  If you want to preserve the app data,
-      # call `ensure_app_installed`.
+      # call `ensure_newest_installed`.
       #
       # Possible return values:
       #
@@ -99,7 +99,7 @@ must be a physical device.]
       #
       # App data is never preserved.  If you want to install a new version of
       # an app and preserve app data (upgrade testing), call
-      # `ensure_app_installed`.
+      # `ensure_newest_installed`.
       #
       # Possible return values:
       #
@@ -143,7 +143,7 @@ must be a physical device.]
       # @raise [UninstallError] If the app could not be uninstalled.
       #
       # @return [Symbol] A keyword that describes the action that was taken.
-      def ensure_app_installed(app_or_ipa)
+      def ensure_newest_installed(app_or_ipa)
         abstract_method!
       end
 

--- a/lib/run_loop/physical_device/life_cycle.rb
+++ b/lib/run_loop/physical_device/life_cycle.rb
@@ -36,6 +36,10 @@ module RunLoop
 
       attr_reader :device
 
+      # Create a new instance.
+      #
+      # @param [RunLoop::Device] device A physical device.
+      # @raise [ArgumentError] If device is a simulator.
       def initialize(device)
         if !device.physical_device?
           raise ArgumentError, %Q[Device:
@@ -61,6 +65,7 @@ must be a physical device.]
 
       # Is the app installed?
       #
+      # @param [String] bundle_id The CFBundleIdentifier of an app.
       # @return [Boolean] true or false
       def app_installed?(bundle_id)
         abstract_method!
@@ -79,7 +84,12 @@ must be a physical device.]
       # * :reinstalled => app was installed, but app data was not preserved.
       # * :installed => app was not installed.
       #
+      # @param [RunLoop::Ipa, RunLoop::App] app_or_ipa The ipa to install.
+      #   The caller is responsible for validating the ipa for the device by
+      #   checking that the codesign and instruction set is correct.
+      #
       # @raise [InstallError] If app was not installed.
+      #
       # @return [Symbol] A keyword describing the action that was performed.
       def install_app(app_or_ipa)
         abstract_method!
@@ -96,8 +106,11 @@ must be a physical device.]
       # * :nothing => app was not installed
       # * :uninstall => app was uninstalled
       #
+      # @param [String] bundle_id The CFBundleIdentifier of an app.
+      #
       # @raise [UninstallError] If the app cannot be uninstalled, usually
       #   because it is a system app.
+      #
       # @return [Symbol] A keyword that describes what action was performed.
       def uninstall_app(bundle_id)
         abstract_method!
@@ -122,6 +135,10 @@ must be a physical device.]
       #                   but app data was not preserved.
       # * :installed => app was not installed.
       #
+      # @param [RunLoop::Ipa, RunLoop::App] app_or_ipa The ipa to install.
+      #   The caller is responsible for validating the ipa for the device by
+      #   checking that the codesign and instruction set is correct.
+      #
       # @raise [InstallError] If the app could not be installed.
       # @raise [UninstallError] If the app could not be uninstalled.
       #
@@ -136,8 +153,18 @@ must be a physical device.]
       # the CFBundleShortVersionString. If either are different, then this
       # method returns false.
       #
+      # @param [RunLoop::Ipa, RunLoop::App] app_or_ipa The ipa to install.
+      #   The caller is responsible for validating the ipa for the device by
+      #   checking that the codesign and instruction set is correct.
+      #
       # @raise [RuntimeError] If app is not already installed.
       def installed_app_same_as?(app_or_ipa)
+        abstract_method!
+      end
+
+      # Returns true if this tool can reset an app's sandbox without
+      # uninstalling the app.
+      def can_reset_app_sandbox?
         abstract_method!
       end
 
@@ -145,9 +172,14 @@ must be a physical device.]
       #
       # This method will never uninstall the app.  If the concrete
       # implementation cannot reset the app data, this method should raise
-      # an exception.
+      # a RunLoop::PhysicalDevice::NotImplementedError
       #
       # Does not clear Keychain.  Use the Calabash iOS Keychain API.
+      #
+      # @param [String] bundle_id The CFBundleIdentifier of an app.
+      #
+      # @raise [RunLoop::PhysicalDevice::NotImplementedError] If this tool
+      #   cannot reset the app sandbox without unintalling the app.
       def reset_app_sandbox(bundle_id)
         abstract_method!
       end

--- a/lib/run_loop/physical_device/life_cycle.rb
+++ b/lib/run_loop/physical_device/life_cycle.rb
@@ -8,6 +8,9 @@ module RunLoop
     # Raised when uninstall fails.
     class UninstallError < RuntimeError; end
 
+    # Raised when tool cannot perform task.
+    class NotImplementedError < StandardError; end
+
     # Controls the behavior of various life cycle commands.
     #
     # You can override these values if they do not work in your environment.
@@ -180,34 +183,13 @@ must be a physical device.]
       #
       # * sandbox/Documents
       # * sandbox/Library
-      # * sandbox/Preferences
+      # * sandbox/Library/Preferences
       # * sandbox/tmp
       #
-      # The data is a hash of arrays that define source/target file
-      # path pairs.
-      #
-      #  {
-      #    :documents => [
-      #      {
-      #        :source => "path/to/file/on/disk",
-      #        :target => "sub/dir/under/Documents"
-      #      },
-      #      {
-      #        :source => "path/to/other/file",
-      #        :target => "./"
-      #      }
-      #    ],
-      #
-      #    :library => [ < ditto >],
-      #    :preferences => [ < ditto > ],
-      #    :tmp => [ < ditto >]
-      #  }
-      #
-      # * If a file exists at a target path, it will be replaced.
-      # * Subdirectories will be created as necessary.
-      # * :source files must exist.
+      # Behavior TBD.
       def sideload(data)
-        abstract_method!
+        raise NotImplementedError,
+          "The behavior of the sideload method has not been determined"
       end
 
       # Removes a file or directory from the app sandbox.

--- a/lib/run_loop/physical_device/life_cycle.rb
+++ b/lib/run_loop/physical_device/life_cycle.rb
@@ -8,10 +8,28 @@ module RunLoop
     # Raised when uninstall fails.
     class UninstallError < RuntimeError; end
 
+    # Controls the behavior of various life cycle commands.
+    #
+    # You can override these values if they do not work in your environment.
+    #
+    # For cucumber users, the best place to override would be in your
+    # features/support/env.rb.
+    #
+    # For example:
+    #
+    # RunLoop::PhysicalDevice::LifeCycle::DEFAULT_OPTIONS[:timeout] = 60
+    DEFAULT_OPTIONS = {
+      :install_timeout => RunLoop::Environment.ci? ? 120 : 30
+    }
+
     # @!visibility private
     class LifeCycle
 
+      require "run_loop/abstract"
       include RunLoop::Abstract
+
+      require "run_loop/shell"
+      include RunLoop::Shell
 
       attr_reader :device
 
@@ -74,6 +92,7 @@ must be a physical device.]
       #
       # * :nothing => app was not installed
       # * :uninstall => app was uninstalled
+      #
       # @raise [UninstallError] If the app cannot be uninstalled, usually
       #   because it is a system app.
       # @return [Symbol] A keyword that describes what action was performed.

--- a/lib/run_loop/physical_device/life_cycle.rb
+++ b/lib/run_loop/physical_device/life_cycle.rb
@@ -1,0 +1,241 @@
+module RunLoop
+  # @!visibility private
+  module PhysicalDevice
+
+    # Raised when installation fails.
+    class InstallError < RuntimeError; end
+
+    # Raised when uninstall fails.
+    class UninstallError < RuntimeError; end
+
+    # @!visibility private
+    class LifeCycle
+
+      include RunLoop::Abstract
+
+      attr_reader :device
+
+      def initialize(device)
+        if !device.physical_device?
+          raise ArgumentError, %Q[Device:
+
+#{device}
+
+must be a physical device.]
+        end
+        @device = device
+      end
+
+      # Is the tool installed?
+      def self.tool_is_installed?
+        raise RunLoop::Abstract::AbstractMethodError,
+          "Subclass must implement '.tool_is_installed?'"
+      end
+
+      # Path to tool.
+      def self.executable_path
+        raise RunLoop::Abstract::AbstractMethodError,
+          "Subclass must implement '.executable_path'"
+      end
+
+      # Is the app installed?
+      #
+      # @return [Boolean] true or false
+      def app_installed?(bundle_id)
+        abstract_method!
+      end
+
+      # Install the app or ipa.
+      #
+      # If the app is already installed, it will be reinstalled from disk;
+      # no version check is performed.
+      #
+      # App data is never preserved.  If you want to preserve the app data,
+      # call `ensure_app_installed`.
+      #
+      # Possible return values:
+      #
+      # * :reinstalled => app was installed, but app data was not preserved.
+      # * :installed => app was not installed.
+      #
+      # @raise [InstallError] If app was not installed.
+      # @return [Symbol] A keyword describing the action that was performed.
+      def install_app(app_or_ipa)
+        abstract_method!
+      end
+
+      # Uninstall the app with bundle_id.
+      #
+      # App data is never preserved.  If you want to install a new version of
+      # an app and preserve app data (upgrade testing), call
+      # `ensure_app_installed`.
+      #
+      # Possible return values:
+      #
+      # * :nothing => app was not installed
+      # * :uninstall => app was uninstalled
+      # @raise [UninstallError] If the app cannot be uninstalled, usually
+      #   because it is a system app.
+      # @return [Symbol] A keyword that describes what action was performed.
+      def uninstall_app(bundle_id)
+        abstract_method!
+      end
+
+      # Ensures the app is installed and ensures that app is not stale by
+      # asking if the version of installed app is different than the version
+      # of the app or ipa on disk.
+      #
+      # The concrete implementation needs to check the CFBundleVersion and
+      # the CFBundleShortVersionString.  If either are different, then the
+      # app should be reinstalled.
+      #
+      # If possible, the app data should be preserved across reinstallation.
+      #
+      # Possible return values:
+      #
+      # * :nothing => app was already installed and versions matched.
+      # * :upgraded => app was stale; newer version from disk was installed and
+      #                app data was preserved.
+      # * :reinstalled => app was stale; newer version from disk was installed,
+      #                   but app data was not preserved.
+      # * :installed => app was not installed.
+      #
+      # @raise [InstallError] If the app could not be installed.
+      # @raise [UninstallError] If the app could not be uninstalled.
+      #
+      # @return [Symbol] A keyword that describes the action that was taken.
+      def ensure_app_installed(app_or_ipa)
+        abstract_method!
+      end
+
+      # Is the app on disk the same as the installed app?
+      #
+      # The concrete implementation needs to check the CFBundleVersion and
+      # the CFBundleShortVersionString. If either are different, then this
+      # method returns false.
+      #
+      # @raise [RuntimeError] If app is not already installed.
+      def installed_app_same_as?(app_or_ipa)
+        abstract_method!
+      end
+
+      # Clear the app sandbox.
+      #
+      # This method will never uninstall the app.  If the concrete
+      # implementation cannot reset the app data, this method should raise
+      # an exception.
+      #
+      # Does not clear Keychain.  Use the Calabash iOS Keychain API.
+      def reset_app_sandbox(bundle_id)
+        abstract_method!
+      end
+
+      # Return the architecture of the device.
+      def architecture
+        abstract_method!
+      end
+
+      # Is the app or ipa compatible with the architecture of the device?
+      def app_has_compatible_architecture?(app_or_ipa)
+        abstract_method!
+      end
+
+      # Return true if the device is an iPhone.
+      def iphone?
+        abstract_method!
+      end
+
+      # Return false if the device is an iPad.
+      def ipad?
+        abstract_method!
+      end
+
+      # Return the model of the device.
+      def model
+        abstract_method!
+      end
+
+      # Sideload data into the app's sandbox.
+      #
+      # These directories exist in the application sandbox.
+      #
+      # * sandbox/Documents
+      # * sandbox/Library
+      # * sandbox/Preferences
+      # * sandbox/tmp
+      #
+      # The data is a hash of arrays that define source/target file
+      # path pairs.
+      #
+      #  {
+      #    :documents => [
+      #      {
+      #        :source => "path/to/file/on/disk",
+      #        :target => "sub/dir/under/Documents"
+      #      },
+      #      {
+      #        :source => "path/to/other/file",
+      #        :target => "./"
+      #      }
+      #    ],
+      #
+      #    :library => [ < ditto >],
+      #    :preferences => [ < ditto > ],
+      #    :tmp => [ < ditto >]
+      #  }
+      #
+      # * If a file exists at a target path, it will be replaced.
+      # * Subdirectories will be created as necessary.
+      # * :source files must exist.
+      def sideload(data)
+        abstract_method!
+      end
+
+      # Removes a file or directory from the app sandbox.
+      #
+      # If the path does not exist, no error will be raised.
+      #
+      # Documents, Library, Preferences, and tmp directories will be
+      # deleted, but then recreated.  For example:
+      #
+      #  remove_file_from_sandbox("Preferences")
+      #
+      # The Preferences directory will be deleted and then recreated.
+      def remove_from_sandbox(path)
+        abstract_method!
+      end
+
+      # @!visibility private
+      def expect_app_or_ipa(app_or_ipa)
+        if ![is_app?(app_or_ipa), is_ipa?(app_or_ipa)].any?
+          if app_or_ipa.nil?
+            object = "nil"
+          elsif app_or_ipa == ""
+            object = "<empty string>"
+          else
+            object = app_or_ipa
+          end
+
+          raise ArgumentError, %Q[Expected:
+
+#{object}
+
+to be a RunLoop::App or a RunLoop::Ipa.]
+        end
+
+        true
+      end
+
+      # @!visibility private
+      def is_app?(app_or_ipa)
+        app_or_ipa.is_a?(RunLoop::App)
+      end
+
+      # @!visibility private
+      def is_ipa?(app_or_ipa)
+        app_or_ipa.is_a?(RunLoop::Ipa)
+      end
+    end
+  end
+end
+

--- a/spec/lib/abstract_spec.rb
+++ b/spec/lib/abstract_spec.rb
@@ -1,0 +1,20 @@
+
+describe RunLoop::Abstract do
+
+  let(:object) do
+    Class.new do
+      include RunLoop::Abstract
+
+      def an_abstract_method
+        abstract_method!
+      end
+    end.new
+  end
+
+  it "#abstract_method" do
+    expect do
+      object.an_abstract_method
+    end.to raise_error RunLoop::Abstract::AbstractMethodError, /an_abstract_method/
+  end
+end
+

--- a/spec/lib/physical_device/life_cycle_spec.rb
+++ b/spec/lib/physical_device/life_cycle_spec.rb
@@ -115,7 +115,8 @@ describe RunLoop::PhysicalDevice::LifeCycle do
     it "#sideload" do
       expect do
         lc.sideload({})
-      end.to raise_error RunLoop::Abstract::AbstractMethodError, /sideload/
+      end.to raise_error(RunLoop::PhysicalDevice::NotImplementedError,
+                         /The behavior of the sideload method has not been determined/)
     end
 
     it "#remove_from_sandbox" do

--- a/spec/lib/physical_device/life_cycle_spec.rb
+++ b/spec/lib/physical_device/life_cycle_spec.rb
@@ -125,8 +125,6 @@ describe RunLoop::PhysicalDevice::LifeCycle do
       end.to raise_error(RunLoop::PhysicalDevice::NotImplementedError,
                          /The behavior of the remove_from_sandbox method has not been determined/)
     end
-
-    end
   end
 
   describe "concrete methods" do

--- a/spec/lib/physical_device/life_cycle_spec.rb
+++ b/spec/lib/physical_device/life_cycle_spec.rb
@@ -1,0 +1,175 @@
+
+describe RunLoop::PhysicalDevice::LifeCycle do
+
+  let(:udid) { "e60ef9ae876ab4a218ee966d0525c9fb79e56065" }
+  let(:device) { RunLoop::Device.new("planetx", "9.3.1", udid) }
+
+  describe ".new" do
+    it "raises error if device is not a physical device" do
+      expect(device).to receive(:physical_device?).at_least(:once).and_return(false)
+
+      expect do
+        RunLoop::PhysicalDevice::LifeCycle.new(device)
+      end.to raise_error ArgumentError, /must be a physical device/
+    end
+
+    it "sets the :device attribute" do
+      lc = RunLoop::PhysicalDevice::LifeCycle.new(device)
+
+      expect(lc.device).to be == device
+      expect(lc.instance_variable_get(:@device)).to be == device
+    end
+  end
+
+  describe "abstract class methods" do
+    let(:mod) { RunLoop::PhysicalDevice::LifeCycle }
+
+    it ".tool_is_installed?" do
+      expect do
+        mod.tool_is_installed?
+      end.to raise_error RunLoop::Abstract::AbstractMethodError, /tool_is_installed\?/
+    end
+
+    it ".executable_path" do
+      expect do
+        mod.executable_path
+      end.to raise_error RunLoop::Abstract::AbstractMethodError, /executable_path/
+    end
+  end
+
+  describe "abstract instance methods" do
+
+    let(:lc) { RunLoop::PhysicalDevice::LifeCycle.new(device) }
+
+    it "#app_installed?" do
+      expect do
+        lc.app_installed?("com.example.MyApp")
+      end.to raise_error RunLoop::Abstract::AbstractMethodError, /app_installed?/
+    end
+
+    it "#install_app" do
+      expect do
+        lc.install_app("app instance")
+      end.to raise_error RunLoop::Abstract::AbstractMethodError, /install_app/
+    end
+
+    it "#uninstall_app" do
+      expect do
+        lc.uninstall_app("app instance")
+      end.to raise_error RunLoop::Abstract::AbstractMethodError, /uninstall_app/
+    end
+
+    it "#ensure_app_installed" do
+      expect do
+        lc.ensure_app_installed("app instance")
+      end.to raise_error RunLoop::Abstract::AbstractMethodError, /ensure_app_installed/
+    end
+
+    it "#installed_app_same_as?" do
+      expect do
+        lc.installed_app_same_as?("app instance")
+      end.to raise_error RunLoop::Abstract::AbstractMethodError, /installed_app_same_as?/
+    end
+
+    it "#reset_app_sandbox?" do
+      expect do
+        lc.reset_app_sandbox("com.example.MyApp")
+      end.to raise_error RunLoop::Abstract::AbstractMethodError, /reset_app_sandbox/
+    end
+
+    it "#architecture" do
+      expect do
+        lc.architecture
+      end.to raise_error RunLoop::Abstract::AbstractMethodError, /architecture/
+    end
+
+    it "#app_has_compatible_architecture?" do
+      expect do
+        lc.app_has_compatible_architecture?("app instance")
+      end.to raise_error RunLoop::Abstract::AbstractMethodError, /app_has_compatible_architecture\?/
+    end
+
+    it "#iphone?" do
+      expect do
+        lc.iphone?
+      end.to raise_error RunLoop::Abstract::AbstractMethodError, /iphone\?/
+    end
+
+    it "#ipad?" do
+      expect do
+        lc.ipad?
+      end.to raise_error RunLoop::Abstract::AbstractMethodError, /ipad\?/
+    end
+
+    it "#model" do
+      expect do
+        lc.model
+      end.to raise_error RunLoop::Abstract::AbstractMethodError, /model/
+    end
+
+    it "#sideload" do
+      expect do
+        lc.sideload({})
+      end.to raise_error RunLoop::Abstract::AbstractMethodError, /sideload/
+    end
+
+    it "#remove_from_sandbox" do
+      expect do
+        lc.remove_from_sandbox("relative/path")
+      end.to raise_error RunLoop::Abstract::AbstractMethodError, /remove_from_sandbox/
+    end
+  end
+
+  describe "concrete methods" do
+    let(:lc) { RunLoop::PhysicalDevice::LifeCycle.new(device) }
+    let(:app) do
+      path = Resources.shared.app_bundle_path
+      RunLoop::App.new(path)
+    end
+
+    let(:ipa) do
+      path = Resources.shared.ipa_path
+      RunLoop::Ipa.new(path)
+    end
+
+    describe "#expect_app_or_ipa" do
+      it "app instance" do
+        expect(lc.expect_app_or_ipa(app)).to be_truthy
+      end
+
+      it "ipa instance" do
+        expect(lc.expect_app_or_ipa(ipa)).to be_truthy
+      end
+
+      describe "raises error when" do
+        it "receives nil" do
+          expect do
+            lc.expect_app_or_ipa(nil)
+          end.to raise_error ArgumentError, /nil/
+        end
+
+        it "receives an empty string" do
+          expect do
+            lc.expect_app_or_ipa("")
+          end.to raise_error ArgumentError, /<empty string>/
+        end
+
+        it "receives an other object" do
+          expect do
+            lc.expect_app_or_ipa({})
+          end.to raise_error ArgumentError, /{}/
+        end
+      end
+    end
+
+    it "#is_app?" do
+      expect(lc.is_app?(app)).to be_truthy
+      expect(lc.is_app?(ipa)).to be_falsey
+    end
+
+    it "#is_ipa?" do
+      expect(lc.is_ipa?(app)).to be_falsey
+      expect(lc.is_ipa?(ipa)).to be_truthy
+    end
+  end
+end

--- a/spec/lib/physical_device/life_cycle_spec.rb
+++ b/spec/lib/physical_device/life_cycle_spec.rb
@@ -19,6 +19,11 @@ describe RunLoop::PhysicalDevice::LifeCycle do
       expect(lc.device).to be == device
       expect(lc.instance_variable_get(:@device)).to be == device
     end
+
+    it "responds to #exec" do
+      lc = RunLoop::PhysicalDevice::LifeCycle.new(device)
+      expect(lc.respond_to?(:exec)).to be_truthy
+    end
   end
 
   describe "abstract class methods" do

--- a/spec/lib/physical_device/life_cycle_spec.rb
+++ b/spec/lib/physical_device/life_cycle_spec.rb
@@ -64,10 +64,10 @@ describe RunLoop::PhysicalDevice::LifeCycle do
       end.to raise_error RunLoop::Abstract::AbstractMethodError, /uninstall_app/
     end
 
-    it "#ensure_app_installed" do
+    it "#ensure_newest_installed" do
       expect do
-        lc.ensure_app_installed("app instance")
-      end.to raise_error RunLoop::Abstract::AbstractMethodError, /ensure_app_installed/
+        lc.ensure_newest_installed("app instance")
+      end.to raise_error RunLoop::Abstract::AbstractMethodError, /ensure_newest_installed/
     end
 
     it "#installed_app_same_as?" do

--- a/spec/lib/physical_device/life_cycle_spec.rb
+++ b/spec/lib/physical_device/life_cycle_spec.rb
@@ -122,7 +122,10 @@ describe RunLoop::PhysicalDevice::LifeCycle do
     it "#remove_from_sandbox" do
       expect do
         lc.remove_from_sandbox("relative/path")
-      end.to raise_error RunLoop::Abstract::AbstractMethodError, /remove_from_sandbox/
+      end.to raise_error(RunLoop::PhysicalDevice::NotImplementedError,
+                         /The behavior of the remove_from_sandbox method has not been determined/)
+    end
+
     end
   end
 


### PR DESCRIPTION
### Motivation

We want an API for handling an app's life cycle on physical devices.

- [x] @TobiasRoikjer Can you review? Please do not merge.

### TODO

- [x] rename `ensure_app_installed`
- [x] ~~add resigning API~~ should be handled by a different module.