### PR TITLE
Rename exec methods in various classes

### DIFF
--- a/lib/run_loop/codesign.rb
+++ b/lib/run_loop/codesign.rb
@@ -18,7 +18,7 @@ module RunLoop
     # @!visibility private
     def self.info(path)
       self.expect_path_exists(path)
-      self.exec(["--display", "--verbose=4", path])
+      self.run_codesign_command(["--display", "--verbose=4", path])
     end
 
     # @!visibility private
@@ -59,7 +59,7 @@ module RunLoop
       end
     end
 
-    def self.exec(args)
+    def self.run_codesign_command(args)
       if !args.is_a?(Array)
         raise ArgumentError, "Expected args: '#{args}' to be an Array"
       end

--- a/lib/run_loop/codesign.rb
+++ b/lib/run_loop/codesign.rb
@@ -67,7 +67,7 @@ module RunLoop
       xcrun = RunLoop::Xcrun.new
       cmd = ["codesign"] + args
       options = {:log_cmd => true}
-      hash = xcrun.exec(cmd, options)
+      hash = xcrun.run_command_in_context(cmd, options)
 
       hash[:out]
     end

--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -207,7 +207,7 @@ class RunLoop::CoreSimulator
 
     if simulator.update_simulator_state != "Shutdown"
       args = ["simctl", "shutdown", simulator.udid]
-      xcrun.exec(args, xcrun_opts)
+      xcrun.run_command_in_context(args, xcrun_opts)
       begin
         self.wait_for_simulator_state(simulator, "Shutdown")
       rescue RuntimeError => _
@@ -226,7 +226,7 @@ $ bundle exec run-loop simctl manage-processes
     end
 
     args = ["simctl", "erase", simulator.udid]
-    hash = xcrun.exec(args, xcrun_opts)
+    hash = xcrun.run_command_in_context(args, xcrun_opts)
 
     if hash[:exit_status] != 0
       raise RuntimeError, %Q{
@@ -489,7 +489,7 @@ $ bundle exec run-loop simctl manage-processes
     args = ['simctl', 'uninstall', device.udid, app.bundle_identifier]
 
     timeout = DEFAULT_OPTIONS[:uninstall_app_timeout]
-    xcrun.exec(args, log_cmd: true, timeout: timeout)
+    xcrun.run_command_in_context(args, log_cmd: true, timeout: timeout)
 
     device.simulator_wait_for_stable_state
     true
@@ -570,7 +570,7 @@ $ bundle exec run-loop simctl manage-processes
     process_name = "MacOS/#{sim_name}"
 
     args = ["xcrun", "ps", "x", "-o", "pid,command"]
-    hash = xcrun.exec(args)
+    hash = xcrun.run_command_in_context(args)
 
     exit_status = hash[:exit_status]
     if exit_status != 0
@@ -611,7 +611,7 @@ Command had no output
 
     args = ['simctl', 'install', device.udid, app.path]
     timeout = DEFAULT_OPTIONS[:install_app_timeout]
-    xcrun.exec(args, log_cmd: true, timeout: timeout)
+    xcrun.run_command_in_context(args, log_cmd: true, timeout: timeout)
 
     device.simulator_wait_for_stable_state
     installed_app_bundle_dir
@@ -621,7 +621,7 @@ Command had no output
   def launch_app_with_simctl
     args = ['simctl', 'launch', device.udid, app.bundle_identifier]
     timeout = DEFAULT_OPTIONS[:launch_app_timeout]
-    xcrun.exec(args, log_cmd: true, timeout: timeout)
+    xcrun.run_command_in_context(args, log_cmd: true, timeout: timeout)
   end
 
   # @!visibility private
@@ -864,7 +864,7 @@ Command had no output
     target = File.join(directory, bundle_name)
 
     args = ['ditto', app.path, target]
-    xcrun.exec(args, log_cmd: true)
+    xcrun.run_command_in_context(args, log_cmd: true)
 
     RunLoop.log_debug("Installed #{app} on CoreSimulator #{device.udid}")
 

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -505,7 +505,7 @@ version: #{version}
       ]
 
       # RunLoop::PlistBuddy cannot add items to arrays.
-      xcrun.exec(cmd, {:log_cmd => true})
+      xcrun.run_command_in_context(cmd, {:log_cmd => true})
 
       simulator_languages
     end
@@ -547,7 +547,7 @@ version: #{version}
       end
 
       args = ['simctl', 'list', 'devices']
-      hash = xcrun.exec(args)
+      hash = xcrun.run_command_in_context(args)
       out = hash[:out]
 
       matched_line = out.split("\n").find do |line|

--- a/lib/run_loop/dylib_injector.rb
+++ b/lib/run_loop/dylib_injector.rb
@@ -70,7 +70,7 @@ module RunLoop
       hash = nil
       success = false
       begin
-        hash = xcrun.exec(["lldb", "--no-lldbinit", "--source", script_path], options)
+        hash = xcrun.run_command_in_context(["lldb", "--no-lldbinit", "--source", script_path], options)
         pid = hash[:pid]
         exit_status = hash[:exit_status]
         success = exit_status == 0

--- a/lib/run_loop/instruments.rb
+++ b/lib/run_loop/instruments.rb
@@ -193,7 +193,7 @@ module RunLoop
     def templates
       @instruments_templates ||= lambda do
         args = ['instruments', '-s', 'templates']
-        hash = xcrun.exec(args, log_cmd: true)
+        hash = xcrun.run_command_in_context(args, log_cmd: true)
         hash[:out].chomp.split("\n").map do |elm|
           stripped = elm.strip.tr('"', '')
           if stripped == '' || stripped == 'Known Templates:'
@@ -269,7 +269,7 @@ module RunLoop
     def fetch_devices
       @device_hash ||= lambda do
         args = ['instruments', '-s', 'devices']
-        xcrun.exec(args, log_cmd: true)
+        xcrun.run_command_in_context(args, log_cmd: true)
       end.call
     end
 

--- a/lib/run_loop/otool.rb
+++ b/lib/run_loop/otool.rb
@@ -44,7 +44,7 @@ must exist and not be a directory.
       args = ["otool", "-hv", "-arch", "all", path]
       opts = { :log_cmd => false }
 
-      hash = xcrun.exec(args, opts)
+      hash = xcrun.run_command_in_context(args, opts)
 
       if hash[:exit_status] != 0
         raise RuntimeError,

--- a/lib/run_loop/shell.rb
+++ b/lib/run_loop/shell.rb
@@ -5,7 +5,7 @@ module RunLoop
     require "run_loop/encoding"
     include RunLoop::Encoding
 
-    # Controls the behavior of Shell#exec.
+    # Controls the behavior of Shell#run_shell_command.
     #
     # You can override these values if they do not work in your environment.
     #
@@ -26,7 +26,7 @@ module RunLoop
     # Raised when shell command times out.
     class TimeoutError < RuntimeError; end
 
-    def exec(args, options={})
+    def run_shell_command(args, options={})
 
       merged_options = DEFAULT_OPTIONS.merge(options)
 

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -1137,7 +1137,7 @@ module RunLoop
     # @see #simctl_list
     def simctl_list_devices
       args = ['simctl', 'list', 'devices']
-      hash = xcrun.exec(args)
+      hash = xcrun.run_command_in_context(args)
 
       current_sdk = nil
       simulators = {}
@@ -1220,7 +1220,7 @@ module RunLoop
     # @see #simctl_list
     def simctl_list_runtimes
       args = ['simctl', 'list', 'runtimes']
-      hash = xcrun.exec(args)
+      hash = xcrun.run_command_in_context(args)
 
       # Ex.
       # == Runtimes ==

--- a/lib/run_loop/simctl.rb
+++ b/lib/run_loop/simctl.rb
@@ -115,7 +115,7 @@ module RunLoop
     # @!visibility private
     def execute(array, options)
       merged = DEFAULTS.merge(options)
-      xcrun.exec(array, merged)
+      xcrun.run_command_in_context(array, merged)
     end
 
     # @!visibility private

--- a/lib/run_loop/strings.rb
+++ b/lib/run_loop/strings.rb
@@ -55,7 +55,7 @@ must exist and not be a directory.
       args = ["strings", path]
       opts = { :log_cmd => true }
 
-      hash = xcrun.exec(args, opts)
+      hash = xcrun.run_command_in_context(args, opts)
 
       if hash[:exit_status] != 0
         raise RuntimeError,

--- a/lib/run_loop/xcrun.rb
+++ b/lib/run_loop/xcrun.rb
@@ -5,7 +5,7 @@ module RunLoop
     require "run_loop/encoding"
     include RunLoop::Encoding
 
-    # Controls the behavior of Xcrun#exec.
+    # Controls the behavior of Xcrun#run_command_in_context.
     #
     # You can override these values if they do not work in your environment.
     #
@@ -26,8 +26,8 @@ module RunLoop
     # Raised when Xcrun times out.
     class TimeoutError < RuntimeError; end
 
-    def exec(args, options={})
-
+    # Aliased to #exec, which will be removed in 3.0
+    def run_command_in_context(args, options={})
       merged_options = DEFAULT_OPTIONS.merge(options)
 
       timeout = merged_options[:timeout]
@@ -98,6 +98,10 @@ with a timeout of #{timeout}
 
       hash
     end
+
+    # TODO Remove in 3.0
+    # https://github.com/calabash/run_loop/issues/478
+    alias_method :exec, :run_command_in_context
   end
 end
 

--- a/lib/run_loop/xcuitest.rb
+++ b/lib/run_loop/xcuitest.rb
@@ -448,9 +448,9 @@ Sending request to perform '#{gesture}' with:
       shutdown
 
       options = {:log_cmd => true}
-      exec(["pkill", "xctestctl"], options)
-      exec(["pkill", "testmanagerd"], options)
-      exec(["pkill", "xcodebuild"], options)
+      run_shell_command(["pkill", "xctestctl"], options)
+      run_shell_command(["pkill", "testmanagerd"], options)
+      run_shell_command(["pkill", "xcodebuild"], options)
 
       start = Time.now
       RunLoop.log_debug("Waiting for CBX-Runner to launch...")

--- a/spec/integration/core_simulator_spec.rb
+++ b/spec/integration/core_simulator_spec.rb
@@ -74,7 +74,7 @@ describe RunLoop::CoreSimulator do
   describe "#launch" do
     before do
       args = ['simctl', 'erase', simulator.udid]
-      xcrun.exec(args, {:log_cmd => true })
+      xcrun.run_command_in_context(args, {:log_cmd => true })
     end
 
     it "launches the app" do
@@ -103,7 +103,7 @@ describe RunLoop::CoreSimulator do
 
   it 'install with simctl' do
     args = ['simctl', 'erase', simulator.udid]
-    xcrun.exec(args, {:log_cmd => true })
+    xcrun.run_command_in_context(args, {:log_cmd => true })
 
     expect(core_sim.install)
     expect(core_sim.launch)

--- a/spec/integration/xcrun_spec.rb
+++ b/spec/integration/xcrun_spec.rb
@@ -6,7 +6,7 @@ describe RunLoop::Xcrun do
     it 'can call simctl' do
       args = ['simctl', 'list', 'devices']
 
-      hash = xcrun.exec(args, log_cmd: true, timeout: 2)
+      hash = xcrun.run_command_in_context(args, log_cmd: true, timeout: 2)
 
       expect(hash[:out]).to be_truthy
       expect(hash[:exit_status]).to be_truthy
@@ -18,7 +18,7 @@ describe RunLoop::Xcrun do
 
     args = ['xcodebuild', '-version']
 
-    hash = xcrun.exec(args, log_cmd: true, timeout: 2)
+    hash = xcrun.run_command_in_context(args, log_cmd: true, timeout: 2)
 
     expect(hash[:out]).to be_truthy
     expect(hash[:exit_status]).to be_truthy

--- a/spec/lib/app_spec.rb
+++ b/spec/lib/app_spec.rb
@@ -22,7 +22,7 @@ describe RunLoop::App do
     let(:path) { "path/to/My.app" }
     let(:info) { File.join(path, "Info.plist") }
     let(:name) { "My" }
-    let(:exec) { File.join(path, "My") }
+    let(:executable) { File.join(path, "My") }
     let(:pbuddy) { RunLoop::PlistBuddy.new }
 
     before do
@@ -61,7 +61,7 @@ describe RunLoop::App do
         it "executable file does not exist" do
           expect(RunLoop::App).to receive(:info_plist_exist?).with(path).and_return(true)
           expect(pbuddy).to receive(:plist_read).with("CFBundleExecutable", info).and_return(name)
-          expect(File).to receive(:exist?).with(exec).and_return(false)
+          expect(File).to receive(:exist?).with(executable).and_return(false)
 
           expect(RunLoop::App.send(:executable_file_exist?, path)).to be_falsey
         end
@@ -70,7 +70,7 @@ describe RunLoop::App do
       it "true" do
         expect(RunLoop::App).to receive(:info_plist_exist?).with(path).and_return(true)
         expect(pbuddy).to receive(:plist_read).with("CFBundleExecutable", info).and_return(name)
-        expect(File).to receive(:exist?).with(exec).and_return(true)
+        expect(File).to receive(:exist?).with(executable).and_return(true)
 
         expect(RunLoop::App.send(:executable_file_exist?, path)).to be_truthy
       end

--- a/spec/lib/codesign_spec.rb
+++ b/spec/lib/codesign_spec.rb
@@ -14,7 +14,7 @@ describe RunLoop::Codesign do
 
     it ".info" do
       args = ["--display", "--verbose=4", path]
-      expect(RunLoop::Codesign).to receive(:exec).with(args).and_return("info")
+      expect(RunLoop::Codesign).to receive(:run_codesign_command).with(args).and_return("info")
 
       expect(RunLoop::Codesign.info(path)).to be == "info"
     end
@@ -107,19 +107,19 @@ describe RunLoop::Codesign do
     end
   end
 
-  describe ".exec" do
+  describe ".run_codesign_command" do
     it "expects an Array argument" do
       expect do
-        RunLoop::Codesign.send(:exec, "string")
+        RunLoop::Codesign.send(:run_codesign_command, "string")
       end.to raise_error ArgumentError, /to be an Array/
     end
 
-    it ".exec" do
+    it "calls out to codesign" do
       path = File.expand_path("./tmp/file.txt")
       FileUtils.mkdir_p("./tmp")
       FileUtils.touch(path)
       args = ["--display", "--verbose=4", path]
-      actual = RunLoop::Codesign.send(:exec, args)
+      actual = RunLoop::Codesign.send(:run_codesign_command, args)
       expected = "tmp/file.txt: code object is not signed at all"
       expect(actual[/#{expected}/, 0]).to be_truthy
     end

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -85,23 +85,23 @@ describe RunLoop::CoreSimulator do
 
     it "calls erase if sim is shutdown" do
       expect(device).to receive(:update_simulator_state).and_return "Shutdown"
-      expect(xcrun).to receive(:exec).with(*erase_args).and_return(erase_hash)
+      expect(xcrun).to receive(:run_command_in_context).with(*erase_args).and_return(erase_hash)
 
       expect(RunLoop::CoreSimulator.erase(device, options)).to be_truthy
     end
 
     it "waits for sim to shutdown" do
       expect(device).to receive(:update_simulator_state).once.and_return("Unknown")
-      expect(xcrun).to receive(:exec).with(*shutdown_args).and_return true
+      expect(xcrun).to receive(:run_command_in_context).with(*shutdown_args).and_return true
       expect(RunLoop::CoreSimulator).to receive(:wait_for_simulator_state).and_return true
-      expect(xcrun).to receive(:exec).with(*erase_args).and_return(erase_hash)
+      expect(xcrun).to receive(:run_command_in_context).with(*erase_args).and_return(erase_hash)
 
       expect(RunLoop::CoreSimulator.erase(device, options)).to be_truthy
     end
 
     it "raises error if device cannot be shutdown" do
       expect(device).to receive(:update_simulator_state).once.and_return("Unknown")
-      expect(xcrun).to receive(:exec).with(*shutdown_args).and_return true
+      expect(xcrun).to receive(:run_command_in_context).with(*shutdown_args).and_return true
       expect(RunLoop::CoreSimulator).to receive(:wait_for_simulator_state).and_raise RuntimeError, "Not shutdown"
 
       expect do
@@ -112,7 +112,7 @@ describe RunLoop::CoreSimulator do
     it "raises error if device cannot be erased" do
       expect(device).to receive(:update_simulator_state).and_return "Shutdown"
       hash = {:exit_status => 1, :out => "Simulator domain error"}
-      expect(xcrun).to receive(:exec).with(*erase_args).and_return(hash)
+      expect(xcrun).to receive(:run_command_in_context).with(*erase_args).and_return(hash)
 
       expect do
         RunLoop::CoreSimulator.erase(device, options)
@@ -313,7 +313,7 @@ describe RunLoop::CoreSimulator do
 
         timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:uninstall_app_timeout]
         options = { log_cmd: true, timeout: timeout }
-        expect(core_sim.xcrun).to receive(:exec).with(args, options).and_return true
+        expect(core_sim.xcrun).to receive(:run_command_in_context).with(args, options).and_return true
 
         expect(core_sim.device).to receive(:simulator_wait_for_stable_state).and_return true
 
@@ -336,7 +336,7 @@ describe RunLoop::CoreSimulator do
 
       it "xcrun exit status is non-zero" do
         hash[:exit_status] = 1
-        expect(xcrun).to receive(:exec).and_return(hash)
+        expect(xcrun).to receive(:run_command_in_context).and_return(hash)
 
         expect do
           core_sim.send(:running_simulator_pid)
@@ -346,7 +346,7 @@ describe RunLoop::CoreSimulator do
       describe "xcrun returns no :out" do
         it "out is nil" do
           hash[:out] = nil
-          expect(xcrun).to receive(:exec).and_return(hash)
+          expect(xcrun).to receive(:run_command_in_context).and_return(hash)
 
           expect do
             core_sim.send(:running_simulator_pid)
@@ -355,7 +355,7 @@ describe RunLoop::CoreSimulator do
 
         it "out is empty string" do
           hash[:out] = ""
-          expect(xcrun).to receive(:exec).and_return(hash)
+          expect(xcrun).to receive(:run_command_in_context).and_return(hash)
 
           expect do
             core_sim.send(:running_simulator_pid)
@@ -372,7 +372,7 @@ describe RunLoop::CoreSimulator do
 32976 vim lib/run_loop/xcrun.rb
 7656 /bin/ps x -o pid,command
 }
-        expect(xcrun).to receive(:exec).and_return(hash)
+        expect(xcrun).to receive(:run_command_in_context).and_return(hash)
 
         expect(core_sim.send(:running_simulator_pid)).to be == nil
       end
@@ -387,7 +387,7 @@ describe RunLoop::CoreSimulator do
 7656 /MacOS/SillySim
 }
         expect(core_sim).to receive(:sim_name).and_return("SillySim")
-        expect(xcrun).to receive(:exec).and_return(hash)
+        expect(xcrun).to receive(:run_command_in_context).and_return(hash)
 
         expect(core_sim.send(:running_simulator_pid)).to be == 7656
       end
@@ -804,7 +804,7 @@ describe RunLoop::CoreSimulator do
         timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:install_app_timeout]
         options = { :log_cmd => true, :timeout => timeout }
 
-        expect(core_sim.xcrun).to receive(:exec).with(args, options).and_return({})
+        expect(core_sim.xcrun).to receive(:run_command_in_context).with(args, options).and_return({})
         expect(core_sim.device).to receive(:simulator_wait_for_stable_state).and_return true
 
         expect(core_sim).to receive(:installed_app_bundle_dir).and_return('/new/path')
@@ -817,7 +817,7 @@ describe RunLoop::CoreSimulator do
       args = ["simctl", "launch", device.udid, app.bundle_identifier]
       timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:launch_app_timeout]
       options = { :log_cmd => true, :timeout => timeout }
-      expect(core_sim.xcrun).to receive(:exec).with(args, options).and_return({})
+      expect(core_sim.xcrun).to receive(:run_command_in_context).with(args, options).and_return({})
 
       expect(core_sim.send(:launch_app_with_simctl)).to be == {}
     end
@@ -1088,7 +1088,7 @@ describe RunLoop::CoreSimulator do
 
         args = ['ditto', app.path, '/some/CalSmoke-cal.app']
         options = {:log_cmd => true}
-        expect(core_sim.xcrun).to receive(:exec).with(args, options).and_return({})
+        expect(core_sim.xcrun).to receive(:run_command_in_context).with(args, options).and_return({})
 
         expect(core_sim).to receive(:clear_device_launch_csstore).and_return true
 

--- a/spec/lib/device_agent/framework_spec.rb
+++ b/spec/lib/device_agent/framework_spec.rb
@@ -36,6 +36,6 @@ describe RunLoop::DeviceAgent::Frameworks do
 
   it "#shell" do
     shell = instance.send(:shell)
-    expect(shell.respond_to?(:exec)).to be_truthy
+    expect(shell.respond_to?(:run_shell_command)).to be_truthy
   end
 end

--- a/spec/lib/device_spec.rb
+++ b/spec/lib/device_spec.rb
@@ -540,7 +540,7 @@ describe RunLoop::Device do
       it 'raises an error if the udid matches no simulator' do
         xcrun = RunLoop::Xcrun.new
         args = ['simctl', 'list', 'devices']
-        expect(xcrun).to receive(:exec).with(args).and_return({:out => ''})
+        expect(xcrun).to receive(:run_command_in_context).with(args).and_return({:out => ''})
         expect(simulator).to receive(:xcrun).and_return xcrun
 
         expect do
@@ -553,7 +553,7 @@ describe RunLoop::Device do
         hash = {:out => line}
         xcrun = RunLoop::Xcrun.new
         args = ['simctl', 'list', 'devices']
-        expect(xcrun).to receive(:exec).with(args).and_return(hash)
+        expect(xcrun).to receive(:run_command_in_context).with(args).and_return(hash)
         expect(simulator).to receive(:xcrun).and_return xcrun
 
         expect(simulator.send(:fetch_simulator_state)).to be == 'Shutdown'

--- a/spec/lib/dylib_injector_spec.rb
+++ b/spec/lib/dylib_injector_spec.rb
@@ -68,14 +68,14 @@ describe RunLoop::DylibInjector do
       expect(lldb).to receive(:write_script).and_return script
       cmd = ["lldb", "--no-lldbinit", "--source", script]
 
-      expect(xcrun).to receive(:exec).with(cmd, options).and_return(hash)
+      expect(xcrun).to receive(:run_command_in_context).with(cmd, options).and_return(hash)
 
       expect(lldb.inject_dylib(timeout)).to be_truthy
     end
 
     describe "returns false" do
       it "when xcrun times out" do
-        expect(xcrun).to receive(:exec).and_raise RunLoop::Xcrun::TimeoutError
+        expect(xcrun).to receive(:run_command_in_context).and_raise RunLoop::Xcrun::TimeoutError
 
         expect(lldb.inject_dylib(timeout)).to be_falsey
       end
@@ -84,7 +84,7 @@ describe RunLoop::DylibInjector do
         hash[:exit_status] = 1
         hash[:out] = "Line 0\nLine 1\nLine 2"
 
-        expect(xcrun).to receive(:exec).and_return(hash)
+        expect(xcrun).to receive(:run_command_in_context).and_return(hash)
 
         expect(lldb.inject_dylib(timeout)).to be_falsey
       end

--- a/spec/lib/instruments_spec.rb
+++ b/spec/lib/instruments_spec.rb
@@ -257,14 +257,14 @@ describe RunLoop::Instruments do
     end
 
     it 'Xcode >= 6.0' do
-      # TODO: Xcrun#exec no longer returns a hash with :err; stderr and stdout are combined
+      # TODO: Xcrun#run_command_in_context no longer returns a hash with :err; stderr and stdout are combined
       hash =
             {
                   :out => RunLoop::RSpec::Instruments::TEMPLATES_GTE_60[:output],
                   :err => RunLoop::RSpec::Instruments::SPAM_GTE_60
             }
 
-      expect(xcrun).to receive(:exec).with(args, options).and_return hash
+      expect(xcrun).to receive(:run_command_in_context).with(args, options).and_return hash
 
       expected = RunLoop::RSpec::Instruments::TEMPLATES_GTE_60[:expected]
       expect(instruments.templates).to be == expected
@@ -277,7 +277,7 @@ describe RunLoop::Instruments do
 
     let(:options) { {:log_cmd => true } }
 
-    # TODO: Xcrun#exec no longer returns a hash with :err; stderr and stdout are combined
+    # TODO: Xcrun#run_command_in_context no longer returns a hash with :err; stderr and stdout are combined
     let(:xcode_511_output) do
       {
             :out => RunLoop::RSpec::Instruments::DEVICES_511,
@@ -285,7 +285,7 @@ describe RunLoop::Instruments do
       }
     end
 
-    # TODO: Xcrun#exec no longer returns a hash with :err; stderr and stdout are combined
+    # TODO: Xcrun#run_command_in_context no longer returns a hash with :err; stderr and stdout are combined
     let(:xcode_6_output) do
       {
             :out => RunLoop::RSpec::Instruments::DEVICES_60,
@@ -293,7 +293,7 @@ describe RunLoop::Instruments do
       }
     end
 
-    # TODO: Xcrun#exec no longer returns a hash with :err; stderr and stdout are combined
+    # TODO: Xcrun#run_command_in_context no longer returns a hash with :err; stderr and stdout are combined
     let(:xcode_7_output) do
       {
             :out => RunLoop::RSpec::Instruments::DEVICES_GTE_70,
@@ -306,7 +306,7 @@ describe RunLoop::Instruments do
     it '#fetch_devices' do
       hash = { :a => :b }
       expect(instruments).to receive(:xcrun).and_return xcrun
-      expect(xcrun).to receive(:exec).with(args, options).and_return hash
+      expect(xcrun).to receive(:run_command_in_context).with(args, options).and_return hash
 
       actual = instruments.send(:fetch_devices)
       expect(actual).to be == hash

--- a/spec/lib/otool_spec.rb
+++ b/spec/lib/otool_spec.rb
@@ -85,7 +85,7 @@ describe RunLoop::Otool do
     end
 
     it "returns arch information" do
-      expect(xcrun).to receive(:exec).and_return(hash)
+      expect(xcrun).to receive(:run_command_in_context).and_return(hash)
 
       expect(otool.send(:arch_info)).to be == hash[:out]
       expect(otool.instance_variable_get(:@arch_info)).to be == hash[:out]
@@ -93,7 +93,7 @@ describe RunLoop::Otool do
 
     it "raises error if there is a problem" do
       hash[:exit_status] = 1
-      expect(xcrun).to receive(:exec).and_return(hash)
+      expect(xcrun).to receive(:run_command_in_context).and_return(hash)
 
       expect do
         otool.send(:arch_info)

--- a/spec/lib/physical_device/life_cycle_spec.rb
+++ b/spec/lib/physical_device/life_cycle_spec.rb
@@ -20,9 +20,9 @@ describe RunLoop::PhysicalDevice::LifeCycle do
       expect(lc.instance_variable_get(:@device)).to be == device
     end
 
-    it "responds to #exec" do
+    it "responds to #run_shell_command" do
       lc = RunLoop::PhysicalDevice::LifeCycle.new(device)
-      expect(lc.respond_to?(:exec)).to be_truthy
+      expect(lc.respond_to?(:run_shell_command)).to be_truthy
     end
   end
 

--- a/spec/lib/shell_spec.rb
+++ b/spec/lib/shell_spec.rb
@@ -20,16 +20,16 @@ describe RunLoop::Shell do
     }
   end
 
-  describe "#exec" do
+  describe "#run_shell_command" do
     it "raises an error if arg is not an Array" do
       expect do
-        object.exec("simctl list devices")
+        object.run_shell_command("simctl list devices")
       end.to raise_error ArgumentError, /Expected args/
     end
 
     it "raises an error if any arg is not a string" do
       expect do
-        object.exec(["sleep", 5])
+        object.run_shell_command(["sleep", 5])
       end.to raise_error ArgumentError,
       /Expected arg '5' to be a String, but found 'Fixnum'/
     end
@@ -39,7 +39,7 @@ describe RunLoop::Shell do
       expect(object).to receive(:ensure_command_output_utf8).and_raise(error)
 
       expect do
-        object.exec(["sleep", "0.5"])
+        object.run_shell_command(["sleep", "0.5"])
       end.to raise_error RunLoop::Encoding::UTF8Error, /complex message/
     end
 
@@ -47,7 +47,7 @@ describe RunLoop::Shell do
       expect(CommandRunner).to receive(:run).and_raise RuntimeError, "Some error"
 
       expect do
-        object.exec(["sleep", "0.5"])
+        object.run_shell_command(["sleep", "0.5"])
       end.to raise_error RunLoop::Shell::Error, /Some error/
     end
 
@@ -57,13 +57,13 @@ describe RunLoop::Shell do
         expect(CommandRunner).to receive(:run).and_return(command_output)
 
         expect do
-          object.exec(["sleep", "0.5"])
+          object.run_shell_command(["sleep", "0.5"])
         end.to raise_error RunLoop::Shell::TimeoutError, /Timed out after/
       end
 
       it "actual" do
         expect do
-          object.exec(["sleep", "0.5"], timeout: 0.05)
+          object.run_shell_command(["sleep", "0.5"], timeout: 0.05)
         end.to raise_error RunLoop::Shell::TimeoutError, /Timed out after/
       end
     end
@@ -75,7 +75,7 @@ describe RunLoop::Shell do
         command_output[:out] = "mocked"
         expect(CommandRunner).to receive(:run).and_return(command_output)
 
-        hash = object.exec(["sleep", "0.1"])
+        hash = object.run_shell_command(["sleep", "0.1"])
 
         expect(hash[:out]).to be == "mocked"
         expect(hash[:pid]).to be == 3030

--- a/spec/lib/sim_control_spec.rb
+++ b/spec/lib/sim_control_spec.rb
@@ -336,7 +336,7 @@ describe RunLoop::SimControl do
 
       it ':devices' do
         args = ['simctl', 'list', 'devices']
-        expect(xcrun).to receive(:exec).with(args).and_return(devices_out)
+        expect(xcrun).to receive(:run_command_in_context).with(args).and_return(devices_out)
 
         actual = sim_control.send(:simctl_list, :devices)
 
@@ -362,7 +362,7 @@ describe RunLoop::SimControl do
 
       it ':runtimes' do
         args = ['simctl', 'list', 'runtimes']
-        expect(xcrun).to receive(:exec).with(args).and_return(runtimes_out)
+        expect(xcrun).to receive(:run_command_in_context).with(args).and_return(runtimes_out)
 
         actual = sim_control.send(:simctl_list, :runtimes)
 

--- a/spec/lib/simctl_spec.rb
+++ b/spec/lib/simctl_spec.rb
@@ -178,7 +178,7 @@ describe RunLoop::Simctl do
     merged = RunLoop::Simctl::DEFAULTS.merge(options)
     cmd = ["simctl", "subcommand"]
     expect(simctl).to receive(:xcrun).and_return(xcrun)
-    expect(xcrun).to receive(:exec).with(cmd, merged).and_return({})
+    expect(xcrun).to receive(:run_command_in_context).with(cmd, merged).and_return({})
 
     expect(simctl.send(:execute, cmd, options)).to be == {}
   end

--- a/spec/lib/strings_spec.rb
+++ b/spec/lib/strings_spec.rb
@@ -106,7 +106,7 @@ describe RunLoop::Strings do
     end
 
     it "returns arch information" do
-      expect(xcrun).to receive(:exec).and_return(hash)
+      expect(xcrun).to receive(:run_command_in_context).and_return(hash)
 
       expect(strings.send(:dump)).to be == hash[:out]
       expect(strings.instance_variable_get(:@dump)).to be == hash[:out]
@@ -114,7 +114,7 @@ describe RunLoop::Strings do
 
     it "raises error if there is a problem" do
       hash[:exit_status] = 1
-      expect(xcrun).to receive(:exec).and_return(hash)
+      expect(xcrun).to receive(:run_command_in_context).and_return(hash)
 
       expect do
         strings.send(:dump)

--- a/spec/lib/xcrun_spec.rb
+++ b/spec/lib/xcrun_spec.rb
@@ -17,16 +17,21 @@ describe RunLoop::Xcrun do
     }
   end
 
-  describe '#exec' do
+  describe '#run_command_in_context' do
+
+    it "is aliased to #exec" do
+      expect(xcrun.respond_to?(:exec)).to be_truthy
+    end
+
     it 'raises an error if arg is not an Array' do
       expect do
-        xcrun.exec('simctl list devices')
+        xcrun.run_command_in_context('simctl list devices')
       end.to raise_error ArgumentError, /Expected args/
     end
 
     it 'raises an error if any arg is not a string' do
       expect do
-        xcrun.exec(['sleep', 5])
+        xcrun.run_command_in_context(['sleep', 5])
       end.to raise_error ArgumentError,
       /Expected arg '5' to be a String, but found 'Fixnum'/
     end
@@ -36,7 +41,7 @@ describe RunLoop::Xcrun do
       expect(xcrun).to receive(:ensure_command_output_utf8).and_raise(error)
 
       expect do
-        xcrun.exec(["sleep", "0.5"])
+        xcrun.run_command_in_context(["sleep", "0.5"])
       end.to raise_error RunLoop::Encoding::UTF8Error, /complex message/
     end
 
@@ -44,7 +49,7 @@ describe RunLoop::Xcrun do
       expect(CommandRunner).to receive(:run).and_raise RuntimeError, 'Some error'
 
       expect do
-        xcrun.exec(['sleep', '0.5'])
+        xcrun.run_command_in_context(['sleep', '0.5'])
       end.to raise_error RunLoop::Xcrun::Error, /Some error/
     end
 
@@ -54,13 +59,13 @@ describe RunLoop::Xcrun do
         expect(CommandRunner).to receive(:run).and_return(command_output)
 
         expect do
-          xcrun.exec(['sleep', '0.5'])
+          xcrun.run_command_in_context(['sleep', '0.5'])
         end.to raise_error RunLoop::Xcrun::TimeoutError, /Xcrun timed out after/
       end
 
       it 'actual' do
         expect do
-          xcrun.exec(['sleep', '0.5'], timeout: 0.05)
+          xcrun.run_command_in_context(['sleep', '0.5'], timeout: 0.05)
         end.to raise_error RunLoop::Xcrun::TimeoutError, /Xcrun timed out after/
       end
     end
@@ -73,7 +78,7 @@ describe RunLoop::Xcrun do
         command_output[:out] = 'mocked'
         expect(CommandRunner).to receive(:run).and_return(command_output)
 
-        xcrun_hash = xcrun.exec(['sleep', '0.1'])
+        xcrun_hash = xcrun.run_command_in_context(['sleep', '0.1'])
 
         expect(xcrun_hash[:out]).to be == 'mocked'
         expect(xcrun_hash[:pid]).to be == 3030


### PR DESCRIPTION
### Motivation

I have been using `#exec` and `.exec` methods on various classes as shorthand for "shell out an run this command".  _exec_ is not a good name because it conflicts with `Kernel#exec`.

This is renaming refactor.  `Xcrun#exec` is preserved for backward compatibility.

This work is done in the context of XCUITest/DeviceAgent support.

Related:

* remove Xcode#exec #478