### PR TITLE
All simctl commands are performed through Simctl instance

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -103,7 +103,7 @@ def create_simulator(n, options={})
   runtime = merged_options[:runtime]
 
   n.times do
-    system('xcrun', 'simctl', 'create', name, type, runtime)
+    system('xcrun', "simctl", 'create', name, type, runtime)
   end
 end
 
@@ -111,7 +111,7 @@ def delete_simulator(name)
   simctl.simulators.each do |simulator|
     if simulator.name == name
       puts "Deleting #{simulator}"
-      system('xcrun', 'simctl', 'delete', simulator.udid)
+      system('xcrun', "simctl", 'delete', simulator.udid)
     end
   end
   true

--- a/lib/run_loop/cli/cli.rb
+++ b/lib/run_loop/cli/cli.rb
@@ -30,8 +30,8 @@ module RunLoop
       desc 'instruments', "Interact with Xcode's command-line instruments"
       subcommand 'instruments', RunLoop::CLI::Instruments
 
-      desc 'simctl', "Interact with Xcode's command-line simctl"
-      subcommand 'simctl', RunLoop::CLI::Simctl
+      desc "simctl", "Interact with Xcode's command-line simctl"
+      subcommand "simctl", RunLoop::CLI::Simctl
 
       desc "locale", "Tools for interacting with locales"
       subcommand "locale", RunLoop::CLI::Locale

--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -555,9 +555,8 @@ Command had no output
   def install_app_with_simctl
     launch_simulator
 
-    args = ["simctl", 'install', device.udid, app.path]
     timeout = DEFAULT_OPTIONS[:install_app_timeout]
-    xcrun.run_command_in_context(args, log_cmd: true, timeout: timeout)
+    simctl.install(device, app, timeout)
 
     device.simulator_wait_for_stable_state
     installed_app_bundle_dir

--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -434,10 +434,8 @@ Could not launch #{app.bundle_identifier} on #{device} after trying #{tries} tim
 
     launch_simulator
 
-    args = ["simctl", 'uninstall', device.udid, app.bundle_identifier]
-
     timeout = DEFAULT_OPTIONS[:uninstall_app_timeout]
-    xcrun.run_command_in_context(args, log_cmd: true, timeout: timeout)
+    simctl.uninstall(device, app, timeout)
 
     device.simulator_wait_for_stable_state
     true

--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -487,7 +487,7 @@ $ bundle exec run-loop simctl manage-processes
 
     launch_simulator
 
-    args = ['simctl', 'uninstall', device.udid, app.bundle_identifier]
+    args = ["simctl", 'uninstall', device.udid, app.bundle_identifier]
 
     timeout = DEFAULT_OPTIONS[:uninstall_app_timeout]
     xcrun.run_command_in_context(args, log_cmd: true, timeout: timeout)
@@ -610,7 +610,7 @@ Command had no output
   def install_app_with_simctl
     launch_simulator
 
-    args = ['simctl', 'install', device.udid, app.path]
+    args = ["simctl", 'install', device.udid, app.path]
     timeout = DEFAULT_OPTIONS[:install_app_timeout]
     xcrun.run_command_in_context(args, log_cmd: true, timeout: timeout)
 
@@ -620,7 +620,7 @@ Command had no output
 
   # @!visibility private
   def launch_app_with_simctl
-    args = ['simctl', 'launch', device.udid, app.bundle_identifier]
+    args = ["simctl", 'launch', device.udid, app.bundle_identifier]
     timeout = DEFAULT_OPTIONS[:launch_app_timeout]
     xcrun.run_command_in_context(args, log_cmd: true, timeout: timeout)
   end

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -562,7 +562,8 @@ failed with this output:
         raise RuntimeError, 'This method is available only for simulators'
       end
 
-      args = ['simctl', 'list', 'devices']
+      # TODO Move!!!!
+      args = ["simctl", 'list', 'devices']
       hash = xcrun.run_command_in_context(args)
       out = hash[:out]
 

--- a/lib/run_loop/shell.rb
+++ b/lib/run_loop/shell.rb
@@ -26,6 +26,16 @@ module RunLoop
     # Raised when shell command times out.
     class TimeoutError < RuntimeError; end
 
+    def self.run_shell_command(args, options={})
+      shell = Class.new do
+        include RunLoop::Shell
+        def to_s; "#<Anonymous Shell>"; end
+        def inspect; to_s; end
+      end.new
+
+      shell.run_shell_command(args, options)
+    end
+
     def run_shell_command(args, options={})
 
       merged_options = DEFAULT_OPTIONS.merge(options)

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -1136,6 +1136,8 @@ module RunLoop
     #  base sdk version.
     # @see #simctl_list
     def simctl_list_devices
+      # Ensure correct CoreSimulator service is installed.
+      RunLoop::Simctl.new
       args = ["simctl", 'list', 'devices']
       hash = xcrun.run_command_in_context(args)
 
@@ -1219,6 +1221,8 @@ module RunLoop
     #
     # @see #simctl_list
     def simctl_list_runtimes
+      # Ensure correct CoreSimulator service is installed.
+      RunLoop::Simctl.new
       args = ["simctl", 'list', 'runtimes']
       hash = xcrun.run_command_in_context(args)
 

--- a/lib/run_loop/sim_control.rb
+++ b/lib/run_loop/sim_control.rb
@@ -1136,7 +1136,7 @@ module RunLoop
     #  base sdk version.
     # @see #simctl_list
     def simctl_list_devices
-      args = ['simctl', 'list', 'devices']
+      args = ["simctl", 'list', 'devices']
       hash = xcrun.run_command_in_context(args)
 
       current_sdk = nil
@@ -1219,7 +1219,7 @@ module RunLoop
     #
     # @see #simctl_list
     def simctl_list_runtimes
-      args = ['simctl', 'list', 'runtimes']
+      args = ["simctl", 'list', 'runtimes']
       hash = xcrun.run_command_in_context(args)
 
       # Ex.

--- a/lib/run_loop/simctl.rb
+++ b/lib/run_loop/simctl.rb
@@ -106,7 +106,7 @@ module RunLoop
     def app_container(device, bundle_id)
       return nil if !xcode.version_gte_7?
       cmd = ["simctl", "get_app_container", device.udid, bundle_id]
-      hash = execute(cmd, DEFAULTS)
+      hash = shell_out_with_xcrun(cmd, DEFAULTS)
 
       exit_status = hash[:exit_status]
       if exit_status != 0
@@ -134,7 +134,7 @@ module RunLoop
         true
       else
         cmd = ["simctl", "shutdown", device.udid]
-        hash = execute(cmd, DEFAULTS)
+        hash = shell_out_with_xcrun(cmd, DEFAULTS)
 
         exit_status = hash[:exit_status]
         if exit_status != 0
@@ -206,7 +206,7 @@ $ bundle exec run-loop simctl manage-processes
       wait_for_shutdown(device, wait_timeout, wait_delay)
 
       cmd = ["simctl", "erase", device.udid]
-      hash = execute(cmd, DEFAULTS)
+      hash = shell_out_with_xcrun(cmd, DEFAULTS)
 
       exit_status = hash[:exit_status]
       if exit_status != 0
@@ -248,7 +248,7 @@ $ bundle exec run-loop simctl manage-processes
       options = DEFAULTS.dup
       options[:timeout] = timeout
 
-      hash = execute(cmd, options)
+      hash = shell_out_with_xcrun(cmd, options)
 
       exit_status = hash[:exit_status]
       if exit_status != 0
@@ -292,7 +292,7 @@ $ bundle exec run-loop simctl manage-processes
       options = DEFAULTS.dup
       options[:timeout] = timeout
 
-      hash = execute(cmd, options)
+      hash = shell_out_with_xcrun(cmd, options)
 
       exit_status = hash[:exit_status]
       if exit_status != 0
@@ -334,7 +334,7 @@ $ bundle exec run-loop simctl manage-processes
       options = DEFAULTS.dup
       options[:timeout] = timeout
 
-      hash = execute(cmd, options)
+      hash = shell_out_with_xcrun(cmd, options)
 
       exit_status = hash[:exit_status]
       if exit_status != 0
@@ -401,7 +401,7 @@ $ bundle exec run-loop simctl manage-processes
     end
 
     # @!visibility private
-    def execute(array, options)
+    def shell_out_with_xcrun(array, options)
       merged = DEFAULTS.merge(options)
       xcrun.run_command_in_context(array, merged)
     end
@@ -431,7 +431,7 @@ $ bundle exec run-loop simctl manage-processes
       @watchos_devices = []
 
       cmd = ["simctl", "list", "devices", "--json"]
-      hash = execute(cmd, DEFAULTS)
+      hash = shell_out_with_xcrun(cmd, DEFAULTS)
 
       out = hash[:out]
       exit_status = hash[:exit_status]

--- a/lib/run_loop/simctl.rb
+++ b/lib/run_loop/simctl.rb
@@ -30,6 +30,28 @@ module RunLoop
     end
 
     # @!visibility private
+    def self.ensure_valid_core_simulator_service
+      require "run_loop/shell"
+      args = ["xcrun", "simctl", "help"]
+
+      max_tries = 3
+      3.times do |try|
+        hash = {}
+        begin
+          hash = Shell.run_shell_command(args)
+          if hash[:exit_status] != 0
+            RunLoop.log_debug("Invalid CoreSimulator service for active Xcode: try #{try + 1} of #{max_tries}")
+          else
+            return true
+          end
+        rescue RunLoop::Shell::Error => _
+          RunLoop.log_debug("Invalid CoreSimulator service for active Xcode, retrying #{try + 1} of #{max_tries}")
+        end
+      end
+      false
+    end
+
+    # @!visibility private
     attr_reader :device
 
     # @!visibility private
@@ -37,6 +59,7 @@ module RunLoop
       @ios_devices = []
       @tvos_devices = []
       @watchos_devices = []
+      Simctl.ensure_valid_core_simulator_service
     end
 
     # @!visibility private

--- a/lib/run_loop/simctl.rb
+++ b/lib/run_loop/simctl.rb
@@ -211,6 +211,49 @@ $ bundle exec run-loop simctl manage-processes
   command: xcrun #{cmd.join(" ")}
 simulator: #{device}
 
+              #{hash[:out]}
+
+This usually means your CoreSimulator processes need to be restarted.
+
+You can restart the CoreSimulator processes with this command:
+
+$ bundle exec run-loop simctl manage-processes
+
+]
+      end
+      true
+    end
+
+    # @!visibility private
+    #
+    # Launches the app on on the device.
+    #
+    # Caller is responsible for the following:
+    #
+    # 1. Launching the simulator.
+    # 2. Installing the application,
+    #
+    # No checks are made.
+    #
+    # @param [RunLoop::Device] device The simulator to launch on.
+    # @param [RunLoop::App] app The app to launch.
+    # @param [Numeric] timeout How long to wait for simctl to complete.
+    def launch(device, app, timeout)
+      cmd = ["simctl", "launch", device.udid, app.bundle_identifier]
+      options = DEFAULTS.dup
+      options[:timeout] = timeout
+
+      hash = execute(cmd, options)
+
+      exit_status = hash[:exit_status]
+      if exit_status != 0
+        raise RuntimeError,
+%Q[Could not launch app on simulator:
+
+  command: xcrun #{cmd.join(" ")}
+simulator: #{device}
+      app: #{app}
+
 #{hash[:out]}
 
 This usually means your CoreSimulator processes need to be restarted.

--- a/lib/run_loop/simctl.rb
+++ b/lib/run_loop/simctl.rb
@@ -231,7 +231,7 @@ $ bundle exec run-loop simctl manage-processes
     # Caller is responsible for the following:
     #
     # 1. Launching the simulator.
-    # 2. Installing the application,
+    # 2. Installing the application.
     #
     # No checks are made.
     #
@@ -249,6 +249,50 @@ $ bundle exec run-loop simctl manage-processes
       if exit_status != 0
         raise RuntimeError,
 %Q[Could not launch app on simulator:
+
+  command: xcrun #{cmd.join(" ")}
+simulator: #{device}
+      app: #{app}
+
+#{hash[:out]}
+
+This usually means your CoreSimulator processes need to be restarted.
+
+You can restart the CoreSimulator processes with this command:
+
+$ bundle exec run-loop simctl manage-processes
+
+]
+      end
+      true
+    end
+
+    # @!visibility private
+    #
+    # Launches the app on on the device.
+    #
+    # Caller is responsible for the following:
+    #
+    # 1. Launching the simulator.
+    # 2. That the application is installed; simctl uninstall will fail if app
+    #    is installed.
+    #
+    # No checks are made.
+    #
+    # @param [RunLoop::Device] device The simulator to launch on.
+    # @param [RunLoop::App] app The app to launch.
+    # @param [Numeric] timeout How long to wait for simctl to complete.
+    def uninstall(device, app, timeout)
+      cmd = ["simctl", "uninstall", device.udid, app.bundle_identifier]
+      options = DEFAULTS.dup
+      options[:timeout] = timeout
+
+      hash = execute(cmd, options)
+
+      exit_status = hash[:exit_status]
+      if exit_status != 0
+        raise RuntimeError,
+%Q[Could not uninstall app from simulator:
 
   command: xcrun #{cmd.join(" ")}
 simulator: #{device}

--- a/lib/run_loop/simctl.rb
+++ b/lib/run_loop/simctl.rb
@@ -15,7 +15,7 @@ module RunLoop
     # @!visibility private
     SIMCTL_PLIST_DIR = lambda {
       dirname  = File.dirname(__FILE__)
-      joined = File.join(dirname, '..', '..', 'plists', 'simctl')
+      joined = File.join(dirname, "..", "..", "plists", "simctl")
       File.expand_path(joined)
     }.call
 

--- a/lib/run_loop/simctl.rb
+++ b/lib/run_loop/simctl.rb
@@ -138,13 +138,17 @@ module RunLoop
 
         exit_status = hash[:exit_status]
         if exit_status != 0
-          raise RuntimeError,
-                %Q[Could not shutdown the simulator:
+
+          if simulator_state_as_int(device) == SIM_STATES["Shutdown"]
+            RunLoop.log_debug("simctl shutdown called when state is 'Shutdown'; ignoring error")
+          else
+            raise RuntimeError,
+                  %Q[Could not shutdown the simulator:
 
   command: xcrun #{cmd.join(" ")}
 simulator: #{device}
 
-                #{hash[:out]}
+                  #{hash[:out]}
 
 This usually means your CoreSimulator processes need to be restarted.
 
@@ -153,6 +157,7 @@ You can restart the CoreSimulator processes with this command:
 $ bundle exec run-loop simctl manage-processes
 
 ]
+          end
         end
         true
       end

--- a/lib/run_loop/simctl.rb
+++ b/lib/run_loop/simctl.rb
@@ -313,6 +313,48 @@ $ bundle exec run-loop simctl manage-processes
 
     # @!visibility private
     #
+    # Launches the app on on the device.
+    #
+    # Caller is responsible for the following:
+    #
+    # 1. Launching the simulator.
+    #
+    # No checks are made.
+    #
+    # @param [RunLoop::Device] device The simulator to launch on.
+    # @param [RunLoop::App] app The app to launch.
+    # @param [Numeric] timeout How long to wait for simctl to complete.
+    def install(device, app, timeout)
+      cmd = ["simctl", "install", device.udid, app.path]
+      options = DEFAULTS.dup
+      options[:timeout] = timeout
+
+      hash = execute(cmd, options)
+
+      exit_status = hash[:exit_status]
+      if exit_status != 0
+        raise RuntimeError,
+%Q[Could not install app on simulator:
+
+  command: xcrun #{cmd.join(" ")}
+simulator: #{device}
+      app: #{app}
+
+#{hash[:out]}
+
+This usually means your CoreSimulator processes need to be restarted.
+
+You can restart the CoreSimulator processes with this command:
+
+$ bundle exec run-loop simctl manage-processes
+
+]
+      end
+      true
+    end
+
+    # @!visibility private
+    #
     # SimControl compatibility
     def ensure_accessibility(device)
       sim_control.ensure_accessibility(device)

--- a/lib/run_loop/simctl.rb
+++ b/lib/run_loop/simctl.rb
@@ -117,14 +117,19 @@ module RunLoop
     end
 
     # @!visibility private
-    def simulator_state(device)
+    def simulator_state_as_int(device)
       plist = device.simulator_device_plist
       pbuddy.plist_read("state", plist).to_i
     end
 
     # @!visibility private
+    def simulator_state_as_string(device)
+      string_for_sim_state(simulator_state_as_int(device))
+    end
+
+    # @!visibility private
     def shutdown(device)
-      if simulator_state(device) == SIM_STATES["Shutdown"]
+      if simulator_state_as_int(device) == SIM_STATES["Shutdown"]
         RunLoop.log_debug("Simulator is already shutdown")
         true
       else
@@ -168,7 +173,7 @@ $ bundle exec run-loop simctl manage-processes
       state = nil
 
       while Time.now < poll_until
-        state = simulator_state(device)
+        state = simulator_state_as_int(device)
         in_state = state == SIM_STATES["Shutdown"]
         break if in_state
         sleep delay if delay != 0
@@ -191,7 +196,7 @@ $ bundle exec run-loop simctl manage-processes
     # @param [Numeric] wait_timeout How long to wait for the simulator to have
     #  state "Shutdown"; passed to #wait_for_shutdown.
     # @param [Numeric] wait_delay How long to wait between calls to
-    #  #simulator_state while waiting for the simulator have to state "Shutdown";
+    #  #simulator_state_as_int while waiting for the simulator have to state "Shutdown";
     #  passed to #wait_for_shutdown
     def erase(device, wait_timeout, wait_delay)
       require "run_loop/core_simulator"

--- a/spec/integration/core_simulator_spec.rb
+++ b/spec/integration/core_simulator_spec.rb
@@ -73,7 +73,7 @@ describe RunLoop::CoreSimulator do
 
   describe "#launch" do
     before do
-      args = ['simctl', 'erase', simulator.udid]
+      args = ["simctl", 'erase', simulator.udid]
       xcrun.run_command_in_context(args, {:log_cmd => true })
     end
 
@@ -102,7 +102,7 @@ describe RunLoop::CoreSimulator do
   end
 
   it 'install with simctl' do
-    args = ['simctl', 'erase', simulator.udid]
+    args = ["simctl", 'erase', simulator.udid]
     xcrun.run_command_in_context(args, {:log_cmd => true })
 
     expect(core_sim.install)

--- a/spec/integration/core_simulator_spec.rb
+++ b/spec/integration/core_simulator_spec.rb
@@ -103,11 +103,9 @@ describe RunLoop::CoreSimulator do
   end
 
   it 'install with simctl' do
-    args = ["simctl", 'erase', simulator.udid]
-    xcrun.run_command_in_context(args, {:log_cmd => true })
-
-    expect(core_sim.install)
-    expect(core_sim.launch)
+    RunLoop::CoreSimulator.erase(simulator)
+    expect(core_sim.install).to be_truthy
+    expect(core_sim.launch).to be_truthy
   end
 
   it 'uninstall app and sandbox with simctl' do

--- a/spec/integration/core_simulator_spec.rb
+++ b/spec/integration/core_simulator_spec.rb
@@ -73,8 +73,7 @@ describe RunLoop::CoreSimulator do
 
   describe "#launch" do
     before do
-      args = ["simctl", 'erase', simulator.udid]
-      xcrun.run_command_in_context(args, {:log_cmd => true })
+      Resources.shared.simctl.erase(simulator)
     end
 
     it "launches the app" do
@@ -95,7 +94,9 @@ describe RunLoop::CoreSimulator do
   end
 
   it "retries app launching" do
-    expect(core_sim).to receive(:launch_app_with_simctl).exactly(3).times.and_raise(RunLoop::Xcrun::TimeoutError)
+    tries = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:app_launch_retries] - 1
+    error = RunLoop::Xcrun::TimeoutError.new("Xcrun timed out")
+    expect(core_sim).to receive(:launch_app_with_simctl).exactly(tries).times.and_raise(error)
     expect(core_sim).to receive(:launch_app_with_simctl).and_call_original
 
     expect(core_sim.launch).to be == true

--- a/spec/integration/core_simulator_spec.rb
+++ b/spec/integration/core_simulator_spec.rb
@@ -73,7 +73,8 @@ describe RunLoop::CoreSimulator do
 
   describe "#launch" do
     before do
-      Resources.shared.simctl.erase(simulator)
+      opts = RunLoop::CoreSimulator::DEFAULT_OPTIONS
+      Resources.shared.simctl.erase(simulator, opts[:launch_app_timeout], opts[:wait_for_state_timeout])
     end
 
     it "launches the app" do

--- a/spec/integration/core_simulator_spec.rb
+++ b/spec/integration/core_simulator_spec.rb
@@ -24,12 +24,15 @@ describe RunLoop::CoreSimulator do
       core_sim.launch_simulator
 
       expect(RunLoop::CoreSimulator.erase(simulator)).to be_truthy
+      plist = simulator.simulator_device_plist
+      expect(File.exist?(plist)).to be_truthy
     end
 
     it "can shutdown and erase a simulator" do
       expect(RunLoop::CoreSimulator.erase(simulator)).to be_truthy
+      plist = simulator.simulator_device_plist
+      expect(File.exist?(plist)).to be_truthy
     end
-
   end
 
   describe '#launch_simulator' do

--- a/spec/integration/core_spec.rb
+++ b/spec/integration/core_spec.rb
@@ -21,62 +21,6 @@ describe RunLoop::Core do
     end
   end
 
-  describe '.simulator_target?' do
-    if Resources.shared.core_simulator_env?
-      describe "named simulator" do
-
-        after(:each) do
-          pid = fork do
-            local_simctl = Resources.shared.simctl
-            simulators = local_simctl.simulators
-            simulators.each do |device|
-              if device.name == 'rspec-test-device'
-                udid = device.udid
-                `xcrun simctl delete #{udid}`
-                exit!
-              end
-            end
-          end
-          sleep(1)
-          Process.kill('QUIT', pid)
-        end
-
-        it ":device_target => 'rspec-test-device'" do
-          xcode = Resources.shared.xcode
-          if xcode.version < xcode.v64
-            Luffa.log_warn("Skipping test: Xcode < 6.4 detected (#{version.to_s}")
-          else
-
-            device_type_id = 'iPhone 5s'
-
-            if xcode.version_gte_8?
-              runtime_id = 'com.apple.CoreSimulator.SimRuntime.iOS-10-0'
-            elsif xcode.version_gte_73?
-              runtime_id = 'com.apple.CoreSimulator.SimRuntime.iOS-9-3'
-            elsif xcode.version_gte_72?
-              runtime_id = 'com.apple.CoreSimulator.SimRuntime.iOS-9-2'
-            elsif xcode.version_gte_71?
-              runtime_id = 'com.apple.CoreSimulator.SimRuntime.iOS-9-1'
-            elsif xcode.version_gte_7?
-              runtime_id = 'com.apple.CoreSimulator.SimRuntime.iOS-9-0'
-            else
-              runtime_id = 'com.apple.CoreSimulator.SimRuntime.iOS-8-4'
-            end
-          end
-
-          cmd = "xcrun simctl create rspec-test-device \"#{device_type_id}\" \"#{runtime_id}\""
-          udid = `#{cmd}`.strip
-          sleep 2
-          exit_code = $?.exitstatus
-          expect(udid).to_not be == nil
-          expect(exit_code).to be == 0
-          options = { :device_target => 'rspec-test-device' }
-          expect(RunLoop::Core.simulator_target?(options)).to be == true
-        end
-      end
-    end
-  end
-
   describe '.default_tracetemplate' do
     describe 'returns a template for' do
       xcode = Resources.shared.xcode

--- a/spec/integration/simctl_spec.rb
+++ b/spec/integration/simctl_spec.rb
@@ -4,6 +4,12 @@ describe RunLoop::Simctl do
   let(:simctl) { Resources.shared.simctl }
   let(:sim_control) { Resources.shared.sim_control }
   let(:device) { Resources.shared.simctl.simulators.sample }
+  let(:app) { RunLoop::App.new(Resources.shared.cal_app_bundle_path) }
+  let(:core_sim) { RunLoop::CoreSimulator.new(device, app) }
+
+  before do
+    allow(RunLoop::Environment).to receive(:debug?).and_return(true)
+  end
 
   it "SimControl and Simctl return same simulators" do
     from_sim_control = sim_control.simulators
@@ -22,11 +28,29 @@ describe RunLoop::Simctl do
     expect(simctl.wait_for_shutdown(device, 0.1, 0)).to be_truthy
   end
 
-  it "#erase" do
+  it "handles the app life cycle" do
     timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:wait_for_state_timeout]
     delay = RunLoop::CoreSimulator::WAIT_FOR_SIMULATOR_STATE_INTERVAL
     expect(simctl.erase(device, timeout, delay)).to be_truthy
-  end
 
-  it "#launch"
+    device.simulator_wait_for_stable_state
+
+    core_sim.launch_simulator
+
+    timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:install_app_timeout]
+    expect(simctl.install(device, app, timeout)).to be_truthy
+    options = { :timeout => 10, :raise_on_timeout => true }
+    device.simulator_wait_for_stable_state
+
+    timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:launch_app_timeout]
+    expect(simctl.launch(device, app, timeout)).to be_truthy
+    RunLoop::ProcessWaiter.new(app.executable_name, options).wait_for_any
+    device.simulator_wait_for_stable_state
+
+    timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:uninstall_app_timeout]
+    expect(simctl.uninstall(device, app, timeout)).to be_truthy
+    device.simulator_wait_for_stable_state
+
+    RunLoop::CoreSimulator.quit_simulator
+  end
 end

--- a/spec/integration/simctl_spec.rb
+++ b/spec/integration/simctl_spec.rb
@@ -27,4 +27,6 @@ describe RunLoop::Simctl do
     delay = RunLoop::CoreSimulator::WAIT_FOR_SIMULATOR_STATE_INTERVAL
     expect(simctl.erase(device, timeout, delay)).to be_truthy
   end
+
+  it "#launch"
 end

--- a/spec/integration/simctl_spec.rb
+++ b/spec/integration/simctl_spec.rb
@@ -21,4 +21,10 @@ describe RunLoop::Simctl do
   it "#wait_for_shutdown" do
     expect(simctl.wait_for_shutdown(device, 0.1, 0)).to be_truthy
   end
+
+  it "#erase" do
+    timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:wait_for_state_timeout]
+    delay = RunLoop::CoreSimulator::WAIT_FOR_SIMULATOR_STATE_INTERVAL
+    expect(simctl.erase(device, timeout, delay)).to be_truthy
+  end
 end

--- a/spec/integration/simctl_spec.rb
+++ b/spec/integration/simctl_spec.rb
@@ -3,6 +3,7 @@ describe RunLoop::Simctl do
 
   let(:simctl) { Resources.shared.simctl }
   let(:sim_control) { Resources.shared.sim_control }
+  let(:device) { Resources.shared.simctl.simulators.sample }
 
   it "SimControl and Simctl return same simulators" do
     from_sim_control = sim_control.simulators
@@ -11,5 +12,13 @@ describe RunLoop::Simctl do
     # Devices are not object-equal with ==, so the best we can do here is
     # check the simulator count.
     expect(from_sim_control.count).to be == from_simctl.count
+  end
+
+  it "#shutdown" do
+    expect(simctl.shutdown(device)).to be_truthy
+  end
+
+  it "#wait_for_shutdown" do
+    expect(simctl.wait_for_shutdown(device, 0.1, 0)).to be_truthy
   end
 end

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -32,91 +32,15 @@ describe RunLoop::CoreSimulator do
   end
 
   describe ".erase" do
-      let(:xcrun) { RunLoop::Xcrun.new }
+    let(:simctl) { Resources.shared.simctl }
+    let(:options) { { :simctl => simctl, :timeout => 100 } }
+    let(:device) { RunLoop::Device.new("name", "8.1", "udid") }
+    let(:delay) { RunLoop::CoreSimulator::WAIT_FOR_SIMULATOR_STATE_INTERVAL }
 
-      let(:options) do
-        {
-          :xcrun => xcrun,
-          :timeout => 100
-        }
-      end
-
-      let(:device) { RunLoop::Device.new("name", "8.1", "udid") }
-
-      let(:erase_args) do
-        [
-          ["simctl", "erase", "udid"],
-          {
-            :log_cmd => true,
-            :timeout => 100
-          }
-        ]
-      end
-
-      let(:shutdown_args) do
-        [
-          ["simctl", "shutdown", "udid"],
-          {
-            :log_cmd => true,
-            :timeout => 100
-          }
-        ]
-      end
-
-      let(:erase_hash) do
-        {
-          :out => "",
-          :exit_status => 0
-        }
-      end
-
-    before do
-      allow(RunLoop::CoreSimulator).to receive(:quit_simulator).and_return true
-    end
-
-    it "raises an error if simulator argument is a physical device" do
-      # Device#to_s calls physical_device?
-      expect(device).to receive(:physical_device?).twice.and_return true
-
-      expect do
-        RunLoop::CoreSimulator.erase(device, options)
-      end.to raise_error(ArgumentError, /is a physical device/)
-    end
-
-    it "calls erase if sim is shutdown" do
-      expect(device).to receive(:update_simulator_state).and_return "Shutdown"
-      expect(xcrun).to receive(:run_command_in_context).with(*erase_args).and_return(erase_hash)
+    it "calls simctl erase with merged options" do
+      expect(simctl).to receive(:erase).with(device, 100, delay).and_return(true)
 
       expect(RunLoop::CoreSimulator.erase(device, options)).to be_truthy
-    end
-
-    it "waits for sim to shutdown" do
-      expect(device).to receive(:update_simulator_state).once.and_return("Unknown")
-      expect(xcrun).to receive(:run_command_in_context).with(*shutdown_args).and_return true
-      expect(RunLoop::CoreSimulator).to receive(:wait_for_simulator_state).and_return true
-      expect(xcrun).to receive(:run_command_in_context).with(*erase_args).and_return(erase_hash)
-
-      expect(RunLoop::CoreSimulator.erase(device, options)).to be_truthy
-    end
-
-    it "raises error if device cannot be shutdown" do
-      expect(device).to receive(:update_simulator_state).once.and_return("Unknown")
-      expect(xcrun).to receive(:run_command_in_context).with(*shutdown_args).and_return true
-      expect(RunLoop::CoreSimulator).to receive(:wait_for_simulator_state).and_raise RuntimeError, "Not shutdown"
-
-      expect do
-        RunLoop::CoreSimulator.erase(device, options)
-      end.to raise_error RuntimeError, /Could not erase simulator because it could not be Shutdown/
-    end
-
-    it "raises error if device cannot be erased" do
-      expect(device).to receive(:update_simulator_state).and_return "Shutdown"
-      hash = {:exit_status => 1, :out => "Simulator domain error"}
-      expect(xcrun).to receive(:run_command_in_context).with(*erase_args).and_return(hash)
-
-      expect do
-        RunLoop::CoreSimulator.erase(device, options)
-      end.to raise_error RuntimeError, /Simulator domain error/
     end
   end
 

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -240,12 +240,9 @@ describe RunLoop::CoreSimulator do
       it 'launches the simulator and installs the app with simctl' do
         expect(core_sim).to receive(:app_is_installed?).and_return true
         expect(core_sim).to receive(:launch_simulator).and_return true
-        args = ["simctl", 'uninstall', device.udid, app.bundle_identifier]
 
         timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:uninstall_app_timeout]
-        options = { log_cmd: true, timeout: timeout }
-        expect(core_sim.xcrun).to receive(:run_command_in_context).with(args, options).and_return true
-
+        expect(core_sim.simctl).to receive(:uninstall).with(device, app, timeout).and_return(true)
         expect(core_sim.device).to receive(:simulator_wait_for_stable_state).and_return true
 
         expect(core_sim.uninstall_app_and_sandbox).to be_truthy

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -214,6 +214,13 @@ describe RunLoop::CoreSimulator do
         expect(core_sim.xcrun).to be == xcrun
         expect(core_sim.instance_variable_get(:@xcrun)).to be == xcrun
       end
+
+      it "#simctl" do
+        simctl = core_sim.simctl
+        expect(simctl).to be_a_kind_of(RunLoop::Simctl)
+        expect(core_sim.simctl).to be == simctl
+        expect(core_sim.instance_variable_get(:@simctl)).to be == simctl
+      end
     end
 
     let(:app) { RunLoop::App.new(Resources.shared.cal_app_bundle_path) }
@@ -733,113 +740,106 @@ describe RunLoop::CoreSimulator do
     end
 
     it "#launch_app_with_simctl" do
-      args = ["simctl", "launch", device.udid, app.bundle_identifier]
       timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:launch_app_timeout]
-      options = { :log_cmd => true, :timeout => timeout }
-      expect(core_sim.xcrun).to receive(:run_command_in_context).with(args, options).and_return({})
+      expect(core_sim.simctl).to receive(:launch).with(device, app, timeout).and_return(true)
 
-      expect(core_sim.send(:launch_app_with_simctl)).to be == {}
+      expect(core_sim.send(:launch_app_with_simctl)).to be == true
     end
 
-    it "#handle_failed_app_launch" do
-      hash = {
-        :out => "The error output",
-        :exit_status => 1
-      }
+    describe "#try_to_launch_app" do
+      it "returns true if simctl did not raise a Timeout or Runtime error" do
+        expect(core_sim).to receive(:launch_app_with_simctl).and_return(true)
 
-      actual = core_sim.send(:handle_failed_app_launch, hash, 2, 5, 0)
-      expect(actual).to be == hash[:out]
-    end
-
-    describe "#attempt_to_launch_with_simctl" do
-      let(:error) { RunLoop::Xcrun::TimeoutError.new("My timeout") }
-      let (:hash) do
-        {
-          :exit_status => 1,
-          :out => error.message
-        }
+        actual = core_sim.send(:try_to_launch_app)
+        expect(actual).to be == nil
       end
 
-      it "successful launch" do
-        hash[:exit_status] = 0
-        hash[:out] = nil
-        expect(core_sim).to receive(:launch_app_with_simctl).and_return(hash)
+      context "retries launch after restarting the simulator" do
+        let(:timeout_error) { RunLoop::Xcrun::TimeoutError.new("Timeout") }
+        let(:runtime_error) { RuntimeError.new("Runtime") }
 
-        actual = core_sim.send(:attempt_to_launch_app_with_simctl)
-        expect(actual).to be == hash
+        before do
+          expect(RunLoop::CoreSimulator).to receive(:terminate_core_simulator_processes).and_return(true)
+          expect(core_sim).to receive(:launch_simulator).and_return(true)
+          expect(Kernel).to receive(:sleep).with(0.5).and_return(true)
+        end
+        it "returns the error if simctl timed out and restarts the simulator" do
+          expect(core_sim).to receive(:launch_app_with_simctl).and_raise(timeout_error)
+
+          actual = core_sim.send(:try_to_launch_app)
+          expect(actual).to be == timeout_error
+        end
+
+        it "returns the error if simctl failed and restarts the simulator" do
+          expect(core_sim).to receive(:launch_app_with_simctl).and_raise(runtime_error)
+
+          actual = core_sim.send(:try_to_launch_app)
+          expect(actual).to be == runtime_error
+        end
       end
 
-      it "timeout error" do
-        expect(core_sim).to receive(:launch_app_with_simctl).and_raise(error)
-        expect(RunLoop::CoreSimulator).to receive(:terminate_core_simulator_processes).and_return(true)
-        expect(core_sim).to receive(:launch_simulator).and_return(true)
-        expect(Kernel).to receive(:sleep).with(0.5).and_return(true)
-
-        actual = core_sim.send(:attempt_to_launch_app_with_simctl)
-        expect(actual).to be == hash
-      end
-
-      it "any other error" do
-        expect(core_sim).to receive(:launch_app_with_simctl).and_raise(RuntimeError)
+      it "only rescues Runtime and TimeOut errors" do
+        expect(core_sim).to receive(:launch_app_with_simctl).and_raise(ArgumentError)
 
         expect do
-          core_sim.send(:attempt_to_launch_app_with_simctl)
-        end.to raise_error RuntimeError
+          core_sim.send(:try_to_launch_app)
+        end.to raise_error ArgumentError
       end
     end
 
-    describe "#launch" do
-      let(:tries) { 3 }
+    context ".try_to_launch_app_n_times" do
+      let(:error) { RuntimeError.new("Error for testing") }
+      let(:last_error) { RuntimeError.new("Last error") }
 
+      it "returns true if simctl launch succeeded" do
+        expect(core_sim).to receive(:try_to_launch_app).and_return(nil)
+
+        expect(core_sim.send(:try_to_launch_app_n_times, 1)).to be == nil
+      end
+
+      it "tries N times to launch" do
+        expect(core_sim).to receive(:try_to_launch_app).and_return(error, error, nil)
+
+        expect(core_sim.send(:try_to_launch_app_n_times, 3)).to be == nil
+      end
+
+      it "returns the last error if launch fails after N times" do
+        expect(core_sim).to receive(:try_to_launch_app).and_return(error, error, last_error)
+
+        expect(core_sim.send(:try_to_launch_app_n_times, 3)).to be == last_error
+      end
+    end
+
+    context "#app_launch_retries" do
+      it "returns the value of :app_launch_retries from DEFAULT_OPTIONS" do
+        stub_const("RunLoop::CoreSimulator::DEFAULT_OPTIONS", {:app_launch_retries => 10})
+
+        expect(core_sim.send(:app_launch_retries)).to be == 10
+      end
+    end
+
+    context "#launch" do
       before do
         expect(core_sim).to receive(:install).and_return(true)
         expect(core_sim).to receive(:launch_simulator).and_return(true)
-        expect(RunLoop::Environment).to receive(:ci?).and_return(false)
       end
 
-      it "launches on the first try" do
-        hash = {
-          :out => nil,
-          :exit_status => 0
-        }
-        expect(core_sim).to receive(:attempt_to_launch_app_with_simctl).and_return(hash)
-        expect(core_sim).to receive(:wait_for_app_launch).and_return(:launched)
+      it "returns true if app launched after N times" do
+        tries = 10
+        expect(core_sim).to receive(:app_launch_retries).and_return(tries)
+        expect(core_sim).to receive(:try_to_launch_app_n_times).with(tries).and_return(nil)
+        expect(core_sim).to receive(:wait_for_app_launch).and_return(true)
 
-        expect(core_sim.launch).to be == :launched
+        expect(core_sim.launch).to be == true
       end
 
-      it "never launches" do
-        hash = {
-          :out => "My launch error",
-          :exit_status => 1
-        }
-
-        expect(core_sim).to receive(:attempt_to_launch_app_with_simctl).exactly(tries).times.and_return(hash)
-        expect(core_sim).to receive(:handle_failed_app_launch).exactly(tries).times.and_return(hash[:out])
+      it "raises last launch error if the app failed to launch" do
+        error = RuntimeError.new("Last error")
+        expect(core_sim).to receive(:try_to_launch_app_n_times).and_return(error)
 
         expect do
           core_sim.launch
-        end.to raise_error RuntimeError, /#{hash[:out]}/
-      end
-
-      it "launches after 2 tries" do
-        bad = {
-          :out => "My launch error",
-          :exit_status => 1
-        }
-
-        good = {
-          :out => nil,
-          :exit_status => 0
-        }
-
-        values = [bad, bad, good]
-
-        expect(core_sim).to receive(:attempt_to_launch_app_with_simctl).and_return(*values)
-        expect(core_sim).to receive(:handle_failed_app_launch).exactly(tries - 1).times.and_return(bad)
-        expect(core_sim).to receive(:wait_for_app_launch).and_return(:launched)
-
-        expect(core_sim.launch).to be == :launched
+        end.to raise_error RuntimeError, /Could not launch/
       end
     end
 

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -309,7 +309,7 @@ describe RunLoop::CoreSimulator do
       it 'launches the simulator and installs the app with simctl' do
         expect(core_sim).to receive(:app_is_installed?).and_return true
         expect(core_sim).to receive(:launch_simulator).and_return true
-        args = ['simctl', 'uninstall', device.udid, app.bundle_identifier]
+        args = ["simctl", 'uninstall', device.udid, app.bundle_identifier]
 
         timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:uninstall_app_timeout]
         options = { log_cmd: true, timeout: timeout }
@@ -795,7 +795,7 @@ describe RunLoop::CoreSimulator do
 
       it '#install_app_with_simctl' do
         expect(core_sim).to receive(:launch_simulator).and_return true
-        args = ['simctl', 'install', device.udid, app.path]
+        args = ["simctl", 'install', device.udid, app.path]
         timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:install_app_timeout]
         options = { :log_cmd => true, :timeout => timeout }
 

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -723,12 +723,9 @@ describe RunLoop::CoreSimulator do
 
       it '#install_app_with_simctl' do
         expect(core_sim).to receive(:launch_simulator).and_return true
-        args = ["simctl", 'install', device.udid, app.path]
         timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:install_app_timeout]
-        options = { :log_cmd => true, :timeout => timeout }
-
-        expect(core_sim.xcrun).to receive(:run_command_in_context).with(args, options).and_return({})
-        expect(core_sim.device).to receive(:simulator_wait_for_stable_state).and_return true
+        expect(core_sim.simctl).to receive(:install).with(device, app, timeout).and_return(true)
+        expect(core_sim.device).to receive(:simulator_wait_for_stable_state).and_return(true)
 
         expect(core_sim).to receive(:installed_app_bundle_dir).and_return('/new/path')
 

--- a/spec/lib/device_spec.rb
+++ b/spec/lib/device_spec.rb
@@ -42,7 +42,17 @@ describe RunLoop::Device do
         end
       end
     end
+
+    context "#simctl" do
+      it "is a memoized attr reader" do
+        simctl = device.send(:simctl)
+        expect(device.send(:simctl)).to be == simctl
+        expect(device.instance_variable_get(:@simctl)).to be == simctl
+        expect(simctl).to be_a_kind_of(RunLoop::Simctl)
+      end
+    end
   end
+
 
   describe '#to_s' do
     it 'physical device' do
@@ -507,65 +517,6 @@ describe RunLoop::Device do
                           'CE5BA25E-9434-475A-8947-ECC3918E64E3')
     end
 
-    describe '#discern_state_from_line' do
-
-      it 'unavailable' do
-        line = 'iPhone 5 (AC1509A2-9DE3-4BDD-9820-258BB7D5B41F) (Shutdown) (unavailable, runtime profile not found)'
-
-        expect(simulator.send(:detect_state_from_line, line)).to be == 'Unavailable'
-      end
-
-      it 'unknown state' do
-        line = 'some line'
-
-        expect(simulator.send(:detect_state_from_line, line)).to be == 'Unknown'
-      end
-
-      it 'booted' do
-        line = 'iPad Air 2 (43A6049E-AFD6-4D9D-8510-E129FBB3FE0F) (Booted)'
-
-        expect(simulator.send(:detect_state_from_line, line)).to be == 'Booted'
-      end
-
-      it 'shutdown' do
-        line = 'iPad Air 2 (43A6049E-AFD6-4D9D-8510-E129FBB3FE0F) (Shutdown)'
-
-        expect(simulator.send(:detect_state_from_line, line)).to be == 'Shutdown'
-      end
-    end
-
-    describe '#fetch_simulator_state' do
-      it 'raises an error if the device is not a simulator' do
-        expect(simulator).to receive(:physical_device?).and_return true
-
-        expect do
-          simulator.send(:fetch_simulator_state)
-        end.to raise_error RuntimeError, /This method is available only for simulators/
-      end
-
-      it 'raises an error if the udid matches no simulator' do
-        xcrun = RunLoop::Xcrun.new
-        args = ["simctl", 'list', 'devices']
-        expect(xcrun).to receive(:run_command_in_context).with(args).and_return({:out => ''})
-        expect(simulator).to receive(:xcrun).and_return xcrun
-
-        expect do
-          simulator.send(:fetch_simulator_state)
-        end.to raise_error RuntimeError, /Expected a simulator with udid/
-      end
-
-      it 'returns the state of the device' do
-        line = 'iPad Air 2 (CE5BA25E-9434-475A-8947-ECC3918E64E3) (Shutdown)'
-        hash = {:out => line}
-        xcrun = RunLoop::Xcrun.new
-        args = ["simctl", 'list', 'devices']
-        expect(xcrun).to receive(:run_command_in_context).with(args).and_return(hash)
-        expect(simulator).to receive(:xcrun).and_return xcrun
-
-        expect(simulator.send(:fetch_simulator_state)).to be == 'Shutdown'
-      end
-    end
-
     describe '#update_simulator_state' do
       it 'raises error if called on a physical device' do
         expect(simulator).to receive(:physical_device?).and_return true
@@ -576,7 +527,8 @@ describe RunLoop::Device do
       end
 
       it 'sets the simulator state' do
-        expect(simulator).to receive(:fetch_simulator_state).and_return 'State'
+        simctl = simulator.send(:simctl)
+        expect(simctl).to receive(:simulator_state_as_string).and_return 'State'
 
         expect(simulator.update_simulator_state).to be == 'State'
         expect(simulator.instance_variable_get(:@state)).to be == 'State'

--- a/spec/lib/device_spec.rb
+++ b/spec/lib/device_spec.rb
@@ -545,7 +545,7 @@ describe RunLoop::Device do
 
       it 'raises an error if the udid matches no simulator' do
         xcrun = RunLoop::Xcrun.new
-        args = ['simctl', 'list', 'devices']
+        args = ["simctl", 'list', 'devices']
         expect(xcrun).to receive(:run_command_in_context).with(args).and_return({:out => ''})
         expect(simulator).to receive(:xcrun).and_return xcrun
 
@@ -558,7 +558,7 @@ describe RunLoop::Device do
         line = 'iPad Air 2 (CE5BA25E-9434-475A-8947-ECC3918E64E3) (Shutdown)'
         hash = {:out => line}
         xcrun = RunLoop::Xcrun.new
-        args = ['simctl', 'list', 'devices']
+        args = ["simctl", 'list', 'devices']
         expect(xcrun).to receive(:run_command_in_context).with(args).and_return(hash)
         expect(simulator).to receive(:xcrun).and_return xcrun
 

--- a/spec/lib/shell_spec.rb
+++ b/spec/lib/shell_spec.rb
@@ -20,6 +20,15 @@ describe RunLoop::Shell do
     }
   end
 
+  context ".run_shell_command" do
+    it "creates an anonymous Shell instance and returns run_shell_command" do
+      args = ["echo", "Hello"]
+      actual = RunLoop::Shell.run_shell_command(args)
+      expect(actual[:exit_status]).to be == 0
+      expect(actual[:out]).to be == "Hello"
+    end
+  end
+
   describe "#run_shell_command" do
     it "raises an error if arg is not an Array" do
       expect do

--- a/spec/lib/sim_control_spec.rb
+++ b/spec/lib/sim_control_spec.rb
@@ -335,7 +335,7 @@ describe RunLoop::SimControl do
       end
 
       it ':devices' do
-        args = ['simctl', 'list', 'devices']
+        args = ["simctl", 'list', 'devices']
         expect(xcrun).to receive(:run_command_in_context).with(args).and_return(devices_out)
 
         actual = sim_control.send(:simctl_list, :devices)
@@ -361,7 +361,7 @@ describe RunLoop::SimControl do
       end
 
       it ':runtimes' do
-        args = ['simctl', 'list', 'runtimes']
+        args = ["simctl", 'list', 'runtimes']
         expect(xcrun).to receive(:run_command_in_context).with(args).and_return(runtimes_out)
 
         actual = sim_control.send(:simctl_list, :runtimes)

--- a/spec/lib/simctl_spec.rb
+++ b/spec/lib/simctl_spec.rb
@@ -254,6 +254,28 @@ describe RunLoop::Simctl do
       end
     end
 
+    context "#erase" do
+      let(:hash) { { :exit_status => 0, :out => "Some output" } }
+
+      before do
+        expect(RunLoop::CoreSimulator).to receive(:quit_simulator).and_return(true)
+        expect(simctl).to receive(:shutdown).with(device).and_return(true)
+        expect(simctl).to receive(:wait_for_shutdown).and_return(true)
+        expect(simctl).to receive(:execute).and_return(hash)
+      end
+
+      it "returns true if the simulator is erased" do
+        expect(simctl.erase(device, 10, 0.1)).to be_truthy
+      end
+
+      it "raises an error if there is a problem erasing the simulator" do
+        hash[:exit_status] = 1
+        expect do
+          simctl.erase(device, 10, 0.1)
+        end.to raise_error RuntimeError, /Could not erase the simulator/
+      end
+    end
+
     describe "#fetch_devices!" do
       let(:cmd) { ["simctl", "list", "devices", "--json"]  }
       let(:hash) do

--- a/spec/lib/simctl_spec.rb
+++ b/spec/lib/simctl_spec.rb
@@ -214,14 +214,14 @@ describe RunLoop::Simctl do
 
         expect(simctl.shutdown(device)).to be_truthy
       end
-      it "returns true after telling simctl to shutdown simulator" do
+      it "returns true if simctl shutdown completes with 0 exit status" do
         expect(simctl).to receive(:simulator_state).and_return(2)
         expect(simctl).to receive(:execute).and_return(hash)
 
         expect(simctl.shutdown(device)).to be_truthy
       end
 
-      it "raises an error if simctl exits non-zero" do
+      it "raises an error if simctl shutdown completes with non-zero exit status" do
         expect(simctl).to receive(:simulator_state).and_return(2)
         hash[:exit_status] = 1
         expect(simctl).to receive(:execute).and_return(hash)
@@ -266,11 +266,11 @@ describe RunLoop::Simctl do
         expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
       end
 
-      it "returns true if the simulator is erased" do
+      it "returns true if simctl erase completes with 0 exit status" do
         expect(simctl.erase(device, 10, 0.1)).to be_truthy
       end
 
-      it "raises an error if there is a problem erasing the simulator" do
+      it "raises an error if simctl erase completes with non-zero exit status" do
         hash[:exit_status] = 1
         expect do
           simctl.erase(device, 10, 0.1)
@@ -288,18 +288,41 @@ describe RunLoop::Simctl do
         options
       end
 
-      it "returns true after launching app on device" do
+      it "returns true if calling simctl launch completes with exit status 0" do
         expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
 
         expect(simctl.launch(device, app, 10))
       end
 
-      it "raises error if there was a problem with the launch" do
+      it "raises error if simctl launch completes with non-zero exit status" do
         hash[:exit_status] = 1
         expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
         expect do
           expect(simctl.launch(device, app, 10))
         end.to raise_error RuntimeError, /Could not launch app on simulator/
+      end
+    end
+
+    context "#uninstall" do
+      let(:hash) { { :exit_status => 0, :out => "Some output" } }
+      let(:app) { RunLoop::App.new(Resources.shared.app_bundle_path) }
+      let(:cmd) { ["simctl", "uninstall", device.udid, app.bundle_identifier] }
+      let(:options) do
+        options = RunLoop::Simctl::DEFAULTS.dup
+        options[:timeout] = 10
+        options
+      end
+      it "returns true if simctl uninstall completes with exit status 0" do
+        expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+
+        expect(simctl.uninstall(device, app, 10))
+      end
+      it "raises error if simctl uninstall completes with non-zero exit status" do
+        hash[:exit_status] = 1
+        expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+        expect do
+          expect(simctl.uninstall(device, app, 10))
+        end.to raise_error RuntimeError, /Could not uninstall app from simulator/
       end
     end
 

--- a/spec/lib/simctl_spec.rb
+++ b/spec/lib/simctl_spec.rb
@@ -1,7 +1,6 @@
 
 describe RunLoop::Simctl do
   let(:device) { Resources.shared.default_simulator }
-  let(:simctl) { RunLoop::Simctl.new }
   let(:xcrun) { RunLoop::Xcrun.new }
   let(:xcode) { Resources.shared.xcode }
   let(:sim_control) { Resources.shared.sim_control }
@@ -20,314 +19,377 @@ describe RunLoop::Simctl do
     expect(File.exist?(RunLoop::Simctl.uia_automation_plugin_plist)).to be_truthy
   end
 
+  context ".ensure_valid_core_simulator_service" do
+    let(:args) { ["xcrun", "simctl", "help"] }
+    let(:hash) { { } }
+    it "returns true if simctl help exits with 0" do
+      hash[:exit_status] = 0
+      expect(RunLoop::Shell).to receive(:run_shell_command).with(args).and_return(hash)
+
+      actual = RunLoop::Simctl.ensure_valid_core_simulator_service
+      expect(actual).to be == true
+    end
+
+    it "returns false if simctl help fails more than 3 times" do
+      hash[:exit_status] = 1
+      expect(RunLoop::Shell).to receive(:run_shell_command).with(args).exactly(3).times.and_return(hash)
+
+      actual = RunLoop::Simctl.ensure_valid_core_simulator_service
+      expect(actual).to be == false
+    end
+
+    it "returns true after rescuing Shell::Error 2 times" do
+      hash[:exit_status] = 0
+      expect(RunLoop::Shell).to receive(:run_shell_command).with(args).exactly(2).times.and_raise RunLoop::Shell::Error
+      expect(RunLoop::Shell).to receive(:run_shell_command).with(args).and_return(hash)
+
+      actual = RunLoop::Simctl.ensure_valid_core_simulator_service
+      expect(actual).to be == true
+    end
+
+    it "returns true after handling non-zero exit 2 times" do
+      fail_hash = {:exit_status => 1}
+      hash[:exit_status] = 0
+      expect(RunLoop::Shell).to receive(:run_shell_command).with(args).exactly(2).times.and_return(fail_hash)
+      expect(RunLoop::Shell).to receive(:run_shell_command).with(args).and_return(hash)
+
+      actual = RunLoop::Simctl.ensure_valid_core_simulator_service
+      expect(actual).to be == true
+    end
+
+    it "returns true after handling one Shell::Error and one non-zero exit" do
+      fail_hash = {:exit_status => 1}
+      hash[:exit_status] = 0
+      expect(RunLoop::Shell).to receive(:run_shell_command).with(args).and_raise RunLoop::Shell::Error
+      expect(RunLoop::Shell).to receive(:run_shell_command).with(args).times.and_return(fail_hash)
+      expect(RunLoop::Shell).to receive(:run_shell_command).with(args).and_return(hash)
+
+      actual = RunLoop::Simctl.ensure_valid_core_simulator_service
+      expect(actual).to be == true
+    end
+  end
+
   it ".new" do
+    expect(RunLoop::Simctl).to receive(:ensure_valid_core_simulator_service).and_return(true)
+
+    simctl = RunLoop::Simctl.new
+
     expect(simctl.instance_variable_get(:@ios_devices)).to be == []
     expect(simctl.instance_variable_get(:@tvos_devices)).to be == []
     expect(simctl.instance_variable_get(:@watchos_devices)).to be == []
   end
 
-  describe "Compatibility with SimControl" do
+  describe "instance methods" do
+
+    let(:simctl) { RunLoop::Simctl.new }
 
     before do
-      allow(simctl).to receive(:sim_control).and_return(sim_control)
+      allow(RunLoop::Simctl).to receive(:ensure_valid_core_simulator_service).and_return(true)
     end
 
-    it "#ensure_accessibility" do
-      expect(sim_control).to receive(:ensure_accessibility).with(device).and_return(:true)
+    describe "Compatibility with SimControl" do
 
-      expect(simctl.ensure_accessibility(device)).to be == :true
-    end
-
-    it "#ensure_software_keyboard" do
-      expect(sim_control).to receive(:ensure_software_keyboard).with(device).and_return(:true)
-
-      expect(simctl.ensure_software_keyboard(device)).to be == :true
-    end
-
-    it "#xcode is a public method" do
-      actual = simctl.xcode
-      expect(actual).to be_a_kind_of(RunLoop::Xcode)
-      expect(simctl.instance_variable_get(:@xcode)).to be == actual
-    end
-  end
-
-  describe "#simulators" do
-    it "ios_devices are empty" do
-      devices = {
-        :ios => ["a", "b", "c"],
-        :tvos => [],
-        :watchos => []
-      }
-      expect(simctl).to receive(:fetch_devices!).and_return(devices)
-      expect(simctl.simulators).to be == devices[:ios]
-    end
-
-    it "ios_devices are non-empty" do
-      simulators = ["a", "b", "c"]
-      expect(simctl).to receive(:ios_devices).and_return(simulators)
-
-      expect(simctl.simulators).to be == simulators
-    end
-  end
-
-  describe "#app_container" do
-
-    let(:bundle_id) { "sh.calaba.LPTestTarget" }
-    let(:cmd) { ["simctl", "get_app_container", device.udid, bundle_id]  }
-    let(:hash) do
-      {
-        :pid => 1,
-        :out => "path/to/My.app#{$-0}",
-        :exit_status => 0
-      }
-    end
-
-    before do
-      expect(simctl).to receive(:xcode).and_return(xcode)
-    end
-
-    describe "Xcode >= 7" do
       before do
-        expect(xcode).to receive(:version_gte_7?).and_return(true)
+        allow(simctl).to receive(:sim_control).and_return(sim_control)
       end
 
-      it "app is installed" do
-        expect(simctl).to receive(:execute).with(cmd, defaults).and_return(hash)
+      it "#ensure_accessibility" do
+        expect(sim_control).to receive(:ensure_accessibility).with(device).and_return(:true)
 
-        expect(simctl.app_container(device, bundle_id)).to be == hash[:out].strip
+        expect(simctl.ensure_accessibility(device)).to be == :true
       end
 
-      it "app is not installed" do
-        hash[:exit_status] = 1
-        expect(simctl).to receive(:execute).with(cmd, defaults).and_return(hash)
+      it "#ensure_software_keyboard" do
+        expect(sim_control).to receive(:ensure_software_keyboard).with(device).and_return(:true)
+
+        expect(simctl.ensure_software_keyboard(device)).to be == :true
+      end
+
+      it "#xcode is a public method" do
+        actual = simctl.xcode
+        expect(actual).to be_a_kind_of(RunLoop::Xcode)
+        expect(simctl.instance_variable_get(:@xcode)).to be == actual
+      end
+    end
+
+    describe "#simulators" do
+      it "ios_devices are empty" do
+        devices = {
+          :ios => ["a", "b", "c"],
+          :tvos => [],
+          :watchos => []
+        }
+        expect(simctl).to receive(:fetch_devices!).and_return(devices)
+        expect(simctl.simulators).to be == devices[:ios]
+      end
+
+      it "ios_devices are non-empty" do
+        simulators = ["a", "b", "c"]
+        expect(simctl).to receive(:ios_devices).and_return(simulators)
+
+        expect(simctl.simulators).to be == simulators
+      end
+    end
+
+    describe "#app_container" do
+
+      let(:bundle_id) { "sh.calaba.LPTestTarget" }
+      let(:cmd) { ["simctl", "get_app_container", device.udid, bundle_id]  }
+      let(:hash) do
+        {
+          :pid => 1,
+          :out => "path/to/My.app#{$-0}",
+          :exit_status => 0
+        }
+      end
+
+      before do
+        expect(simctl).to receive(:xcode).and_return(xcode)
+      end
+
+      describe "Xcode >= 7" do
+        before do
+          expect(xcode).to receive(:version_gte_7?).and_return(true)
+        end
+
+        it "app is installed" do
+          expect(simctl).to receive(:execute).with(cmd, defaults).and_return(hash)
+
+          expect(simctl.app_container(device, bundle_id)).to be == hash[:out].strip
+        end
+
+        it "app is not installed" do
+          hash[:exit_status] = 1
+          expect(simctl).to receive(:execute).with(cmd, defaults).and_return(hash)
+          expect(simctl.app_container(device, bundle_id)).to be == nil
+        end
+      end
+
+      it "Xcode < 7" do
+        expect(xcode).to receive(:version_gte_7?).and_return(false)
+
         expect(simctl.app_container(device, bundle_id)).to be == nil
       end
     end
 
-    it "Xcode < 7" do
-      expect(xcode).to receive(:version_gte_7?).and_return(false)
+    describe "#fetch_devices!" do
+      let(:cmd) { ["simctl", "list", "devices", "--json"]  }
+      let(:hash) do
+        {
+          :pid => 1,
+          :out => %Q[{ "key" : "value" }],
+          :exit_status => 0
+        }
+      end
+      let(:options) { RunLoop::Simctl::DEFAULTS }
 
-      expect(simctl.app_container(device, bundle_id)).to be == nil
-    end
-  end
-
-  describe "#fetch_devices!" do
-    let(:cmd) { ["simctl", "list", "devices", "--json"]  }
-    let(:hash) do
-      {
-        :pid => 1,
-        :out => %Q[{ "key" : "value" }],
-        :exit_status => 0
-      }
-    end
-    let(:options) { RunLoop::Simctl::DEFAULTS }
-
-    before do
-      allow(simctl).to receive(:xcode).and_return(xcode)
-    end
-
-    describe "Xcode >= 7" do
       before do
-        expect(xcode).to receive(:version_gte_7?).and_return(true)
+        allow(simctl).to receive(:xcode).and_return(xcode)
       end
 
-      it "non-zero exit status" do
-        hash[:exit_status] = 1
-        hash[:out] = "An error message"
-        expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+      describe "Xcode >= 7" do
+        before do
+          expect(xcode).to receive(:version_gte_7?).and_return(true)
+        end
 
+        it "non-zero exit status" do
+          hash[:exit_status] = 1
+          hash[:out] = "An error message"
+          expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+
+          expect do
+            simctl.send(:fetch_devices!)
+          end.to raise_error RuntimeError, /simctl exited 1/
+        end
+
+        it "returns a hash of iOS, tvOS, and watchOS devices" do
+          # Clears existing values
+          simctl.instance_variable_set(:@ios_devices, [:ios])
+          simctl.instance_variable_set(:@tvos_devices, [:tvos])
+          simctl.instance_variable_set(:@watchos_devices, [:watchos])
+
+          hash[:out] = RunLoop::RSpec::Simctl::SIMCTL_DEVICE_JSON_XCODE7
+          expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+
+          actual = simctl.send(:fetch_devices!)
+          expect(actual[:ios].include?(:ios)).to be_falsey
+          expect(actual[:tvos].include?(:tvos)).to be_falsey
+          expect(actual[:watchos].include?(:watchos)).to be_falsey
+
+          expect(actual[:ios].count).to be == 79
+          expect(actual[:tvos].count).to be == 3
+          expect(actual[:watchos].count).to be == 8
+        end
+      end
+
+      it "Xcode < 7" do
+        expect(xcode).to receive(:version_gte_7?).and_return(false)
+        expect(simctl).to receive(:sim_control).and_return(sim_control)
+        expect(sim_control).to receive(:simulators).and_return(["a", "b", "c"])
+
+        actual = simctl.send(:fetch_devices!)
+        expect(actual[:ios]).to be == ["a", "b", "c"]
+        expect(actual[:tvos]).to be == []
+        expect(actual[:watchos]).to be == []
+      end
+    end
+
+    it "#execute" do
+      options = {:a => :b}
+      merged = RunLoop::Simctl::DEFAULTS.merge(options)
+      cmd = ["simctl", "subcommand"]
+      expect(simctl).to receive(:xcrun).and_return(xcrun)
+      expect(xcrun).to receive(:run_command_in_context).with(cmd, merged).and_return({})
+
+      expect(simctl.send(:execute, cmd, options)).to be == {}
+    end
+
+    it "#xcrun" do
+      actual = simctl.send(:xcrun)
+      expect(actual).to be_a_kind_of(RunLoop::Xcrun)
+      expect(simctl.instance_variable_get(:@xcrun)).to be == actual
+    end
+
+    it "#sim_control" do
+      actual = simctl.send(:sim_control)
+      expect(actual).to be_a_kind_of(RunLoop::SimControl)
+      expect(simctl.instance_variable_get(:@sim_control)).to be == actual
+    end
+
+    describe "#json_to_hash" do
+      before do
+        expect(simctl).to receive(:filter_stderr).and_call_original
+      end
+      it "symbolizes keys" do
+        json = %Q[{ "key" : "value" }]
+        expected = { "key" => "value" }
+        expect(simctl.send(:json_to_hash, json)).to be == expected
+      end
+
+      it "raises error" do
         expect do
-          simctl.send(:fetch_devices!)
-        end.to raise_error RuntimeError, /simctl exited 1/
+          expect(simctl.send(:json_to_hash, ""))
+        end.to raise_error RuntimeError, /Could not parse simctl JSON response/
+      end
+    end
+
+    describe "categorizing and parsing device keys" do
+      let(:ios) { "iOS 9.1" }
+      let(:tvos) { "tvOS 9.0" }
+      let(:watchos) { "watchOS 2.1" }
+
+      it "#device_key_is_ios?" do
+        expect(simctl.send(:device_key_is_ios?, ios)).to be_truthy
+        expect(simctl.send(:device_key_is_ios?, tvos)).to be_falsey
+        expect(simctl.send(:device_key_is_ios?, watchos)).to be_falsey
       end
 
-      it "returns a hash of iOS, tvOS, and watchOS devices" do
-        # Clears existing values
+      it "#device_key_is_tvos?" do
+        expect(simctl.send(:device_key_is_tvos?, ios)).to be_falsey
+        expect(simctl.send(:device_key_is_tvos?, tvos)).to be_truthy
+        expect(simctl.send(:device_key_is_tvos?, watchos)).to be_falsey
+      end
+
+      it "#device_key_is_watchos?" do
+        expect(simctl.send(:device_key_is_watchos?, ios)).to be_falsey
+        expect(simctl.send(:device_key_is_watchos?, tvos)).to be_falsey
+        expect(simctl.send(:device_key_is_watchos?, watchos)).to be_truthy
+      end
+
+      it "#device_key_to_version" do
+        expect(simctl.send(:device_key_to_version, ios)).to be == RunLoop::Version.new("9.1")
+        expect(simctl.send(:device_key_to_version, tvos)).to be == RunLoop::Version.new("9.0")
+        expect(simctl.send(:device_key_to_version, watchos)).to be == RunLoop::Version.new("2.1")
+      end
+    end
+
+    describe "parsing device record" do
+      let(:record) do
+        {
+          "state" => "Shutdown",
+          "availability" => "(available)",
+          "name" => "iPhone 5s",
+          "udid" => "33E644E8-096B-4766-A957-4B34FB18DC48"
+        }
+      end
+      let(:version) { "9.1" }
+
+      it "#device_available?" do
+        expect(simctl.send(:device_available?, record)).to be_truthy
+
+        record["availability"] = "  (unavailable, device type profile not found)"
+        expect(simctl.send(:device_available?, record)).to be_falsey
+
+        record["availability"] =  " (unavailable, Mac OS X 10.11.4 is not supported)"
+        expect(simctl.send(:device_available?, record)).to be_falsey
+      end
+
+      it "#device_from_record" do
+        actual = simctl.send(:device_from_record, record, version)
+        expect(actual).to be_a_kind_of(RunLoop::Device)
+
+        expect(actual.version).to be == RunLoop::Version.new("9.1")
+        expect(actual.name).to be == record["name"]
+        expect(actual.udid).to be == record["udid"]
+        expect(actual.state).to be == record["state"]
+      end
+    end
+
+    describe "#bucket_for_key" do
+      let(:ios) { "iOS 9.1" }
+      let(:tvos) { "tvOS 9.0" }
+      let(:watchos) { "watchOS 2.1" }
+
+      before do
         simctl.instance_variable_set(:@ios_devices, [:ios])
         simctl.instance_variable_set(:@tvos_devices, [:tvos])
         simctl.instance_variable_set(:@watchos_devices, [:watchos])
+      end
 
-        hash[:out] = RunLoop::RSpec::Simctl::SIMCTL_DEVICE_JSON_XCODE7
-        expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+      it "ios" do
+        expect(simctl.send(:bucket_for_key, ios)).to be == [:ios]
+      end
 
-        actual = simctl.send(:fetch_devices!)
-        expect(actual[:ios].include?(:ios)).to be_falsey
-        expect(actual[:tvos].include?(:tvos)).to be_falsey
-        expect(actual[:watchos].include?(:watchos)).to be_falsey
+      it "tvos" do
+        expect(simctl.send(:bucket_for_key, tvos)).to be == [:tvos]
+      end
 
-        expect(actual[:ios].count).to be == 79
-        expect(actual[:tvos].count).to be == 3
-        expect(actual[:watchos].count).to be == 8
+      it "watchos" do
+        expect(simctl.send(:bucket_for_key, watchos)).to be == [:watchos]
+      end
+
+      it "unknown" do
+        expect do
+          simctl.send(:bucket_for_key, "unknown key")
+        end.to raise_error RuntimeError, /Unexpected key while processing simctl output/
       end
     end
 
-    it "Xcode < 7" do
-      expect(xcode).to receive(:version_gte_7?).and_return(false)
-      expect(simctl).to receive(:sim_control).and_return(sim_control)
-      expect(sim_control).to receive(:simulators).and_return(["a", "b", "c"])
+    describe "filtering stderr output from JSON" do
+      describe "#stderr_line?" do
+        it "CoreSimulatorService" do
+          line = "attempting to unload a stale CoreSimulatorService job"
+          expect(simctl.send(:stderr_line?, line)).to be_truthy
+        end
 
-      actual = simctl.send(:fetch_devices!)
-      expect(actual[:ios]).to be == ["a", "b", "c"]
-      expect(actual[:tvos]).to be == []
-      expect(actual[:watchos]).to be == []
-    end
-  end
-
-  it "#execute" do
-    options = {:a => :b}
-    merged = RunLoop::Simctl::DEFAULTS.merge(options)
-    cmd = ["simctl", "subcommand"]
-    expect(simctl).to receive(:xcrun).and_return(xcrun)
-    expect(xcrun).to receive(:run_command_in_context).with(cmd, merged).and_return({})
-
-    expect(simctl.send(:execute, cmd, options)).to be == {}
-  end
-
-  it "#xcrun" do
-    actual = simctl.send(:xcrun)
-    expect(actual).to be_a_kind_of(RunLoop::Xcrun)
-    expect(simctl.instance_variable_get(:@xcrun)).to be == actual
-  end
-
-  it "#sim_control" do
-    actual = simctl.send(:sim_control)
-    expect(actual).to be_a_kind_of(RunLoop::SimControl)
-    expect(simctl.instance_variable_get(:@sim_control)).to be == actual
-  end
-
-  describe "#json_to_hash" do
-    before do
-      expect(simctl).to receive(:filter_stderr).and_call_original
-    end
-    it "symbolizes keys" do
-      json = %Q[{ "key" : "value" }]
-      expected = { "key" => "value" }
-      expect(simctl.send(:json_to_hash, json)).to be == expected
-    end
-
-    it "raises error" do
-      expect do
-        expect(simctl.send(:json_to_hash, ""))
-      end.to raise_error RuntimeError, /Could not parse simctl JSON response/
-    end
-  end
-
-  describe "categorizing and parsing device keys" do
-    let(:ios) { "iOS 9.1" }
-    let(:tvos) { "tvOS 9.0" }
-    let(:watchos) { "watchOS 2.1" }
-
-    it "#device_key_is_ios?" do
-      expect(simctl.send(:device_key_is_ios?, ios)).to be_truthy
-      expect(simctl.send(:device_key_is_ios?, tvos)).to be_falsey
-      expect(simctl.send(:device_key_is_ios?, watchos)).to be_falsey
-    end
-
-    it "#device_key_is_tvos?" do
-      expect(simctl.send(:device_key_is_tvos?, ios)).to be_falsey
-      expect(simctl.send(:device_key_is_tvos?, tvos)).to be_truthy
-      expect(simctl.send(:device_key_is_tvos?, watchos)).to be_falsey
-    end
-
-    it "#device_key_is_watchos?" do
-      expect(simctl.send(:device_key_is_watchos?, ios)).to be_falsey
-      expect(simctl.send(:device_key_is_watchos?, tvos)).to be_falsey
-      expect(simctl.send(:device_key_is_watchos?, watchos)).to be_truthy
-    end
-
-    it "#device_key_to_version" do
-      expect(simctl.send(:device_key_to_version, ios)).to be == RunLoop::Version.new("9.1")
-      expect(simctl.send(:device_key_to_version, tvos)).to be == RunLoop::Version.new("9.0")
-      expect(simctl.send(:device_key_to_version, watchos)).to be == RunLoop::Version.new("2.1")
-    end
-  end
-
-  describe "parsing device record" do
-    let(:record) do
-      {
-        "state" => "Shutdown",
-        "availability" => "(available)",
-        "name" => "iPhone 5s",
-        "udid" => "33E644E8-096B-4766-A957-4B34FB18DC48"
-      }
-    end
-    let(:version) { "9.1" }
-
-    it "#device_available?" do
-      expect(simctl.send(:device_available?, record)).to be_truthy
-
-      record["availability"] = "  (unavailable, device type profile not found)"
-      expect(simctl.send(:device_available?, record)).to be_falsey
-
-      record["availability"] =  " (unavailable, Mac OS X 10.11.4 is not supported)"
-      expect(simctl.send(:device_available?, record)).to be_falsey
-    end
-
-    it "#device_from_record" do
-      actual = simctl.send(:device_from_record, record, version)
-      expect(actual).to be_a_kind_of(RunLoop::Device)
-
-      expect(actual.version).to be == RunLoop::Version.new("9.1")
-      expect(actual.name).to be == record["name"]
-      expect(actual.udid).to be == record["udid"]
-      expect(actual.state).to be == record["state"]
-    end
-  end
-
-  describe "#bucket_for_key" do
-    let(:ios) { "iOS 9.1" }
-    let(:tvos) { "tvOS 9.0" }
-    let(:watchos) { "watchOS 2.1" }
-
-    before do
-      simctl.instance_variable_set(:@ios_devices, [:ios])
-      simctl.instance_variable_set(:@tvos_devices, [:tvos])
-      simctl.instance_variable_set(:@watchos_devices, [:watchos])
-    end
-
-    it "ios" do
-      expect(simctl.send(:bucket_for_key, ios)).to be == [:ios]
-    end
-
-    it "tvos" do
-      expect(simctl.send(:bucket_for_key, tvos)).to be == [:tvos]
-    end
-
-    it "watchos" do
-      expect(simctl.send(:bucket_for_key, watchos)).to be == [:watchos]
-    end
-
-    it "unknown" do
-      expect do
-        simctl.send(:bucket_for_key, "unknown key")
-      end.to raise_error RuntimeError, /Unexpected key while processing simctl output/
-    end
-  end
-
-  describe "filtering stderr output from JSON" do
-    describe "#stderr_line?" do
-      it "CoreSimulatorService" do
-        line = "attempting to unload a stale CoreSimulatorService job"
-        expect(simctl.send(:stderr_line?, line)).to be_truthy
+        it "simctl[< pid info >]" do
+          line = "simctl[98400:32684208] blah blah"
+          expect(simctl.send(:stderr_line?, line)).to be_truthy
+        end
       end
 
-      it "simctl[< pid info >]" do
-        line = "simctl[98400:32684208] blah blah"
-        expect(simctl.send(:stderr_line?, line)).to be_truthy
-      end
-    end
-
-    it "#filter_stderr" do
-      lines =
+      it "#filter_stderr" do
+        lines =
 %q[good line
 attempting to unload a stale CoreSimulatorService job
 simctl[98400:32684208] blah blah
 another good line]
 
-      expected = %q[good line
+        expected = %q[good line
 another good line]
 
-      expect(simctl.send(:filter_stderr, lines)).to be == expected
+        expect(simctl.send(:filter_stderr, lines)).to be == expected
+      end
     end
   end
 end

--- a/spec/lib/simctl_spec.rb
+++ b/spec/lib/simctl_spec.rb
@@ -278,53 +278,69 @@ describe RunLoop::Simctl do
       end
     end
 
-    context "#launch" do
+    context "app lifecycle" do
       let(:hash) { { :exit_status => 0, :out => "Some output" } }
       let(:app) { RunLoop::App.new(Resources.shared.app_bundle_path) }
-      let(:cmd) { ["simctl", "launch", device.udid, app.bundle_identifier] }
       let(:options) do
         options = RunLoop::Simctl::DEFAULTS.dup
         options[:timeout] = 10
         options
       end
 
-      it "returns true if calling simctl launch completes with exit status 0" do
-        expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+      context "#launch" do
+        let(:cmd) { ["simctl", "launch", device.udid, app.bundle_identifier] }
 
-        expect(simctl.launch(device, app, 10))
-      end
+        it "returns true if calling simctl launch completes with exit status 0" do
+          expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
 
-      it "raises error if simctl launch completes with non-zero exit status" do
-        hash[:exit_status] = 1
-        expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
-        expect do
           expect(simctl.launch(device, app, 10))
-        end.to raise_error RuntimeError, /Could not launch app on simulator/
-      end
-    end
+        end
 
-    context "#uninstall" do
-      let(:hash) { { :exit_status => 0, :out => "Some output" } }
-      let(:app) { RunLoop::App.new(Resources.shared.app_bundle_path) }
-      let(:cmd) { ["simctl", "uninstall", device.udid, app.bundle_identifier] }
-      let(:options) do
-        options = RunLoop::Simctl::DEFAULTS.dup
-        options[:timeout] = 10
-        options
+        it "raises error if simctl launch completes with non-zero exit status" do
+          hash[:exit_status] = 1
+          expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+          expect do
+            expect(simctl.launch(device, app, 10))
+          end.to raise_error RuntimeError, /Could not launch app on simulator/
+        end
       end
-      it "returns true if simctl uninstall completes with exit status 0" do
-        expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
 
-        expect(simctl.uninstall(device, app, 10))
-      end
-      it "raises error if simctl uninstall completes with non-zero exit status" do
-        hash[:exit_status] = 1
-        expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
-        expect do
+      context "#uninstall" do
+        let(:cmd) { ["simctl", "uninstall", device.udid, app.bundle_identifier] }
+
+        it "returns true if simctl uninstall completes with exit status 0" do
+          expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+
           expect(simctl.uninstall(device, app, 10))
-        end.to raise_error RuntimeError, /Could not uninstall app from simulator/
+        end
+        it "raises error if simctl uninstall completes with non-zero exit status" do
+          hash[:exit_status] = 1
+          expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+          expect do
+            expect(simctl.uninstall(device, app, 10))
+          end.to raise_error RuntimeError, /Could not uninstall app from simulator/
+        end
+      end
+
+      context "#install" do
+        let(:cmd) { ["simctl", "install", device.udid, app.path] }
+
+        it "returns true if simctl install completes with exit status 0" do
+          expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+
+          expect(simctl.install(device, app, 10))
+        end
+
+        it "raises error if simctl install completes with non-zero exit status" do
+          hash[:exit_status] = 1
+          expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+          expect do
+            expect(simctl.install(device, app, 10))
+          end.to raise_error RuntimeError, /Could not install app on simulator/
+        end
       end
     end
+
 
     describe "#fetch_devices!" do
       let(:cmd) { ["simctl", "list", "devices", "--json"]  }

--- a/spec/lib/simctl_spec.rb
+++ b/spec/lib/simctl_spec.rb
@@ -157,14 +157,14 @@ describe RunLoop::Simctl do
         end
 
         it "app is installed" do
-          expect(simctl).to receive(:execute).with(cmd, defaults).and_return(hash)
+          expect(simctl).to receive(:shell_out_with_xcrun).with(cmd, defaults).and_return(hash)
 
           expect(simctl.app_container(device, bundle_id)).to be == hash[:out].strip
         end
 
         it "app is not installed" do
           hash[:exit_status] = 1
-          expect(simctl).to receive(:execute).with(cmd, defaults).and_return(hash)
+          expect(simctl).to receive(:shell_out_with_xcrun).with(cmd, defaults).and_return(hash)
           expect(simctl.app_container(device, bundle_id)).to be == nil
         end
       end
@@ -219,13 +219,13 @@ describe RunLoop::Simctl do
 
       it "returns true if the simulator is already shutdown" do
         expect(simctl).to receive(:simulator_state_as_int).and_return(1)
-        expect(simctl).not_to receive(:execute)
+        expect(simctl).not_to receive(:shell_out_with_xcrun)
 
         expect(simctl.shutdown(device)).to be_truthy
       end
       it "returns true if simctl shutdown completes with 0 exit status" do
         expect(simctl).to receive(:simulator_state_as_int).and_return(2)
-        expect(simctl).to receive(:execute).and_return(hash)
+        expect(simctl).to receive(:shell_out_with_xcrun).and_return(hash)
 
         expect(simctl.shutdown(device)).to be_truthy
       end
@@ -233,7 +233,7 @@ describe RunLoop::Simctl do
       it "raises an error if simctl shutdown completes with non-zero exit status" do
         expect(simctl).to receive(:simulator_state_as_int).and_return(2)
         hash[:exit_status] = 1
-        expect(simctl).to receive(:execute).and_return(hash)
+        expect(simctl).to receive(:shell_out_with_xcrun).and_return(hash)
 
         expect do
           simctl.shutdown(device)
@@ -272,7 +272,7 @@ describe RunLoop::Simctl do
         expect(RunLoop::CoreSimulator).to receive(:quit_simulator).and_return(true)
         expect(simctl).to receive(:shutdown).with(device).and_return(true)
         expect(simctl).to receive(:wait_for_shutdown).and_return(true)
-        expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+        expect(simctl).to receive(:shell_out_with_xcrun).with(cmd, options).and_return(hash)
       end
 
       it "returns true if simctl erase completes with 0 exit status" do
@@ -300,14 +300,14 @@ describe RunLoop::Simctl do
         let(:cmd) { ["simctl", "launch", device.udid, app.bundle_identifier] }
 
         it "returns true if calling simctl launch completes with exit status 0" do
-          expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+          expect(simctl).to receive(:shell_out_with_xcrun).with(cmd, options).and_return(hash)
 
           expect(simctl.launch(device, app, 10))
         end
 
         it "raises error if simctl launch completes with non-zero exit status" do
           hash[:exit_status] = 1
-          expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+          expect(simctl).to receive(:shell_out_with_xcrun).with(cmd, options).and_return(hash)
           expect do
             expect(simctl.launch(device, app, 10))
           end.to raise_error RuntimeError, /Could not launch app on simulator/
@@ -318,13 +318,13 @@ describe RunLoop::Simctl do
         let(:cmd) { ["simctl", "uninstall", device.udid, app.bundle_identifier] }
 
         it "returns true if simctl uninstall completes with exit status 0" do
-          expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+          expect(simctl).to receive(:shell_out_with_xcrun).with(cmd, options).and_return(hash)
 
           expect(simctl.uninstall(device, app, 10))
         end
         it "raises error if simctl uninstall completes with non-zero exit status" do
           hash[:exit_status] = 1
-          expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+          expect(simctl).to receive(:shell_out_with_xcrun).with(cmd, options).and_return(hash)
           expect do
             expect(simctl.uninstall(device, app, 10))
           end.to raise_error RuntimeError, /Could not uninstall app from simulator/
@@ -335,14 +335,14 @@ describe RunLoop::Simctl do
         let(:cmd) { ["simctl", "install", device.udid, app.path] }
 
         it "returns true if simctl install completes with exit status 0" do
-          expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+          expect(simctl).to receive(:shell_out_with_xcrun).with(cmd, options).and_return(hash)
 
           expect(simctl.install(device, app, 10))
         end
 
         it "raises error if simctl install completes with non-zero exit status" do
           hash[:exit_status] = 1
-          expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+          expect(simctl).to receive(:shell_out_with_xcrun).with(cmd, options).and_return(hash)
           expect do
             expect(simctl.install(device, app, 10))
           end.to raise_error RuntimeError, /Could not install app on simulator/
@@ -374,7 +374,7 @@ describe RunLoop::Simctl do
         it "non-zero exit status" do
           hash[:exit_status] = 1
           hash[:out] = "An error message"
-          expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+          expect(simctl).to receive(:shell_out_with_xcrun).with(cmd, options).and_return(hash)
 
           expect do
             simctl.send(:fetch_devices!)
@@ -388,7 +388,7 @@ describe RunLoop::Simctl do
           simctl.instance_variable_set(:@watchos_devices, [:watchos])
 
           hash[:out] = RunLoop::RSpec::Simctl::SIMCTL_DEVICE_JSON_XCODE7
-          expect(simctl).to receive(:execute).with(cmd, options).and_return(hash)
+          expect(simctl).to receive(:shell_out_with_xcrun).with(cmd, options).and_return(hash)
 
           actual = simctl.send(:fetch_devices!)
           expect(actual[:ios].include?(:ios)).to be_falsey
@@ -420,7 +420,7 @@ describe RunLoop::Simctl do
       expect(simctl).to receive(:xcrun).and_return(xcrun)
       expect(xcrun).to receive(:run_command_in_context).with(cmd, merged).and_return({})
 
-      expect(simctl.send(:execute, cmd, options)).to be == {}
+      expect(simctl.send(:shell_out_with_xcrun, cmd, options)).to be == {}
     end
 
     it "#xcrun" do

--- a/spec/resources.rb
+++ b/spec/resources.rb
@@ -146,62 +146,6 @@ class Resources
     target
   end
 
-  def self.shutdown_all_booted(options = {})
-    xcrun = RunLoop::Xcrun.new
-    return true if self.shutdown_with_simctl(xcrun) == :none
-
-    defaults = {
-          :timeout => 10,
-          :delay => 1
-    }
-
-    merged = defaults.merge(options)
-
-    timeout = merged[:timeout]
-    delay = merged[:delay]
-
-    now = Time.now
-    poll_until = now + timeout
-    counter = 1
-
-    done = false
-    while Time.now < poll_until
-      done = self.shutdown_with_simctl(xcrun) == :none
-      counter += 1
-      break if done
-      sleep delay
-    end
-
-    elapsed = Time.now - now
-    if done
-      RunLoop.log_debug("Shutdown #{counter} booted simulators in '#{elapsed}'")
-    else
-      RunLoop.log_debug("Timed out shutting down booted simulators; shutdown #{counter} in #{elapsed} seconds")
-    end
-
-    done
-  end
-
-  def self.shutdown_with_simctl(xcrun)
-    args = ["simctl", 'shutdown', 'booted']
-    hash = xcrun.exec(args, {:log_cmd => true })
-    out = hash[:out]
-    exit_status = hash[:exit_status]
-
-    if [# Typical output for Xcode >= 6
-          out == 'No devices are booted.',
-
-          # Xcode 6
-          exit_status == 145,
-
-          # Xcode 7
-          exit_status == 158].any?
-      :none
-    else
-      :shutdown
-    end
-  end
-
   def launch_with_options(options, tries=self.launch_retries, &block)
     hash = nil
 

--- a/spec/resources.rb
+++ b/spec/resources.rb
@@ -183,7 +183,7 @@ class Resources
   end
 
   def self.shutdown_with_simctl(xcrun)
-    args = ['simctl', 'shutdown', 'booted']
+    args = ["simctl", 'shutdown', 'booted']
     hash = xcrun.exec(args, {:log_cmd => true })
     out = hash[:out]
     exit_status = hash[:exit_status]
@@ -245,11 +245,11 @@ class Resources
     case sdk
       when :sdk8
         @mock_core_simulator_data_dir_sdk8 ||= lambda {
-          File.expand_path(File.join(resources_dir, 'simctl', 'sdk8', 'data'))
+          File.expand_path(File.join(resources_dir, "simctl", 'sdk8', 'data'))
         }.call
       when :sdk7
         @mock_core_simulator_data_dir_sdk7 ||= lambda {
-          File.expand_path(File.join(resources_dir, 'simctl', 'sdk-less-than-8', 'data'))
+          File.expand_path(File.join(resources_dir, "simctl", 'sdk-less-than-8', 'data'))
         }.call
       else
         raise "Expected sdk '#{sdk}' to be on of #{[:sdk8, :sdk7]}"


### PR DESCRIPTION
### Motivation

Resolves:

* calls to simctl need to guard against wrong CoreSimulator service loaded [JIRA](https://xamarin.atlassian.net/browse/TCFW-301)

Progress on:

* Complete simctl interface #293

This also brings us one step closer to being able to see if `fbsimctl` can be a replacement for `simctl`.

### Test

Joshua, I am particularly interested to see these two integration examples pass on your machine:

```
$ git fetch
$ git co -to origin/feature/add-guard-for-incompatible-CoreSimulator-service
$ bundle update

$ be rspec spec/integration/simctl_spec.rb
$ be rspec spec/integration/core_simulator_spec.rb
```
