### PR TITLE
iOSDeviceManager: wait for sim 'shutdown' state before launching

### DIFF
--- a/lib/run_loop/device_agent/ios_device_manager.rb
+++ b/lib/run_loop/device_agent/ios_device_manager.rb
@@ -74,6 +74,8 @@ but binary does not exist at that path.
           # Simulator cannot be running for this version.
           CoreSimulator.quit_simulator
 
+          CoreSimulator.wait_for_simulator_state(device, "Shutdown")
+
           # TODO: run-loop is responsible for detecting an outdated CBX-Runner
           # application and installing a new one.  However, iOSDeviceManager
           # fails if simulator is already running.


### PR DESCRIPTION
### Motivation

iOSDeviceManager requires the simulator be in state "Shutdown" before is can launch the CBX-Runner.

There are a couple of options:

1. CoreSimulator.quit_simulator detects a Booted sim and waits for it to have state "Shutdown".  This is expensive because it requires `Simctl` to either update the state of every known simulator or to ask for all the simulators (and thereby getting the state).  Either of these approaches might take > 10 seconds.
2. Call out to iOSDeviceManager#kill_simulator - this waits for "Shutdown".
3. After the CoreSimulator.quit_simulator call and before the iOSDeviceManager `start_test`, insert a `CoreSimulator.wait_for_simulator_state(device, "Shutdown")`.

I opted for 3 because it was the fastest to implement. Option 2 is attractive and is arguably the best solution, but I want to wait a bit before transferring more responsibility to iOSDeviceManager.

ATTN @JoeSSS - this will fix the "spec/integration/xcuitest:37" fails every other run problem.