### PR TITLE
XCUITest interface part 2

### DIFF
--- a/lib/run_loop/xcuitest.rb
+++ b/lib/run_loop/xcuitest.rb
@@ -483,15 +483,28 @@ Something went wrong.
     # @!visibility private
     def expect_200_response(response)
       body = response_body_to_hash(response)
-      return body if response.status_code < 300
+      if response.status_code < 300 && !body["error"]
+        return body
+      end
 
-      raise RunLoop::XCUITest::HTTPError,
-        %Q[Expected status code < 200, found #{response.status_code}.
+      if response.status_code > 300
+        raise RunLoop::XCUITest::HTTPError,
+          %Q[Expected status code < 300, found #{response.status_code}.
 
 Server replied with:
 
 #{body}
+
 ]
+      else
+        raise RunLoop::XCUITest::HTTPError,
+						%Q[Expected JSON response with no error, but found
+
+#{body["error"]}
+
+]
+
+      end
     end
 
     # @!visibility private

--- a/lib/run_loop/xcuitest.rb
+++ b/lib/run_loop/xcuitest.rb
@@ -155,7 +155,7 @@ module RunLoop
     end
 
     # @!visibility private
-    def tap_coordinate(x, y)
+    def tap_coordinate(x, y, options)
       make_coordinate_gesture_request("touch", x, y)
     end
 
@@ -215,6 +215,12 @@ module RunLoop
         :options => options
       }
 
+      RunLoop.log_debug(%Q[
+Sending request to perform '#{gesture}' with:
+
+#{JSON.pretty_generate(parameters)}
+
+])
       request = request("gesture", parameters)
       client = client(http_options)
       response = client.post(request)

--- a/lib/run_loop/xcuitest.rb
+++ b/lib/run_loop/xcuitest.rb
@@ -425,6 +425,7 @@ Sending request to perform '#{gesture}' with:
 
       # Temp measure; we need to manage the xcodebuild pids.
       system("pkill xcodebuild")
+      system("pkill testmanagerd")
 
       if device.simulator?
         # quits the simulator

--- a/lib/run_loop/xcuitest.rb
+++ b/lib/run_loop/xcuitest.rb
@@ -124,6 +124,15 @@ module RunLoop
     end
 
     # @!visibility private
+    def runtime
+      options = http_options
+      request = request("device")
+      client = client(options)
+      response = client.get(request)
+      expect_200_response(response)
+    end
+
+    # @!visibility private
     def query(mark)
       options = http_options
       parameters = { :id => mark }


### PR DESCRIPTION
### Motivation

* Interface to /device route
* tap_coordinate takes options
* try to manage testmanagerd
* check response body for error

This is a bit of a WIP, but needs to be merged to test the interface to `xctestctl` and continue orientation testing.