### PR TITLE
DetectAUT: increase search depth for AUT for Xamarin projects

### DIFF
--- a/lib/run_loop/detect_aut/detect.rb
+++ b/lib/run_loop/detect_aut/detect.rb
@@ -29,7 +29,7 @@ module RunLoop
 
       # @!visibility private
       DEFAULTS = {
-        :search_depth => 5
+        :search_depth => 10
       }
 
       # @!visibility private

--- a/spec/lib/detect_aut/detect_spec.rb
+++ b/spec/lib/detect_aut/detect_spec.rb
@@ -157,6 +157,8 @@ describe RunLoop::DetectAUT::Detect do
 
   describe "#globs_for_app_search" do
     it "array of globs that based on default search depth" do
+      defaults = {:search_depth => 5}
+      stub_const("RunLoop::DetectAUT::Detect::DEFAULTS", defaults)
       expected_count = RunLoop::DetectAUT::Detect::DEFAULTS[:search_depth]
       expected = [
         "./*.app",


### PR DESCRIPTION
### Motivation

While working on a Xamarin sample project, I found the search depth of "5" to be too small.  Increased to 10.