### PR TITLE
Catch invalid APP and device target settings

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -151,6 +151,34 @@ module RunLoop
       merged_options = options.merge(discovered_options)
 
       if device.simulator?
+        if !app_details[:app]
+          raise %Q[
+
+Invalid APP, APP_BUNDLE_PATH, or BUNDLE_ID detected.
+
+The following information was detected from the environment:
+
+             APP='#{ENV["APP"]}'
+ APP_BUNDLE_PATH='#{ENV["APP_BUNDLE_PATH"]}'
+       BUNDLE_ID='#{ENV["BUNDLE_ID"]}'
+
+
+It looks like you are trying to launch an app on a simulator using a bundle
+identifier or you have incorrectly set the APP variable to an app bundle that
+does not exist.
+
+If you are trying to launch a test against a physical device, set the DEVICE_TARGET
+variable to the UDID of your device an APP to a bundle identifier or a path to
+an .ipa.
+
+# com.example.MyApp must be installed on the target device
+$ APP=com.example.MyApp DEVICE_TARGET="John's iPhone" cucumber
+
+If you are trying to launch against a simulator and you encounter this error, it
+means that the APP variable is pointing to a .app that does not exist.
+
+]
+        end
         self.prepare_simulator(app_details[:app], device, xcode, simctl, reset_options)
       end
 

--- a/lib/run_loop/detect_aut/detect.rb
+++ b/lib/run_loop/detect_aut/detect.rb
@@ -131,8 +131,14 @@ module RunLoop
 
     # @!visibility private
     def self.app_from_environment
-      RunLoop::Environment.path_to_app_bundle ||
-        RunLoop::Environment.bundle_id
+      app_bundle_path = RunLoop::Environment.path_to_app_bundle
+
+      candidate = app_bundle_path
+      if app_bundle_path && !File.exist?(app_bundle_path)
+        candidate = File.basename(app_bundle_path)
+      end
+
+      candidate || RunLoop::Environment.bundle_id
     end
 
     # @!visibility private

--- a/spec/lib/detect_aut/detect_spec.rb
+++ b/spec/lib/detect_aut/detect_spec.rb
@@ -215,11 +215,29 @@ describe RunLoop::DetectAUT::Detect do
     end
 
     describe ".app_from_environment" do
-      it "APP or APP_BUNDLE_PATH" do
-        expect(RunLoop::Environment).to receive(:path_to_app_bundle).and_return(app_path)
+      describe "APP or APP_BUNDLE_PATH" do
+        it "is a path to a directory that exists" do
+          expect(RunLoop::Environment).to receive(:path_to_app_bundle).and_return(app_path)
 
-        actual = RunLoop::DetectAUT.send(:app_from_environment)
-        expect(actual).to be == app_path
+          actual = RunLoop::DetectAUT.send(:app_from_environment)
+          expect(actual).to be == app_path
+        end
+
+        it "is a bundle id" do
+          bundle_id = "com.example.MyApp"
+          expect(RunLoop::Environment).to receive(:path_to_app_bundle).and_return(bundle_id)
+
+          actual = RunLoop::DetectAUT.send(:app_from_environment)
+          expect(actual).to be == bundle_id
+        end
+
+        it "is a path to a bundle that does not exist" do
+          expect(RunLoop::Environment).to receive(:path_to_app_bundle).and_return(app_path)
+          expect(File).to receive(:exist?).with(app_path).and_return(false)
+
+          actual = RunLoop::DetectAUT.send(:app_from_environment)
+          expect(actual).to be == File.basename(app_path)
+        end
       end
 
       it "BUNDLE_ID" do


### PR DESCRIPTION
### Motivation

Resolves **`nil` path when preparing simulator in compatible arches check when APP was not set correctly** #463

@acroos 