### PR TITLE
CoreSim: don't wait after simctl install

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -596,7 +596,8 @@ Command had no output
     timeout = DEFAULT_OPTIONS[:install_app_timeout]
     simctl.install(device, app, timeout)
 
-    device.simulator_wait_for_stable_state
+    # Experimental: don't wait after the install
+    # device.simulator_wait_for_stable_state
     installed_app_bundle_dir
   end
 

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -785,7 +785,9 @@ describe RunLoop::CoreSimulator do
         expect(core_sim).to receive(:launch_simulator).and_return true
         timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:install_app_timeout]
         expect(core_sim.simctl).to receive(:install).with(device, app, timeout).and_return(true)
-        expect(core_sim.device).to receive(:simulator_wait_for_stable_state).and_return(true)
+
+        # Experimental: don't wait after the install
+        expect(core_sim.device).not_to receive(:simulator_wait_for_stable_state)
 
         expect(core_sim).to receive(:installed_app_bundle_dir).and_return('/new/path')
 


### PR DESCRIPTION
### Motivation

There are now two apps to install: DeviceAgent and the AUT.  The simulator-stable method has not been optimized for Xcode 8 simulators.  I have been testing with this patch for two weeks and I have not encountered any problems. 