### PR TITLE
Remove dnssd dependency

### DIFF
--- a/bin/dnssd
+++ b/bin/dnssd
@@ -9,10 +9,23 @@ Thread.abort_on_exception = true
 trap 'INT' do exit end
 trap 'TERM' do exit end
 
-if RUBY_PLATFORM[/darwin/]
-  require "dnssd"
+if defined?(Bundler)
+  raise "This tool cannot be called in the context of bundle exec"
+elsif RUBY_PLATFORM[/darwin/]
+  begin
+    require "dnssd"
+  rescue LoadError => _
+    raise %Q[
+
+This tool requires the dnssd gem which is not installed.  Install it:
+
+gem install dnssd --version 2.0
+
+and try again.
+]
+  end
 else
-  raise "dnssd gem is not available on #{RUBY_PLATFORM}"
+  raise "This tool is not available on #{RUBY_PLATFORM}"
 end
 
 services = []

--- a/lib/run_loop.rb
+++ b/lib/run_loop.rb
@@ -48,7 +48,6 @@ require "run_loop/http/server"
 require "run_loop/http/request"
 require "run_loop/http/retriable_client"
 require "run_loop/physical_device/life_cycle"
-require "run_loop/dnssd"
 
 module RunLoop
 

--- a/lib/run_loop/dnssd.rb
+++ b/lib/run_loop/dnssd.rb
@@ -3,8 +3,16 @@ module RunLoop
   # @!visibility private
   # This class is a work in progress.
   #
-  # At the moment, it is only useful for debugging the bonjour
-  # server that is started by DeviceAgent.
+  # At the moment, it is only useful for debugging the bonjour server that is
+  # started by DeviceAgent.
+  #
+  # This class requires the dnssd gem, but dnssd cannot be a dependency of this
+  # gem because:
+  #
+  # 1. This gem must be useable on Linux and Windows.  dnssd is a macOS only
+  #    gem.
+  # 2. Adding a native extension works locally, but it requires whitelisting
+  #    the run_loop gem on the Xamarin Test Cloud which is not practical.
   class DNSSD
 
     # @!visibility private
@@ -134,6 +142,21 @@ module RunLoop
     end
 
     def self.browse(type, timeout)
+      begin
+        require "dnssd"
+      rescue LoadError => _
+        raise %Q[
+
+This class requires dnssd which cannot be a dependency of this gem.
+
+See the comments at the top of this file:
+
+#{File.expand_path(__FILE__)}
+
+#{e}
+
+]
+      end
       domain = nil
       flags = 0
       interface = ::DNSSD::InterfaceAny

--- a/run_loop.gemspec
+++ b/run_loop.gemspec
@@ -53,10 +53,6 @@ tools like instruments and simctl.}
   s.add_dependency("httpclient", "~> 2.6")
   s.add_dependency("i18n", ">= 0.7.0", "< 1.0")
 
-  if RUBY_PLATFORM[/darwin/]
-    s.add_dependency("dnssd", "2.0")
-  end
-
   s.add_development_dependency("rspec_junit_formatter", "~> 0.2")
   s.add_development_dependency("luffa", "~> 2.0")
   s.add_development_dependency('bundler', '~> 1.6')


### PR DESCRIPTION
### Motivation

The dnssd gem is macOS only.

Calabash 2.0 and x-platform projects depend on run-loop and must be able to install on Windows and Linux environments. 

A native extension is not practical (it works locally), because it would require the run_loop gem be whitelisted on the Xamarin Test Cloud.

I am going to make this change as patch release because the dnssd interface is a command line development tool and not something that is used during UI testing.

[JIRA](https://xamarin.atlassian.net/browse/TCFW-256)

### Test

I ran the test-cloud-command-line test against this branch.