### PR TITLE
XTC is also a ci environment with same timeouts

### DIFF
--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -282,6 +282,7 @@ module RunLoop
     def self.ci?
       [
         self.ci_var_defined?,
+        self.xtc?,
         self.travis?,
         self.jenkins?,
         self.circle_ci?,


### PR DESCRIPTION
include `xtc?`  in `ci?` since we've seen receive timeouts on XTC with the default setting