### PR TITLE
XCUITest respects to DEVICE_AGENT_URL

### DIFF
--- a/lib/run_loop/encoding.rb
+++ b/lib/run_loop/encoding.rb
@@ -2,6 +2,23 @@
 module RunLoop
   module Encoding
 
+    # Removes diacritic markers from string.
+    #
+    # The ruby Encoding tools cannot perform this action, they can only change
+    # convert one encodign to another by substituting characters.
+    #
+    # In ruby 1.9.3 we would have used Iconv, but that does not exist in 2.0.
+    #
+    # The Encoding::Convert in 2.0 does not work on string with UTF-16 characters.
+    def transliterate(string)
+			require "i18n"
+      locales = I18n.available_locales
+      if !locales.include?(:en)
+        I18n.available_locales = locales + [:en]
+      end
+      I18n.transliterate(string)
+    end
+
     # Raised when a string cannot be coerced to UTF8
     class UTF8Error < RuntimeError; end
 

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -228,6 +228,16 @@ module RunLoop
       end
     end
 
+    # Returns the value of DEVICE_ENDPOINT
+    def self.device_agent_url
+      value = ENV["DEVICE_AGENT_URL"]
+      if value.nil? || value == ""
+        nil
+      else
+        value
+      end
+    end
+
     # Returns true if running in Jenkins CI
     #
     # Checks the value of JENKINS_HOME

--- a/run_loop.gemspec
+++ b/run_loop.gemspec
@@ -52,6 +52,7 @@ tools like instruments and simctl.}
   s.add_dependency('command_runner_ng', '>= 0.0.2')
   s.add_dependency("httpclient", "~> 2.6")
   s.add_dependency("dnssd", "2.0")
+  s.add_dependency("i18n", ">= 0.7.0", "< 1.0")
 
   s.add_development_dependency("rspec_junit_formatter", "~> 0.2")
   s.add_development_dependency("luffa", "~> 2.0")

--- a/spec/lib/encoding_spec.rb
+++ b/spec/lib/encoding_spec.rb
@@ -6,6 +6,20 @@ describe RunLoop::Encoding do
     end.new
   end
 
+  describe "#transliterate" do
+    it "returns a string with no diactric markers" do
+      string = "Max Münstermann"
+      expected = "Max Munstermann"
+      expect(object.transliterate(string)).to be == expected
+    end
+
+    it "replaces unknown characters with ?" do
+      string = "ITZVÓÃ ●℆❡♡"
+      expected = "ITZVOA ????"
+      expect(object.transliterate(string)).to be == expected
+    end
+  end
+
   describe "ensure_command_output_utf8" do
     let(:string) { "string" }
     let(:encoded) { "encoded" }

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -120,6 +120,26 @@ describe RunLoop::Environment do
     end
   end
 
+  describe ".device_agent_url" do
+    it "returns DEVICE_AGENT_URL" do
+      url = "http://denis.local:27753"
+      stub_env({"DEVICE_AGENT_URL" => url})
+      expect(RunLoop::Environment.device_agent_url).to be == url
+    end
+
+    describe "returns nil" do
+      it "is undefined" do
+        stub_env({"DEVICE_AGENT_URL" => nil})
+        expect(RunLoop::Environment.device_agent_url).to be == nil
+      end
+
+      it "is the empty string" do
+        stub_env({"DEVICE_AGENT_URL" => ""})
+        expect(RunLoop::Environment.device_agent_url).to be == nil
+      end
+    end
+  end
+
   describe ".reset_between_scenarios?" do
     it "true" do
       stub_env({"RESET_BETWEEN_SCENARIOS" => "1"})

--- a/spec/lib/xcuitest_spec.rb
+++ b/spec/lib/xcuitest_spec.rb
@@ -64,14 +64,172 @@ describe RunLoop::XCUITest do
     expect(xcuitest.launch_other_app(bundle_id)).to be_truthy
   end
 
-  describe "#url" do
-    it "uses 127.0.0.1 for simulator targets" do
+  it "#url" do
+    expected = "http://denis.local:27753/"
+    expect(xcuitest).to receive(:detect_device_agent_url).and_return(expected)
+
+    actual = xcuitest.send(:url)
+    expect(actual).to be == expected
+    expect(xcuitest.instance_variable_get(:@url)).to be == expected
+  end
+
+  describe "#detect_device_agent_url" do
+    it "DEVICE_AGENT_URL is defined" do
+      expect(xcuitest).to receive(:url_from_environment).and_return("from environment")
+
+      actual = xcuitest.send(:detect_device_agent_url)
+      expect(actual).to be == "from environment"
+    end
+
+    describe "DEVICE_AGENT_URL is not defined" do
+      before do
+        expect(xcuitest).to receive(:url_from_environment).and_return(nil)
+      end
+
+      it "returns 127.0.0.1 url for simulators" do
+        expect(xcuitest).to receive(:url_for_simulator).and_return("simulator")
+
+        actual = xcuitest.send(:detect_device_agent_url)
+        expect(actual).to be == "simulator"
+      end
+
+      it "returns the DEVICE_ENDPOINT url with correct port" do
+        expect(xcuitest).to receive(:url_for_simulator).and_return(nil)
+        expect(xcuitest).to receive(:url_from_device_endpoint).and_return("device endpoint")
+
+        actual = xcuitest.send(:detect_device_agent_url)
+        expect(actual).to be == "device endpoint"
+      end
+
+      it "returns the device name as a DNS hostname" do
+        expect(xcuitest).to receive(:url_for_simulator).and_return(nil)
+        expect(xcuitest).to receive(:url_from_device_endpoint).and_return(nil)
+        expect(xcuitest).to receive(:url_from_device_name).and_return("device name")
+
+        actual = xcuitest.send(:detect_device_agent_url)
+        expect(actual).to be == "device name"
+      end
+    end
+  end
+  describe "#url_from_environment" do
+    it "returns nil if DEVICE_AGENT_URL is not set" do
+      expect(RunLoop::Environment).to receive(:device_agent_url).and_return(nil)
+
+      actual = xcuitest.send(:url_from_environment)
+      expect(actual).to be == nil
+    end
+
+    context "DEVICE_AGENT_URL is set" do
+      let(:url) { "http://denis.local:27753" }
+
+      it "returns the url if it has a trailing /" do
+        with_trailing = "#{url}/"
+        expect(RunLoop::Environment).to receive(:device_agent_url).and_return(with_trailing)
+
+        actual = xcuitest.send(:url_from_environment)
+        expect(actual).to be == with_trailing
+      end
+
+      it "appends a trailing / if it does not have one" do
+        expect(RunLoop::Environment).to receive(:device_agent_url).and_return(url)
+
+        actual = xcuitest.send(:url_from_environment)
+        expect(actual).to be == "#{url}/"
+      end
+    end
+  end
+
+  describe "#url_for_simulator" do
+    let(:port) { RunLoop::XCUITest::DEFAULTS[:port] }
+
+    it "returns 127.0.0.1:22753 for simulators" do
       expect(device).to receive(:simulator?).at_least(:once).and_return(true)
 
-      actual = xcuitest.send(:url)
-      expected = "http://127.0.0.1:27753/"
+      actual = xcuitest.send(:url_for_simulator)
+      expected = "http://127.0.0.1:#{port}/"
       expect(actual).to be == expected
-      expect(xcuitest.instance_variable_get(:@url)).to be == expected
+    end
+
+    it "returns nil for physical devices" do
+      expect(device).to receive(:simulator?).at_least(:once).and_return(false)
+
+      actual = xcuitest.send(:url_for_simulator)
+      expect(actual).to be == nil
+    end
+  end
+
+  describe "#url_from_device_endpoint" do
+    let(:host_url) { "http://denis.local" }
+
+    it "returns nil if DEVICE_ENDPOINT is not set" do
+      expect(RunLoop::Environment).to receive(:device_endpoint).and_return(nil)
+
+      actual = xcuitest.send(:url_from_device_endpoint)
+      expect(actual).to be == nil
+    end
+
+    context "DEVICE_ENDPOINT is set" do
+      let(:port) { RunLoop::XCUITest::DEFAULTS[:port] }
+      let(:expected) { "#{host_url}:#{port}/" }
+
+      it "returns a url with the Calabash port replaced" do
+        url_with_port = "#{host_url}:37265"
+        expect(RunLoop::Environment).to receive(:device_endpoint).and_return(url_with_port)
+        actual = xcuitest.send(:url_from_device_endpoint)
+        expect(actual).to be == expected
+      end
+
+      it "returns a url with port appended" do
+        expect(RunLoop::Environment).to receive(:device_endpoint).and_return(host_url)
+
+        actual = xcuitest.send(:url_from_device_endpoint)
+        expect(actual).to be == expected
+      end
+    end
+  end
+
+  describe "#url_from_device_name" do
+    let(:port) { RunLoop::XCUITest::DEFAULTS[:port] }
+    it "returns a url based on the device name" do
+      expect(device).to receive(:name).and_return("denis")
+
+      expected = "http://denis.local:#{port}/"
+      actual = xcuitest.send(:url_from_device_name)
+      expect(actual).to be == expected
+    end
+
+    context "encodes the name as bonjour name" do
+      it "replaces ' with empty character" do
+        expect(device).to receive(:name).and_return("Joshua's")
+
+        expected = "http://Joshuas.local:#{port}/"
+        actual = xcuitest.send(:url_from_device_name)
+        expect(actual).to be == expected
+      end
+
+      it "replaces spaces with hyphens" do
+        expect(device).to receive(:name).and_return("denis the menance")
+
+        expected = "http://denis-the-menance.local:#{port}/"
+        actual = xcuitest.send(:url_from_device_name)
+        expect(actual).to be == expected
+      end
+
+      it "reformats default device name" do
+        expect(device).to receive(:name).and_return("Joshua's iPhone")
+
+        expected = "http://Joshuas-iPhone.local:#{port}/"
+        actual = xcuitest.send(:url_from_device_name)
+        expect(actual).to be == expected
+      end
+
+      it "encodes non ASCII characters" do
+        expect(device).to receive(:name).and_return("ITZVÓÃ ●℆❡♡")
+
+        expected = "http://ITZVOA-.local:27753/"
+        actual = xcuitest.send(:url_from_device_name)
+        expect(actual).to be == expected
+      end
     end
   end
 


### PR DESCRIPTION
### Motivation

Progress on:

* XTC support for DeviceAgent

Resolves (for run_loop):

* [JIRA: calabash-ios/UITest/XDB should respect a DEVICE_AGENT_URL env var](https://xamarin.atlassian.net/browse/TCFW-84)

The order of preference is:

1. DEVICE_AGENT_URL
2. If simulator target, use the default 127.0.0.1 hostname and port
3. If DEVICE_ENDPOINT, use the hostname provided and change the port
4. Try to deduce the hostname using the device name e.g. Joshuas-iPad.local