### PR TITLE
Shell: raise the correct error when command fails

### DIFF
--- a/lib/run_loop/shell.rb
+++ b/lib/run_loop/shell.rb
@@ -85,18 +85,42 @@ executing this command:
 }
       end
 
+      now = Time.now
+
       if hash[:exit_status].nil?
-        elapsed = "%0.2f" % (Time.now - start_time)
-        raise TimeoutError,
-%Q{Timed out after #{elapsed} seconds executing
+        elapsed = "%0.2f" % (now - start_time)
+
+        if timeout_exceeded?(start_time, timeout)
+          raise TimeoutError,
+%Q[
+Timed out after #{elapsed} seconds executing
 
 #{cmd}
 
 with a timeout of #{timeout}
-}
+]
+        else
+          raise Error,
+                %Q[
+There was an error executing:
+
+#{cmd}
+
+The command generated this output:
+
+#{hash[:out]}
+]
+
+        end
       end
 
       hash
+    end
+
+    private
+
+    def timeout_exceeded?(start_time, timeout)
+      Time.now > start_time + timeout
     end
   end
 end


### PR DESCRIPTION
### Motivation

Shell.run_unix_command was raising a TimeoutError if the command failed to execute (:exit_status => nil).  It now correctly raises a RunLoop::Shell::Error.

[JIRA](https://xamarin.atlassian.net/browse/TCFW-272)