### PR TITLE
Respond to Xcode 8 otool changes

### DIFF
--- a/lib/run_loop/app.rb
+++ b/lib/run_loop/app.rb
@@ -272,8 +272,6 @@ Bundle must:
     end
 
     # @!visibility private
-
-    # @!visibility private
     # A strings factory
     def strings(file)
       RunLoop::Strings.new(file)

--- a/lib/run_loop/app.rb
+++ b/lib/run_loop/app.rb
@@ -218,7 +218,7 @@ Bundle must:
       executables = []
       Dir.glob("#{path}/**/*") do |file|
         next if skip_executable_check?(file)
-        if otool(file).executable?
+        if otool.executable?(file)
           executables << file
         end
       end
@@ -262,10 +262,16 @@ Bundle must:
     end
 
     # @!visibility private
-    # An otool factory.
-    def otool(file)
-      RunLoop::Otool.new(file)
+    def otool
+      @otool ||= RunLoop::Otool.new(xcode)
     end
+
+    # @!visibility private
+    def xcode
+      @xcode ||= RunLoop::Xcode.new
+    end
+
+    # @!visibility private
 
     # @!visibility private
     # A strings factory

--- a/lib/run_loop/otool.rb
+++ b/lib/run_loop/otool.rb
@@ -5,26 +5,14 @@ module RunLoop
   class Otool
 
     # @!visibility private
-    attr_reader :path
-
-    # @!visibility private
-    def initialize(path)
-      @path = path
-
-      if !Otool.valid_path?(path)
-        raise ArgumentError,
-%Q{File:
-
-#{path}
-
-must exist and not be a directory.
-}
-      end
+    # @param [RunLoop::Xcode] xcode An instance of Xcode
+    def initialize(xcode)
+      @xcode = xcode
     end
 
     # @!visibility private
     def to_s
-      "#<OTOOL: #{path}>"
+      "#<OTOOL: Xcode #{xcode.version.to_s}>"
     end
 
     # @!visibility private
@@ -33,15 +21,19 @@ must exist and not be a directory.
     end
 
     # @!visibility private
-    def executable?
-      !arch_info[/is not an object file/, 0]
+    def executable?(path)
+      expect_valid_path!(path)
+      !arch_info(path)[/is not an object file/, 0]
     end
 
     private
 
     # @!visibility private
-    def arch_info
-      args = ["otool", "-hv", "-arch", "all", path]
+    attr_reader :xcode, :command_name
+
+    # @!visibility private
+    def arch_info(path)
+      args = [command_name, "-hv", "-arch", "all", path]
       opts = { :log_cmd => false }
 
       hash = xcrun.run_command_in_context(args, opts)
@@ -52,25 +44,49 @@ must exist and not be a directory.
 
 #{path}
 
-#{args.join(" ")}
+              #{args.join(" ")}
 
 exited #{hash[:exit_status]} with the following output:
 
 #{hash[:out]}
-}
+              }
       end
 
-      @arch_info = hash[:out]
+      hash[:out]
     end
 
     # @!visibility private
-    def self.valid_path?(path)
-      File.exist?(path) && !File.directory?(path)
+    def expect_valid_path!(path)
+      return true if File.exist?(path) && !File.directory?(path)
+      raise ArgumentError, %Q[
+File:
+
+#{path}
+
+must exist and not be a directory.
+
+]
     end
 
     # @!visibility private
     def xcrun
-      RunLoop::Xcrun.new
+      @xcrun ||= RunLoop::Xcrun.new
+    end
+
+    # @!visibility private
+    def xcode
+      @xcode
+    end
+
+    # @!visibility private
+    def command_name
+      @command_name ||= begin
+        if xcode.version_gte_8?
+          "otool-classic"
+        else
+          "otool"
+        end
+      end
     end
   end
 end

--- a/lib/run_loop/otool.rb
+++ b/lib/run_loop/otool.rb
@@ -44,12 +44,12 @@ module RunLoop
 
 #{path}
 
-              #{args.join(" ")}
+#{args.join(" ")}
 
 exited #{hash[:exit_status]} with the following output:
 
 #{hash[:out]}
-              }
+}
       end
 
       hash[:out]

--- a/spec/integration/otool_spec.rb
+++ b/spec/integration/otool_spec.rb
@@ -7,10 +7,33 @@ describe RunLoop::Otool do
   let(:info_plist) { app.info_plist_path }
   let(:dylib) { Resources.shared.sim_dylib_path }
 
-  it "#executable?" do
-    expect(RunLoop::Otool.new(executable).executable?).to be_truthy
-    expect(RunLoop::Otool.new(info_plist).executable?).to be_falsey
-    expect(RunLoop::Otool.new(dylib).executable?).to be_truthy
+  context "#executable?" do
+    it "works with the active Xcode" do
+      xcode = RunLoop::Xcode.new
+      expect(RunLoop::Otool.new(xcode).executable?(executable)).to be_truthy
+      expect(RunLoop::Otool.new(xcode).executable?(info_plist)).to be_falsey
+      expect(RunLoop::Otool.new(xcode).executable?(dylib)).to be_truthy
+    end
+
+    context "other Xcode versions" do
+      xcode_installs = Resources.shared.alt_xcode_details_hash
+      if xcode_installs.empty?
+        it 'no alternative versions of Xcode found' do
+          expect(true).to be == true
+        end
+      else
+        xcode_installs.each do |xcode_details|
+          it "#{xcode_details[:path]} - #{xcode_details[:version]}" do
+            Resources.shared.with_developer_dir(xcode_details[:path]) do
+              xcode = RunLoop::Xcode.new
+              expect(RunLoop::Otool.new(xcode).executable?(executable)).to be_truthy
+              expect(RunLoop::Otool.new(xcode).executable?(info_plist)).to be_falsey
+              expect(RunLoop::Otool.new(xcode).executable?(dylib)).to be_truthy
+            end
+          end
+        end
+      end
+    end
   end
 end
 

--- a/spec/lib/app_spec.rb
+++ b/spec/lib/app_spec.rb
@@ -366,8 +366,8 @@ describe RunLoop::App do
     end
 
     it "returns an empty list if no executables are found" do
-      file = __FILE__
-      otool = RunLoop::Otool.new(file)
+      xcode = RunLoop::Xcode.new
+      otool = RunLoop::Otool.new(xcode)
       expect(app).to receive(:otool).at_least(:once).and_return(otool)
       expect(otool).to receive(:executable?).at_least(:once).and_return(false)
 
@@ -496,6 +496,24 @@ describe RunLoop::App do
     actual = app.send(:lipo)
     expect(actual).to be_a_kind_of(RunLoop::Lipo)
     expect(app.instance_variable_get(:@lipo)).to be == actual
+  end
+
+  context "#otool" do
+    it "returns a memoized RunLoop::Otool instance" do
+      otool = app.send(:otool)
+      expect(app.send(:otool)).to be == otool
+      expect(app.instance_variable_get(:@otool)).to be == otool
+      expect(otool).to be_a_kind_of(RunLoop::Otool)
+    end
+  end
+
+  context "#xcode" do
+    it "returns a memoized RunLoop::Xcode instance" do
+      xcode = app.send(:xcode)
+      expect(app.send(:xcode)).to be == xcode
+      expect(app.instance_variable_get(:@xcode)).to be == xcode
+      expect(xcode).to be_a_kind_of(RunLoop::Xcode)
+    end
   end
 end
 

--- a/spec/lib/otool_spec.rb
+++ b/spec/lib/otool_spec.rb
@@ -4,38 +4,15 @@ describe RunLoop::Otool do
   let(:app) { RunLoop::App.new(Resources.shared.app_bundle_path) }
   let(:executable) { File.join(app.path, app.executable_name) }
   let(:xcrun) { RunLoop::Xcrun.new }
-  let(:otool) { RunLoop::Otool.new(executable) }
+  let(:xcode) { RunLoop::Xcode.new }
+  let(:otool) { RunLoop::Otool.new(xcode) }
 
   describe ".new" do
-    it "sets the @path instance variable" do
-      expect(RunLoop::Otool).to receive(:valid_path?).with(path).and_return(true)
-
-      otool = RunLoop::Otool.new(path)
-
-      expect(otool.path).to be == path
-      expect(otool.instance_variable_get(:@path)).to be == path
-    end
-
-    it "raises an error if path is invalid" do
-      expect(RunLoop::Otool).to receive(:valid_path?).with(path).and_return(false)
-
-      expect do
-        RunLoop::Otool.new(path)
-      end.to raise_error ArgumentError, /must exist and not be a directory/
-    end
-  end
-
-  describe "#executable?" do
-    it "true" do
-      expect(otool).to receive(:arch_info).and_return("Anything but not-an-object-file")
-
-      expect(otool.executable?).to be_truthy
-    end
-
-    it "false" do
-      expect(otool).to receive(:arch_info).and_return("is not an object file")
-
-      expect(otool.executable?).to be_falsey
+    it "sets the @xcode instance variable" do
+      xcode = RunLoop::Xcode.new
+      otool = RunLoop::Otool.new(xcode)
+      expect(otool.instance_variable_get(:@xcode)).to be == xcode
+      expect(otool.send(:xcode)).to be == xcode
     end
   end
 
@@ -47,27 +24,23 @@ describe RunLoop::Otool do
     otool.inspect
   end
 
-  describe ".valid_path?" do
-    it "returns true for valid paths" do
-      expect(File).to receive(:exist?).with(path).and_return(true)
-      expect(File).to receive(:directory?).with(path).and_return(false)
-
-      expect(RunLoop::Otool.send(:valid_path?, path)).to be_truthy
+  context "#executable?" do
+    before do
+      expect(otool).to receive(:expect_valid_path!).with(path).and_return(true)
     end
 
-    describe "false if" do
-      it "file does not exist at path" do
-        expect(File).to receive(:exist?).with(path).and_return(false)
+    it "returns true if otool says it is an object file" do
+      expect(otool).to(
+        receive(:arch_info).with(path).and_return("Anything but not-an-object-file")
+      )
 
-        expect(RunLoop::Otool.send(:valid_path?, path)).to be_falsey
-      end
+      expect(otool.executable?(path)).to be_truthy
+    end
 
-      it "file is a directory" do
-        expect(File).to receive(:exist?).with(path).and_return(true)
-        expect(File).to receive(:directory?).with(path).and_return(true)
+    it "returns false if otool says it is not an object file" do
+      expect(otool).to receive(:arch_info).with(path).and_return("is not an object file")
 
-        expect(RunLoop::Otool.send(:valid_path?, path)).to be_falsey
-      end
+      expect(otool.executable?(path)).to be_falsey
     end
   end
 
@@ -80,15 +53,22 @@ describe RunLoop::Otool do
       }
     end
 
+    let(:command_name) { "depends on xcode version" }
+
+    let(:args) { [command_name, "-hv", "-arch", "all", path] }
+    let(:options) { {:log_cmd => false } }
+
     before do
       allow(otool).to receive(:xcrun).and_return(xcrun)
+      allow(otool).to receive(:command_name).and_return(command_name)
     end
 
     it "returns arch information" do
-      expect(xcrun).to receive(:run_command_in_context).and_return(hash)
+      expect(xcrun).to(
+        receive(:run_command_in_context).with(args, options).and_return(hash)
+      )
 
-      expect(otool.send(:arch_info)).to be == hash[:out]
-      expect(otool.instance_variable_get(:@arch_info)).to be == hash[:out]
+      expect(otool.send(:arch_info, path)).to be == hash[:out]
     end
 
     it "raises error if there is a problem" do
@@ -96,8 +76,67 @@ describe RunLoop::Otool do
       expect(xcrun).to receive(:run_command_in_context).and_return(hash)
 
       expect do
-        otool.send(:arch_info)
+        otool.send(:arch_info, path)
       end.to raise_error RuntimeError, /Could not get arch info from file:/
+    end
+  end
+
+  describe "#expect_valid_path!" do
+    it "returns true for valid paths" do
+      expect(File).to receive(:exist?).with(path).and_return(true)
+      expect(File).to receive(:directory?).with(path).and_return(false)
+
+      expect(otool.send(:expect_valid_path!, path)).to be_truthy
+    end
+
+    it "raises an error if no file exists at path" do
+      expect(File).to receive(:exist?).with(path).and_return(false)
+
+      expect do
+        otool.send(:expect_valid_path!, path)
+      end.to raise_error ArgumentError, /must exist and not be a directory/
+    end
+
+    it "raises an error if file is a directory" do
+      expect(File).to receive(:exist?).with(path).and_return(true)
+      expect(File).to receive(:directory?).with(path).and_return(true)
+      expect do
+        otool.send(:expect_valid_path!, path)
+      end.to raise_error ArgumentError, /must exist and not be a directory/
+    end
+  end
+
+  context "#command_name" do
+
+    before do
+      expect(otool).to receive(:xcode).and_return(xcode)
+    end
+
+    it "returns 'otool-classic' for Xcode >= 8.0" do
+      expect(xcode).to receive(:version_gte_8?).and_return(true)
+
+      expect(otool.send(:command_name)).to be == "otool-classic"
+    end
+
+    it "returns 'otool' for Xcode < 8.0" do
+      expect(xcode).to receive(:version_gte_8?).and_return(false)
+
+      expect(otool.send(:command_name)).to be == "otool"
+    end
+
+    it "sets the @command_name instance variable" do
+      command_name = otool.send(:command_name)
+      expect(otool.send(:command_name)).to be == command_name
+      expect(otool.instance_variable_get(:@command_name)).to be == command_name
+    end
+  end
+
+  context "#xcrun" do
+    it "returns an instance of Xcrun" do
+      xcrun = otool.send(:xcrun)
+      expect(otool.send(:xcrun)).to be == xcrun
+      expect(otool.instance_variable_get(:@xcrun)).to be == xcrun
+      expect(xcrun).to be_a_kind_of(RunLoop::Xcrun)
     end
   end
 end


### PR DESCRIPTION
### Motivation

> Currently the new LLVM-based otool(1) exits with a non-zero status on the first error it encounters for the files on the command line, including treating non-object files as errors. This differs from the previous otool(1), available now as otool-classic(1), which will process all files on the command line even if some have errors. otool-classic(1) will treat non-object files as a warning instead of an error. (26828015)

The Otool API changed:

```
# Old
RunLoop::Otool.new("path/to/file").executable?

# New
xcode = RunLoop::Xcode.new
RunLoop::Otool.new(xcode).executable?("path/to/file")
```

Completes:

* run-loop needs to update its `otool` implementation to respond to Apple changes [JIRA](https://xamarin.atlassian.net/projects/TCFW/issues/TCFW-365)

### Test

```
# Assumes you have alternative Xcode's installed in /Xcode/ directory
$ be rspec spec/integration/otool_spec.rb
```