### PR TITLE
RunLoop.run detects and respects gesture performer key

### DIFF
--- a/lib/run_loop.rb
+++ b/lib/run_loop.rb
@@ -80,10 +80,20 @@ module RunLoop
     # We want to use the _exact_ objects that were passed.
     if options[:xcode]
       cloned_options[:xcode] = options[:xcode]
+    else
+      cloned_options[:xcode] = RunLoop::Xcode.new
     end
 
     if options[:simctl]
       cloned_options[:simctl] = options[:simctl]
+    else
+      cloned_options[:simctl] = RunLoop::Simctl.new
+    end
+
+    if options[:instruments]
+      cloned_options[:instruments] = options[:instruments]
+    else
+      cloned_options[:instruments] = RunLoop::Instruments.new
     end
 
     # Soon to be unsupported.
@@ -91,7 +101,13 @@ module RunLoop
       cloned_options[:sim_control] = options[:sim_control]
     end
 
-    if options[:xcuitest]
+    xcode = cloned_options[:xcode]
+    simctl = cloned_options[:simctl]
+    instruments = cloned_options[:instruments]
+
+    device = Device.detect_device(cloned_options, xcode, simctl, instruments)
+    cloned_options[:device] = device
+
       RunLoop::XCUITest.run(cloned_options)
     else
       if RunLoop::Instruments.new.instruments_app_running?

--- a/lib/run_loop.rb
+++ b/lib/run_loop.rb
@@ -108,6 +108,8 @@ module RunLoop
     device = Device.detect_device(cloned_options, xcode, simctl, instruments)
     cloned_options[:device] = device
 
+    gesture_performer = RunLoop.detect_gesture_performer(cloned_options, xcode, device)
+    if gesture_performer == :device_agent
       RunLoop::XCUITest.run(cloned_options)
     else
       if RunLoop::Instruments.new.instruments_app_running?
@@ -239,5 +241,102 @@ Please quit the Instruments.app and try again.)
 
   def self.log_info(*args)
     RunLoop::Logging.log_info(*args)
+  end
+
+  # @!visibility private
+  #
+  # @param [RunLoop::Xcode] xcode The active Xcode
+  # @param [RunLoop::Device] device The device under test.
+  def self.default_gesture_performer(xcode, device)
+    # TODO XTC support
+    return :instruments if RunLoop::Environment.xtc?
+
+    if xcode.version_gte_8?
+      if device.version >= RunLoop::Version.new("9.0")
+        :device_agent
+      else
+        raise RuntimeError, %Q[
+Invalid Xcode and iOS combination:
+
+Xcode version: #{xcode.version.to_s}
+  iOS version: #{device.version.to_s}
+
+Calabash cannot test iOS < 9.0 using Xcode 8 because XCUITest is not compatible
+with iOS < 9.0 and UIAutomation is not available in Xcode 8.
+
+You can rerun your test if you have Xcode 7 installed:
+
+$ DEVELOPER_DIR=/path/to/Xcode/7.3.1/Xcode.app/Contents/Developer cucumber
+
+]
+      end
+
+    else
+      :instruments
+    end
+  end
+
+  # @!visibility private
+  #
+  # First pass at choosing the correct code path.
+  #
+  # We don't know if we can test on iOS 8 with UIAutomation or XCUITest on
+  # Xcode 8.
+  #
+  # @param [Hash] options The options passed by the user
+  # @param [RunLoop::Xcode] xcode The active Xcode
+  # @param [RunLoop::Device] device The device under test
+  def self.detect_gesture_performer(options, xcode, device)
+    # TODO XTC support
+    return :instruments if RunLoop::Environment.xtc?
+
+    gesture_performer = options[:gesture_performer]
+
+    if gesture_performer
+      if xcode.version_gte_8?
+        if gesture_performer == :instruments
+          raise RuntimeError, %Q[
+Incompatible :gesture_performer option for active Xcode.
+
+Detected :gesture_performer => :instruments and Xcode #{xcode.version}.
+
+Don't set the :gesture_performer option unless you are gem maintainer.
+
+]
+        elsif device.version < RunLoop::Version.new("9.0")
+          raise RuntimeError, %Q[
+
+Invalid Xcode and iOS combination:
+
+Xcode version: #{xcode.version.to_s}
+  iOS version: #{device.version.to_s}
+
+Calabash cannot test iOS < 9.0 using Xcode 8 because XCUITest is not compatible
+with iOS < 9.0 and UIAutomation is not available in Xcode 8.
+
+You can rerun your test if you have Xcode 7 installed:
+
+$ DEVELOPER_DIR=/path/to/Xcode/7.3.1/Xcode.app/Contents/Developer cucumber
+
+Don't set the :gesture_performer option unless you are gem maintainer.
+
+]
+        end
+      end
+
+      if ![:device_agent, :instruments].include?(gesture_performer)
+        raise RuntimeError, %Q[
+Invalid :gesture_performer option: #{gesture_performer}
+
+Allowed performers: :device_agent or :instruments.
+
+Don't set the :gesture_performer option unless you are gem maintainer.
+
+]
+      end
+      gesture_performer
+    else
+      RunLoop.default_gesture_performer(xcode, device)
+    end
   end
 end

--- a/spec/integration/core_simulator_spec.rb
+++ b/spec/integration/core_simulator_spec.rb
@@ -95,7 +95,7 @@ describe RunLoop::CoreSimulator do
   end
 
   it "retries app launching" do
-    expect(core_sim).to receive(:launch_app_with_simctl).twice.and_raise(RunLoop::Xcrun::TimeoutError)
+    expect(core_sim).to receive(:launch_app_with_simctl).exactly(3).times.and_raise(RunLoop::Xcrun::TimeoutError)
     expect(core_sim).to receive(:launch_app_with_simctl).and_call_original
 
     expect(core_sim.launch).to be == true

--- a/spec/lib/run_loop_spec.rb
+++ b/spec/lib/run_loop_spec.rb
@@ -36,6 +36,125 @@ describe RunLoop do
     end
   end
 
+  context ".default_gesture_performer" do
+    it "returns :instruments on the XTC" do
+      expect(RunLoop::Environment).to receive(:xtc?).and_return(true)
+
+      expect(RunLoop.default_gesture_performer(xcode, device)).to be == :instruments
+    end
+
+    context "not XTC" do
+
+      before do
+        expect(RunLoop::Environment).to receive(:xtc?).and_return(false)
+      end
+
+      context "Xcode >= 8" do
+
+        before do
+          expect(xcode).to receive(:version_gte_8?).and_return(true)
+        end
+
+        it "returns :device_agent if device version >= 9.0" do
+          ios9 = RunLoop::Version.new("9.0")
+          expect(device).to receive(:version).at_least(:once).and_return(ios9)
+
+          expect(RunLoop.default_gesture_performer(xcode, device)).to be == :device_agent
+        end
+
+        it "raises error if device version < 9.0" do
+          ios8 = RunLoop::Version.new("8.0")
+          expect(device).to receive(:version).at_least(:once).and_return(ios8)
+
+          expect do
+            RunLoop.default_gesture_performer(xcode, device)
+          end.to raise_error RuntimeError, /Invalid Xcode and iOS combination/
+        end
+      end
+
+      context "Xcode < 8" do
+        it "returns :instruments" do
+          expect(xcode).to receive(:version_gte_8?).and_return(false)
+
+          expect(RunLoop.default_gesture_performer(xcode, device)).to be == :instruments
+        end
+      end
+    end
+  end
+
+  context ".detect_gesture_performer" do
+    let(:options) { {} }
+
+    context "XTC" do
+      it "returns :instruments" do
+        expect(RunLoop::Environment).to receive(:xtc?).and_return(true)
+
+        expected = :instruments
+        actual = RunLoop.detect_gesture_performer(options, xcode, device)
+        expect(actual).to be == expected
+      end
+    end
+
+    context "not XTC" do
+
+      before do
+        expect(RunLoop::Environment).to receive(:xtc?).and_return(false)
+      end
+
+      context ":gesture_performer defined" do
+        context "Xcode < 8" do
+          it "returns :gesture_performer value" do
+            options[:gesture_performer] = :instruments
+            expect(xcode).to receive(:version_gte_8?).and_return(false)
+
+            actual = RunLoop.detect_gesture_performer(options, xcode, device)
+            expect(actual).to be == :instruments
+          end
+        end
+
+        context "Xcode >= 8" do
+          before do
+            expect(xcode).to receive(:version_gte_8?).and_return(true)
+          end
+
+          it "raises error if :instruments" do
+            options[:gesture_performer] = :instruments
+
+            expect do
+              RunLoop.detect_gesture_performer(options, xcode, device)
+            end.to raise_error RuntimeError,
+                               /Incompatible :gesture_performer option for active Xcode/
+          end
+
+          it "raises error if iOS version < 9.0" do
+            options[:gesture_performer] = :device_agent
+            ios8 = RunLoop::Version.new("8.0")
+            expect(device).to receive(:version).at_least(:once).and_return(ios8)
+
+            expect do
+              RunLoop.detect_gesture_performer(options, xcode, device)
+            end.to raise_error RuntimeError, /Invalid Xcode and iOS combination/
+          end
+        end
+
+        it "raises error if unknown gesture_performer" do
+          options[:gesture_performer] = :unknown_performer
+
+          expect do
+            RunLoop.detect_gesture_performer(options, xcode, device)
+          end.to raise_error RuntimeError, /Invalid :gesture_performer option:/
+        end
+      end
+    end
+
+    context ":gesture_performer not defined" do
+      it "returns .default_gesture_performer" do
+        expected = :performer
+        expect(RunLoop).to receive(:default_gesture_performer).and_return(expected)
+
+        expect(RunLoop.detect_gesture_performer(options, xcode, device)).to be == expected
+      end
     end
   end
 end
+

--- a/spec/lib/run_loop_spec.rb
+++ b/spec/lib/run_loop_spec.rb
@@ -5,30 +5,37 @@ describe RunLoop do
     allow_any_instance_of(RunLoop::Instruments).to receive(:instruments_app_running?).and_return(false)
   end
 
+  let(:xcode) { RunLoop::Xcode.new }
+  let(:instruments) { RunLoop::Instruments.new }
+  let(:simctl) { RunLoop::Simctl.new }
+  let(:device) { Resources.shared.device }
+
   describe ".run" do
 
     it "does not mangle options" do
-      xcode = RunLoop::Xcode.new
-      sim_control = RunLoop::SimControl.new
-      simctl = RunLoop::Simctl.new
       options = {
         :xcode => xcode,
-        :sim_control => sim_control,
         :simctl => simctl,
-        :uia_strategy => :preferences
+        :uia_strategy => :preferences,
+        :instruments => instruments,
+        :device => device
       }
 
       after = {
         :xcode => xcode,
-        :sim_control => sim_control,
         :simctl => simctl,
         :uia_strategy => :preferences,
+        :instruments => instruments,
+        :device => device,
       }
 
       expect(RunLoop::Core).to receive(:run_with_options).with(after).and_return({})
       RunLoop.run(options)
 
-      expect(options.count).to be == 4
+      expect(options.count).to be == 5
+    end
+  end
+
     end
   end
 end


### PR DESCRIPTION
### Motivation

RunLoop needs to know when to use UIAutomation/instruments and XCUITest/DeviceAgent.

`RunLoop.run` now responds to the `:gesture_performer`.  Users should never set this option, it is for gem maintainers only.  Users should rely on the default behavior.

The default behavior is:

* :instruments <== Xcode <= 7
* :device_agent <== Xcode >= 8

At the moment, RunLoop will raise an error if the Xcode version is incompatible with the iOS version: Xcode >= 8 and iOS < 9.0.

Please be aware that there is no released version of Calabash that can use :device_agent.

Alpha level support for DeviceAgent will be available in Calabash > 0.19.2 (next release).