### PR TITLE
Start PhysicalDevice::LifeCycle::IOSDeviceManager implementation

### DIFF
--- a/lib/run_loop.rb
+++ b/lib/run_loop.rb
@@ -48,6 +48,7 @@ require "run_loop/http/server"
 require "run_loop/http/request"
 require "run_loop/http/retriable_client"
 require "run_loop/physical_device/life_cycle"
+require "run_loop/physical_device/ios_device_manager"
 
 module RunLoop
 

--- a/lib/run_loop/device_agent/ios_device_manager.rb
+++ b/lib/run_loop/device_agent/ios_device_manager.rb
@@ -97,7 +97,7 @@ but binary does not exist at that path.
 
         if device.physical_device?
           args << "-c"
-          args << RunLoop::Environment.codesign_identity
+          args << RunLoop::Environment.code_sign_identity
         end
 
         log_file = IOSDeviceManager.log_file

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -163,8 +163,8 @@ module RunLoop
     end
 
     # Returns the value of CODESIGN_IDENTITY
-    def self.codesign_identity
-      value = ENV["CODESIGN_IDENTITY"]
+    def self.code_sign_identity
+      value = ENV["CODE_SIGN_IDENTITY"]
       if !value || value == ""
         nil
       else

--- a/lib/run_loop/physical_device/ios_device_manager.rb
+++ b/lib/run_loop/physical_device/ios_device_manager.rb
@@ -1,0 +1,65 @@
+
+module RunLoop
+  module PhysicalDevice
+
+    require "run_loop/physical_device/life_cycle"
+    class IOSDeviceManager < RunLoop::PhysicalDevice::LifeCycle
+
+      # Is the tool installed?
+      def self.tool_is_installed?
+        File.exist?(IOSDeviceManager.executable_path)
+      end
+
+      # Path to tool.
+      def self.executable_path
+        RunLoop::DeviceAgent::IOSDeviceManager.ios_device_manager
+      end
+
+      def app_installed?(bundle_id)
+        args = [
+          IOSDeviceManager.executable_path,
+          "is_installed",
+          "-d", device.udid,
+          "-b", bundle_id
+        ]
+
+        options = { :log_cmd => true }
+        hash = run_shell_command(args, options)
+
+        # TODO: error reporting
+        hash[:exit_status] == 0
+      end
+
+      def install_app(app_or_ipa)
+        app = app_or_ipa
+        if is_ipa?(app)
+          app = app_or_ipa.app
+        end
+
+        code_sign_identity = RunLoop::Environment.code_sign_identity
+        if !code_sign_identity
+          code_sign_identity = "iPhone Developer"
+        end
+
+        args = [
+          IOSDeviceManager.executable_path,
+          "install",
+          "-d", device.udid,
+          "-a", app.path,
+          "-c", code_sign_identity
+        ]
+
+        options = { :log_cmd => true }
+        hash = run_shell_command(args, options)
+
+        # TODO: error reporting
+        if hash[:exit_status] == 0
+          true
+        else
+          puts hash[:out]
+          false
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/environment_spec.rb
+++ b/spec/lib/environment_spec.rb
@@ -351,20 +351,20 @@ describe RunLoop::Environment do
   describe ".codesign_identity" do
     it "returns value" do
       identity = "iPhone Developer: Max Musterman (ABCDE12345)"
-      stub_env({"CODESIGN_IDENTITY" => identity})
+      stub_env({"CODE_SIGN_IDENTITY" => identity})
 
-      expect(RunLoop::Environment.codesign_identity).to be == identity
+      expect(RunLoop::Environment.code_sign_identity).to be == identity
     end
 
     describe "returns nil" do
       it "if value is the empty string" do
-        stub_env("CODESIGN_IDENTITY", "")
-        expect(RunLoop::Environment.codesign_identity).to be == nil
+        stub_env("CODE_SIGN_IDENTITY", "")
+        expect(RunLoop::Environment.code_sign_identity).to be == nil
       end
 
       it "if value is nil" do
-        stub_env({"CODESIGN_IDENTITY" => nil})
-        expect(RunLoop::Environment.codesign_identity).to be == nil
+        stub_env({"CODE_SIGN_IDENTITY" => nil})
+        expect(RunLoop::Environment.code_sign_identity).to be == nil
       end
     end
   end


### PR DESCRIPTION
### Motivation

We want an interface to iOSDeviceManager's physical device management tools.

This is a first pass and should be considered a work in progress.

There are no unit tests for the interface.