### PR TITLE
Travis uses macOS 10.11 and Xcode 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ script:
 
 rvm:
   - 2.0.0
-  - 2.1.7
-  - 2.2.3
+  - 2.1.9
+  - 2.2.5
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: objective-c
 osx_image: xcode7.3
 
 before_script:
-  - gem uninstall -Vax --force --no-abort-on-dependent run_loop
   - scripts/ci/travis/instruments-auth.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
+# Force Xcode environment
 language: objective-c
+
+# Forces macOS 10.11
+osx_image: xcode7.3
 
 before_script:
   - gem uninstall -Vax --force --no-abort-on-dependent run_loop


### PR DESCRIPTION
### Motivation

* Dropping Xcode 6 testing; no longer supporting Xcode 6
* Force macOS 10.11 and Xcode 7.3
* Use precompiled rubies to address rvm SSL install errors on Travis