### PR TITLE
Regex: expand VERSION_REGEX to support iOS 10.0

### DIFF
--- a/lib/run_loop/regex.rb
+++ b/lib/run_loop/regex.rb
@@ -13,7 +13,7 @@ module RunLoop
     DEVICE_UDID_REGEX = /[a-f0-9]{40}/.freeze
 
     # @!visibility private
-    VERSION_REGEX = /(\d\.\d(\.\d)?)/.freeze
+    VERSION_REGEX = /(\d+\.\d+(\.\d+)?)/.freeze
 
   end
 end

--- a/spec/lib/regex_spec.rb
+++ b/spec/lib/regex_spec.rb
@@ -1,0 +1,32 @@
+
+describe RunLoop::Regex do
+
+  context "VERSION_REGEX" do
+
+    let(:regex) { RunLoop::Regex::VERSION_REGEX }
+
+    it "can detect single digit major" do
+      expect("9.0"[regex]).to be == "9.0"
+    end
+
+    it "can detect double digit major" do
+      expect("10.0"[regex]).to be == "10.0"
+    end
+
+    it "can detect single digit minor" do
+      expect("10.9"[regex]).to be == "10.9"
+    end
+
+    it "can detect double digit minor" do
+      expect("10.10"[regex]).to be == "10.10"
+    end
+
+    it "can detect single digit patch" do
+      expect("10.10.0"[regex]).to be == "10.10.0"
+    end
+
+    it "can detect double digit patch" do
+      expect("10.10.10"[regex]).to be == "10.10.10"
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

Regex reports iOS 10 as "0.0"  Whoops!

[JIRA](https://xamarin.atlassian.net/browse/TCFW-285)