### PR TITLE
Don't call ps in the context of xcrun

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -1,6 +1,9 @@
 # A class to manage interactions with CoreSimulators.
 class RunLoop::CoreSimulator
 
+  require "run_loop/shell"
+  include RunLoop::Shell
+
   # These options control various aspects of an app's life cycle on the iOS
   # Simulator.
   #
@@ -568,7 +571,7 @@ $ bundle exec run-loop simctl manage-processes
     process_name = "MacOS/#{sim_name}"
 
     args = ["ps", "x", "-o", "pid,command"]
-    hash = xcrun.run_command_in_context(args)
+    hash = run_shell_command(args)
 
     exit_status = hash[:exit_status]
     if exit_status != 0

--- a/lib/run_loop/process_terminator.rb
+++ b/lib/run_loop/process_terminator.rb
@@ -101,7 +101,7 @@ module RunLoop
     # @!visibility private
     # The details of the process reported by `ps`.
     def ps_details
-      `xcrun ps -p #{pid} -o pid,comm | grep #{pid}`.strip
+      `ps -p #{pid} -o pid,comm | grep #{pid}`.strip
     end
 
     # @!visibility private

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -153,10 +153,10 @@ module RunLoop
       # @todo Maybe should try to send -TERM first and -KILL if TERM fails.
       # @todo Needs benchmarking.
       processes.each do |process_name|
-        descripts = `xcrun ps x -o pid,command | grep "#{process_name}" | grep -v grep`.strip.split("\n")
+        descripts = `ps x -o pid,command | grep "#{process_name}" | grep -v grep`.strip.split("\n")
         descripts.each do |process_desc|
           pid = process_desc.split(' ').first
-          Open3.popen3("xcrun kill -9 #{pid} && xcrun wait #{pid}") do  |_, stdout,  stderr, _|
+          Open3.popen3("kill -9 #{pid} && xcrun wait #{pid}") do  |_, stdout,  stderr, _|
             if ENV['DEBUG_UNIX_CALLS'] == '1'
               out = stdout.read.strip
               err = stderr.read.strip
@@ -601,7 +601,7 @@ module RunLoop
     # @return [String, nil] The pid as a String or nil if no process is found.
     def sim_pid
       process_name = "MacOS/#{sim_name}"
-      `xcrun ps x -o pid,command | grep "#{process_name}" | grep -v grep`.strip.split(' ').first
+      `ps x -o pid,command | grep "#{process_name}" | grep -v grep`.strip.split(' ').first
     end
 
     # @!visibility private

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -322,7 +322,6 @@ describe RunLoop::CoreSimulator do
     end
 
     describe "#running_simulator_pid" do
-      let(:xcrun) { RunLoop::Xcrun.new }
       let(:hash) do
         {
           :exit_status => 0,
@@ -330,13 +329,9 @@ describe RunLoop::CoreSimulator do
         }
       end
 
-      before do
-        allow(core_sim).to receive(:xcrun).and_return xcrun
-      end
-
       it "xcrun exit status is non-zero" do
         hash[:exit_status] = 1
-        expect(xcrun).to receive(:run_command_in_context).and_return(hash)
+        expect(core_sim).to receive(:run_shell_command).and_return hash
 
         expect do
           core_sim.send(:running_simulator_pid)
@@ -346,7 +341,7 @@ describe RunLoop::CoreSimulator do
       describe "xcrun returns no :out" do
         it "out is nil" do
           hash[:out] = nil
-          expect(xcrun).to receive(:run_command_in_context).and_return(hash)
+          expect(core_sim).to receive(:run_shell_command).and_return hash
 
           expect do
             core_sim.send(:running_simulator_pid)
@@ -355,7 +350,7 @@ describe RunLoop::CoreSimulator do
 
         it "out is empty string" do
           hash[:out] = ""
-          expect(xcrun).to receive(:run_command_in_context).and_return(hash)
+          expect(core_sim).to receive(:run_shell_command).and_return hash
 
           expect do
             core_sim.send(:running_simulator_pid)
@@ -364,15 +359,15 @@ describe RunLoop::CoreSimulator do
       end
 
       it "no matching process is found" do
-       hash[:out] =
-%Q{
+        hash[:out] =
+          %Q{
 27247 login -pf moody
 46238 tmate
 31098 less run_loop.out
 32976 vim lib/run_loop/xcrun.rb
 7656 /bin/ps x -o pid,command
 }
-        expect(xcrun).to receive(:run_command_in_context).and_return(hash)
+        expect(core_sim).to receive(:run_shell_command).and_return hash
 
         expect(core_sim.send(:running_simulator_pid)).to be == nil
       end
@@ -387,7 +382,7 @@ describe RunLoop::CoreSimulator do
 7656 /MacOS/SillySim
 }
         expect(core_sim).to receive(:sim_name).and_return("SillySim")
-        expect(xcrun).to receive(:run_command_in_context).and_return(hash)
+        expect(core_sim).to receive(:run_shell_command).and_return hash
 
         expect(core_sim.send(:running_simulator_pid)).to be == 7656
       end


### PR DESCRIPTION
### Motivation

Completes **replaces calls to `xcrun ps` with `ps`**[JIRA](https://xamarin.atlassian.net/browse/TCFW-205).

In Xcode 8, `ps` is not available in the context of `xcrun` - this is causing the unit test runner in DeviceAgent.iOS to fail.

After reviewing the code, I created this issue **Create a class or module for interacting with `ps`** #487 which is part of this epic **Pass all `read` calls through utf-8 filter** #230.