### PR TITLE
LifeCycle: IOSDeviceManager expands the Frameworks.zip if necessary

### DIFF
--- a/lib/run_loop/physical_device/ios_device_manager.rb
+++ b/lib/run_loop/physical_device/ios_device_manager.rb
@@ -15,6 +15,13 @@ module RunLoop
         RunLoop::DeviceAgent::IOSDeviceManager.ios_device_manager
       end
 
+      def initialize(device)
+        super(device)
+
+        # Expands the Frameworks.zip if necessary.
+        RunLoop::DeviceAgent::Frameworks.instance.install
+      end
+
       def app_installed?(bundle_id)
         args = [
           IOSDeviceManager.executable_path,

--- a/spec/lib/physical_device/ios_device_manager_spec.rb
+++ b/spec/lib/physical_device/ios_device_manager_spec.rb
@@ -1,0 +1,14 @@
+
+describe RunLoop::PhysicalDevice::IOSDeviceManager do
+
+  context ".new" do
+    it "calls super with device arg and expands the DeviceAgent Frameworks.zip" do
+      frameworks = RunLoop::DeviceAgent::Frameworks.instance
+      expect(frameworks).to receive(:install).and_return(true)
+      device = Resources.shared.device
+
+      manager = RunLoop::PhysicalDevice::IOSDeviceManager.new(device)
+      expect(manager.device).to be == device
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

The DeviceAgent Frameworks.zip must be expanded before iOSDeviceManager can be invoked.

[JIRA](https://xamarin.atlassian.net/browse/TCFW-286)