### PR TITLE
Gem: require dnssd only on macOS

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -3,7 +3,12 @@ require 'irb/ext/save-history'
 require 'benchmark'
 require 'run_loop'
 require 'command_runner'
-require "dnssd"
+
+if RUBY_PLATFORM[/darwin/]
+  require "dnssd"
+else
+  puts "Skipping dnssd on #{RUBY_PLATFORM}"
+end
 
 AwesomePrint.irb!
 

--- a/bin/dnssd
+++ b/bin/dnssd
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require "dnssd"
 require "socket"
 require "ap"
 require "json"
@@ -9,6 +8,12 @@ Thread.abort_on_exception = true
 
 trap 'INT' do exit end
 trap 'TERM' do exit end
+
+if RUBY_PLATFORM[/darwin/]
+  require "dnssd"
+else
+  raise "dnssd gem is not available on #{RUBY_PLATFORM}"
+end
 
 services = []
 addresses = []

--- a/run_loop.gemspec
+++ b/run_loop.gemspec
@@ -51,8 +51,11 @@ tools like instruments and simctl.}
   s.add_dependency('thor', '>= 0.18.1', '< 1.0')
   s.add_dependency('command_runner_ng', '>= 0.0.2')
   s.add_dependency("httpclient", "~> 2.6")
-  s.add_dependency("dnssd", "2.0")
   s.add_dependency("i18n", ">= 0.7.0", "< 1.0")
+
+  if RUBY_PLATFORM[/darwin/]
+    s.add_dependency("dnssd", "2.0")
+  end
 
   s.add_development_dependency("rspec_junit_formatter", "~> 0.2")
   s.add_development_dependency("luffa", "~> 2.0")


### PR DESCRIPTION
### Motivation

Calabash 2.0 depends on run-loop and must be able to install on Windows and Linux environments.  The dnssd gem is macOS only. 