### PR TITLE
DA:Client: prototype API for SpringBoard alerts

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -407,13 +407,32 @@ Query must contain at least one of these keys:
       end
 
       # @!visibility private
-      def alert_visible?
+      def alert
         parameters = { :type => "Alert" }
         request = request("query", parameters)
         client = http_client(http_options)
         response = client.post(request)
         hash = expect_300_response(response)
-        !hash["result"].empty?
+        hash["result"]
+      end
+
+      # @!visibility private
+      def alert_visible?
+        !alert.empty?
+      end
+
+      # @!visibility private
+      def spring_board_alert
+        request = request("springBoardAlert")
+        client = http_client(http_options)
+        response = client.get(request)
+        hash = expect_300_response(response)
+        hash["result"]
+      end
+
+      # @!visibility private
+      def spring_board_alert_visible?
+        !spring_board_alert.empty?
       end
 
       # @!visibility private


### PR DESCRIPTION
### Motivation

DeviceAgent can interact with SpringBoard alerts (AKA Privacy Alerts).

This is a prototype API - it is documented as private.  It can change at any time.

Here are some possible APIs.

```
:app => An alert generated by the Application Under Test
:spring_board => An alert generated SpringBoard (e.g. Privacy Alert)
:any => Either :app or :spring_board

def alert(type=:app)
def alert?(type=:app)
def wait_for_alert(type=:app, timeout, &block)
def wait_for_no_alert(type=:app, timeout, &block)
```

This is also a possibility:

```
# Active::Support-ish
def alert
def alert.visible?
```

Feedback is welcome.

@TobiasRoikjer Comments in the context of Calabash 2.0?  


