### PR TITLE
DeviceAgent: replace :gesture_performer with :automator

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -126,7 +126,7 @@ def holmes(options={})
     :device => device.udid,
     :xcode => xcode,
     :simctl => simctl,
-    :gesture_performer => :device_agent,
+    :automator => :device_agent,
     :cbx_launcher => :ios_device_manager
   }
 

--- a/lib/run_loop.rb
+++ b/lib/run_loop.rb
@@ -108,8 +108,8 @@ module RunLoop
     device = Device.detect_device(cloned_options, xcode, simctl, instruments)
     cloned_options[:device] = device
 
-    gesture_performer = RunLoop.detect_gesture_performer(cloned_options, xcode, device)
-    if gesture_performer == :device_agent
+    automator = RunLoop.detect_automator(cloned_options, xcode, device)
+    if automator == :device_agent
       RunLoop::DeviceAgent::Client.run(cloned_options)
     else
       if RunLoop::Instruments.new.instruments_app_running?
@@ -247,7 +247,7 @@ Please quit the Instruments.app and try again.)
   #
   # @param [RunLoop::Xcode] xcode The active Xcode
   # @param [RunLoop::Device] device The device under test.
-  def self.default_gesture_performer(xcode, device)
+  def self.default_automator(xcode, device)
     # TODO XTC support
     return :instruments if RunLoop::Environment.xtc?
 
@@ -286,21 +286,21 @@ $ DEVELOPER_DIR=/path/to/Xcode/7.3.1/Xcode.app/Contents/Developer cucumber
   # @param [Hash] options The options passed by the user
   # @param [RunLoop::Xcode] xcode The active Xcode
   # @param [RunLoop::Device] device The device under test
-  def self.detect_gesture_performer(options, xcode, device)
+  def self.detect_automator(options, xcode, device)
     # TODO XTC support
     return :instruments if RunLoop::Environment.xtc?
 
-    gesture_performer = options[:gesture_performer]
+    automator = options[:automator]
 
-    if gesture_performer
+    if automator
       if xcode.version_gte_8?
-        if gesture_performer == :instruments
+        if automator == :instruments
           raise RuntimeError, %Q[
-Incompatible :gesture_performer option for active Xcode.
+Incompatible :automator option for active Xcode.
 
-Detected :gesture_performer => :instruments and Xcode #{xcode.version}.
+Detected :automator => :instruments and Xcode #{xcode.version}.
 
-Don't set the :gesture_performer option unless you are gem maintainer.
+Don't set the :automator option unless you are gem maintainer.
 
 ]
         elsif device.version < RunLoop::Version.new("9.0")
@@ -318,25 +318,25 @@ You can rerun your test if you have Xcode 7 installed:
 
 $ DEVELOPER_DIR=/path/to/Xcode/7.3.1/Xcode.app/Contents/Developer cucumber
 
-Don't set the :gesture_performer option unless you are gem maintainer.
+Don't set the :automator option unless you are gem maintainer.
 
 ]
         end
       end
 
-      if ![:device_agent, :instruments].include?(gesture_performer)
+      if ![:device_agent, :instruments].include?(automator)
         raise RuntimeError, %Q[
-Invalid :gesture_performer option: #{gesture_performer}
+Invalid :automator option: #{automator}
 
-Allowed performers: :device_agent or :instruments.
+Allowed automators: :device_agent or :instruments.
 
-Don't set the :gesture_performer option unless you are gem maintainer.
+Don't set the :automator option unless you are gem maintainer.
 
 ]
       end
-      gesture_performer
+      automator
     else
-      RunLoop.default_gesture_performer(xcode, device)
+      RunLoop.default_automator(xcode, device)
     end
   end
 end

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -222,7 +222,7 @@ means that the APP variable is pointing to a .app that does not exist.
         :repl_path => repl_path,
         :log_file => log_file,
         :results_dir => results_dir,
-        :gesture_performer => :instruments
+        :automator => :instruments
       }
 
       uia_timeout = options[:uia_timeout] || RunLoop::Environment.uia_timeout || 10

--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -85,7 +85,7 @@ $ xcrun security find-identity -v -p codesigning
             :cbx_launcher => cbx_launcher.name,
             :udid => device.udid,
             :app => bundle_id,
-            :gesture_performer => :device_agent,
+            :automator => :device_agent,
             :code_sign_identity => code_sign_identity
           }
           RunLoop::Cache.default.write(cache)

--- a/spec/lib/run_loop_spec.rb
+++ b/spec/lib/run_loop_spec.rb
@@ -39,11 +39,11 @@ describe RunLoop do
     end
   end
 
-  context ".default_gesture_performer" do
+  context ".default_automator" do
     it "returns :instruments on the XTC" do
       expect(RunLoop::Environment).to receive(:xtc?).and_return(true)
 
-      expect(RunLoop.default_gesture_performer(xcode, device)).to be == :instruments
+      expect(RunLoop.default_automator(xcode, device)).to be == :instruments
     end
 
     context "not XTC" do
@@ -62,7 +62,7 @@ describe RunLoop do
           ios9 = RunLoop::Version.new("9.0")
           expect(device).to receive(:version).at_least(:once).and_return(ios9)
 
-          expect(RunLoop.default_gesture_performer(xcode, device)).to be == :device_agent
+          expect(RunLoop.default_automator(xcode, device)).to be == :device_agent
         end
 
         it "raises error if device version < 9.0" do
@@ -70,7 +70,7 @@ describe RunLoop do
           expect(device).to receive(:version).at_least(:once).and_return(ios8)
 
           expect do
-            RunLoop.default_gesture_performer(xcode, device)
+            RunLoop.default_automator(xcode, device)
           end.to raise_error RuntimeError, /Invalid Xcode and iOS combination/
         end
       end
@@ -79,13 +79,13 @@ describe RunLoop do
         it "returns :instruments" do
           expect(xcode).to receive(:version_gte_8?).and_return(false)
 
-          expect(RunLoop.default_gesture_performer(xcode, device)).to be == :instruments
+          expect(RunLoop.default_automator(xcode, device)).to be == :instruments
         end
       end
     end
   end
 
-  context ".detect_gesture_performer" do
+  context ".detect_automator" do
     let(:options) { {} }
 
     context "XTC" do
@@ -93,7 +93,7 @@ describe RunLoop do
         expect(RunLoop::Environment).to receive(:xtc?).and_return(true)
 
         expected = :instruments
-        actual = RunLoop.detect_gesture_performer(options, xcode, device)
+        actual = RunLoop.detect_automator(options, xcode, device)
         expect(actual).to be == expected
       end
     end
@@ -104,13 +104,13 @@ describe RunLoop do
         expect(RunLoop::Environment).to receive(:xtc?).and_return(false)
       end
 
-      context ":gesture_performer defined" do
+      context ":automator defined" do
         context "Xcode < 8" do
-          it "returns :gesture_performer value" do
-            options[:gesture_performer] = :instruments
+          it "returns :automator value" do
+            options[:automator] = :instruments
             expect(xcode).to receive(:version_gte_8?).and_return(false)
 
-            actual = RunLoop.detect_gesture_performer(options, xcode, device)
+            actual = RunLoop.detect_automator(options, xcode, device)
             expect(actual).to be == :instruments
           end
         end
@@ -121,43 +121,43 @@ describe RunLoop do
           end
 
           it "raises error if :instruments" do
-            options[:gesture_performer] = :instruments
+            options[:automator] = :instruments
 
             expect do
-              RunLoop.detect_gesture_performer(options, xcode, device)
+              RunLoop.detect_automator(options, xcode, device)
             end.to raise_error RuntimeError,
-                               /Incompatible :gesture_performer option for active Xcode/
+                               /Incompatible :automator option for active Xcode/
           end
 
           it "raises error if iOS version < 9.0" do
-            options[:gesture_performer] = :device_agent
+            options[:automator] = :device_agent
             ios8 = RunLoop::Version.new("8.0")
             expect(device).to receive(:version).at_least(:once).and_return(ios8)
 
             expect do
-              RunLoop.detect_gesture_performer(options, xcode, device)
+              RunLoop.detect_automator(options, xcode, device)
             end.to raise_error RuntimeError, /Invalid Xcode and iOS combination/
           end
         end
 
-        it "raises error if unknown gesture_performer" do
-          options[:gesture_performer] = :unknown_performer
+        it "raises error if unknown automator" do
+          options[:automator] = :unknown_automator
 
           allow(device).to receive(:version).and_return(RunLoop::Version.new("9.1"))
 
           expect do
-            RunLoop.detect_gesture_performer(options, xcode, device)
-          end.to raise_error RuntimeError, /Invalid :gesture_performer option:/
+            RunLoop.detect_automator(options, xcode, device)
+          end.to raise_error RuntimeError, /Invalid :automator option:/
         end
       end
     end
 
-    context ":gesture_performer not defined" do
-      it "returns .default_gesture_performer" do
-        expected = :performer
-        expect(RunLoop).to receive(:default_gesture_performer).and_return(expected)
+    context ":automator not defined" do
+      it "returns .default_automator" do
+        expected = :automator
+        expect(RunLoop).to receive(:default_automator).and_return(expected)
 
-        expect(RunLoop.detect_gesture_performer(options, xcode, device)).to be == expected
+        expect(RunLoop.detect_automator(options, xcode, device)).to be == expected
       end
     end
   end


### PR DESCRIPTION
### Motivation

RunLoop.run now responds to `:automator` instead of `:gesture_performer`.