### PR TITLE
Allow the user to increase the default DeviceAgent install time

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -33,6 +33,10 @@ module RunLoop
         :simulator_ip => "127.0.0.1",
         :http_timeout => (RunLoop::Environment.ci? || RunLoop::Environment.xtc?) ? 120 : 10,
         :route_version => "1.0",
+
+        # Ignored in the XTC.
+        # This key is subject to removal or changes
+        :device_agent_install_timeout => RunLoop::Environment.ci? ? 120 : 60,
         # This value must always be false on the XTC.
         # This is should only be used by gem maintainers or very advanced users.
         :shutdown_device_agent_before_launch => false

--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -19,14 +19,22 @@ module RunLoop
       # @!visibility private
       #
       # These defaults may change at any time.
+      #
+      # You can override these values if they do not work in your environment.
+      #
+      # For cucumber users, the best place to override would be in your
+      # features/support/env.rb.
+      #
+      # For example:
+      #
+      # RunLoop::DeviceAgent::Client::DEFAULTS[:http_timeout] = 60
       DEFAULTS = {
         :port => 27753,
         :simulator_ip => "127.0.0.1",
-        :http_timeout => (RunLoop::Environment.ci? ||
-                          RunLoop::Environment.xtc?) ? 120 : 10,
+        :http_timeout => (RunLoop::Environment.ci? || RunLoop::Environment.xtc?) ? 120 : 10,
         :route_version => "1.0",
         # This value must always be false on the XTC.
-        # This is should only be used by gem maintainers.
+        # This is should only be used by gem maintainers or very advanced users.
         :shutdown_device_agent_before_launch => false
       }
 

--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -45,10 +45,21 @@ module RunLoop
       # @!visibility private
       #
       # These defaults may change at any time.
+      #
+      # You can override these values if they do not work in your environment.
+      #
+      # For cucumber users, the best place to override would be in your
+      # features/support/env.rb.
+      #
+      # For example:
+      #
+      # RunLoop::DeviceAgent::Client::WAIT_DEFAULTS[:timeout] = 30
       WAIT_DEFAULTS = {
         timeout: (RunLoop::Environment.ci? ||
-                  RunLoop::Environment.xtc?) ? 30 : 8,
+                  RunLoop::Environment.xtc?) ? 30 : 15,
+        # This key is subject to removal or changes.
         retry_frequency: 0.1,
+        # This key is subject to removal or changes.
         exception_class: Timeout::Error
       }
 

--- a/lib/run_loop/device_agent/ios_device_manager.rb
+++ b/lib/run_loop/device_agent/ios_device_manager.rb
@@ -76,6 +76,7 @@ but binary does not exist at that path.
       # @!visibility private
       def launch(options)
         code_sign_identity = options[:code_sign_identity]
+        install_timeout = options[:device_agent_install_timeout]
 
         RunLoop::DeviceAgent::Frameworks.instance.install
         cmd = RunLoop::DeviceAgent::IOSDeviceManager.ios_device_manager
@@ -90,6 +91,16 @@ but binary does not exist at that path.
           sim.launch_simulator
         else
 
+          if !install_timeout
+            raise ArgumentError, %Q[
+
+Expected :device_agent_install_timeout key in options:
+
+#{options}
+
+]
+          end
+
           if !code_sign_identity
             raise ArgumentError, %Q[
 Targeting a physical devices requires a code signing identity.
@@ -101,7 +112,7 @@ $ CODE_SIGN_IDENTITY="iPhone Developer: Your Name (ABCDEF1234)" cucumber
 ]
           end
 
-          options = {:log_cmd => true}
+          options = {:log_cmd => true, :timeout => install_timeout}
           args = [
             cmd, "install",
             "--device-id", device.udid,
@@ -112,7 +123,6 @@ $ CODE_SIGN_IDENTITY="iPhone Developer: Your Name (ABCDEF1234)" cucumber
           start = Time.now
           hash = run_shell_command(args, options)
 
-
           if hash[:exit_status] != 0
             raise RuntimeError, %Q[
 
@@ -120,7 +130,7 @@ Could not install #{runner.runner}.  iOSDeviceManager says:
 
 #{hash[:out]}
 
-            ]
+]
           end
         end
 

--- a/spec/integration/device_agent/client_spec.rb
+++ b/spec/integration/device_agent/client_spec.rb
@@ -18,7 +18,10 @@ describe RunLoop::DeviceAgent::Client do
       workspace = File.expand_path(File.join("..", "DeviceAgent.iOS", "DeviceAgent.xcworkspace"))
       if File.exist?(workspace)
         cbx_launcher = RunLoop::DeviceAgent::Xcodebuild.new(device)
-        client = RunLoop::DeviceAgent::Client.new(bundle_identifier, device, cbx_launcher)
+        client = RunLoop::DeviceAgent::Client.new(bundle_identifier,
+                                                  device,
+                                                  cbx_launcher,
+                                                  {})
         client.launch
 
         options = { :raise_on_timeout => true, :timeout => 5 }
@@ -40,7 +43,9 @@ describe RunLoop::DeviceAgent::Client do
 
     it "ios_device_manager" do
       cbx_launcher = RunLoop::DeviceAgent::IOSDeviceManager.new(device)
-      client = RunLoop::DeviceAgent::Client.new(bundle_identifier, device, cbx_launcher)
+      client = RunLoop::DeviceAgent::Client.new(bundle_identifier,
+                                                device, cbx_launcher,
+                                                {})
       client.launch
 
       options = { :raise_on_timeout => true, :timeout => 5 }

--- a/spec/lib/device_agent/client_spec.rb
+++ b/spec/lib/device_agent/client_spec.rb
@@ -2,9 +2,13 @@
 describe RunLoop::DeviceAgent::Client do
 
   let(:bundle_id) { "com.apple.Preferences" }
+  let(:launcher_options) { {} }
   let(:device) { Resources.shared.simulator("9.0") }
   let(:cbx_launcher) { RunLoop::DeviceAgent::LauncherStrategy.new(device) }
-  let(:client) { RunLoop::DeviceAgent::Client.new(bundle_id, device, cbx_launcher) }
+  let(:client) do
+    RunLoop::DeviceAgent::Client.new(bundle_id, device,
+                                     cbx_launcher, launcher_options)
+  end
 
   let(:response) do
     Class.new do


### PR DESCRIPTION
### Motivation

Users are reporting timeouts when trying to install DeviceAgent to their physical devices.  This is one-time performance hit for each new release of DeviceAgent.  We are working hard to make this faster.  Expect improvements soon.

This PR increases the default timeout to 60 seconds (up from 30).

You can override this value if it does not work in your environment.

```
# Pass it as launch option

options = {
  :device_agent_install_timeout => 240
}

launcher.relaunch(options)
```     

Cucumber users can also override in your `features/support/env.rb.`

```
RunLoop::DeviceAgent::Client::DEFAULTS[:http_timeout] = 60
```

