### PR TITLE
Support LPServer dylib injection on Simulators when running with DeviceAgent

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -279,7 +279,7 @@ Logfile: #{log_file}
 
       RunLoop::Logging.log_debug(logger, "Launching took #{Time.now-before_instruments_launch} seconds")
 
-      dylib_path = self.dylib_path_from_options(merged_options)
+      dylib_path = RunLoop::DylibInjector.dylib_path_from_options(merged_options)
 
       if dylib_path
         if device.physical_device?
@@ -313,26 +313,6 @@ Logfile: #{log_file}
       true
     end
 
-    # Extracts the value of :inject_dylib from options Hash.
-    # @param options [Hash] arguments passed to {RunLoop.run}
-    # @return [String, nil] If the options contains :inject_dylibs and it is a
-    #  path to a dylib that exists, return the path.  Otherwise return nil or
-    #  raise an error.
-    # @raise [RuntimeError] If :inject_dylib points to a path that does not exist.
-    # @raise [ArgumentError] If :inject_dylib is not a String.
-    def self.dylib_path_from_options(options)
-      inject_dylib = options.fetch(:inject_dylib, nil)
-      return nil if inject_dylib.nil?
-      unless inject_dylib.is_a? String
-        raise ArgumentError, "Expected :inject_dylib to be a path to a dylib, but found '#{inject_dylib}'"
-      end
-      dylib_path = File.expand_path(inject_dylib)
-      unless File.exist?(dylib_path)
-        raise "Cannot load dylib.  The file '#{dylib_path}' does not exist."
-      end
-      dylib_path
-    end
-
     # Returns the a default simulator to target.  This default needs to be one
     # that installed by default in the current Xcode version.
     #
@@ -364,7 +344,6 @@ Logfile: #{log_file}
         "iPhone 5s (8.0 Simulator)"
       end
     end
-
 
     def self.create_uia_pipe(repl_path)
       begin

--- a/lib/run_loop/dylib_injector.rb
+++ b/lib/run_loop/dylib_injector.rb
@@ -26,6 +26,30 @@ module RunLoop
       :timeout => RunLoop::Environment.ci? ? 40 : 20
     }
 
+    # Extracts the value of :inject_dylib from options Hash.
+    # @param options [Hash] arguments passed to {RunLoop.run}
+    # @return [String, nil] If the options contains :inject_dylibs and it is a
+    #  path to a dylib that exists, return the path.  Otherwise return nil or
+    #  raise an error.
+    # @raise [RuntimeError] If :inject_dylib points to a path that does not exist.
+    # @raise [ArgumentError] If :inject_dylib is not a String.
+    def self.dylib_path_from_options(options)
+      inject_dylib = options.fetch(:inject_dylib, nil)
+      return nil if inject_dylib.nil?
+      if !inject_dylib.is_a? String
+        raise ArgumentError, %Q[
+
+Expected :inject_dylib to be a path to a dylib, but found '#{inject_dylib}'
+
+]
+      end
+      dylib_path = File.expand_path(inject_dylib)
+      unless File.exist?(dylib_path)
+        raise "Cannot load dylib.  The file '#{dylib_path}' does not exist."
+      end
+      dylib_path
+    end
+
     # @!attribute [r] process_name
     # The name of the process to inject the dylib into.  This should be obtained
     #  by inspecting the Info.plist in the app bundle.

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -274,38 +274,6 @@ describe RunLoop::Core do
     end
   end
 
-  describe '.dylib_path_from_options' do
-    describe 'raises an error' do
-      # @todo this test is probably unnecessary
-      it 'when options argument is not a Hash' do
-        expect { RunLoop::Core.dylib_path_from_options([]) }.to raise_error TypeError
-        expect { RunLoop::Core.dylib_path_from_options(nil) }.to raise_error NoMethodError
-      end
-
-      it 'when :inject_dylib is not a String' do
-        options = { :inject_dylib => true }
-        expect { RunLoop::Core.dylib_path_from_options(options) }.to raise_error ArgumentError
-      end
-
-      it 'when dylib does not exist' do
-        options = { :inject_dylib => 'foo/bar.dylib' }
-        expect { RunLoop::Core.dylib_path_from_options(options) }.to raise_error RuntimeError
-      end
-    end
-
-    describe 'returns' do
-      it 'nil if options does not contain :inject_dylib key' do
-        expect(RunLoop::Core.dylib_path_from_options({})).to be == nil
-      end
-
-      it 'value of :inject_dylib key if the path exists' do
-        path = Resources.shared.sim_dylib_path
-        options = { :inject_dylib => path }
-        expect(RunLoop::Core.dylib_path_from_options(options)).to be == path
-      end
-    end
-  end
-
   describe '.log_run_loop_options' do
     let(:options) {
       {

--- a/spec/lib/http/retriable_client_spec.rb
+++ b/spec/lib/http/retriable_client_spec.rb
@@ -13,6 +13,39 @@ describe RunLoop::HTTP::RetriableClient do
     allow(RunLoop::Environment).to receive(:debug?).and_return(true)
   end
 
+   context "self.dylib_path_from_options" do
+    context "raises errors" do
+      it "when options argument is not a Hash" do
+        expect { RunLoop::DylibInjector.dylib_path_from_options([]) }.to raise_error TypeError
+        expect { RunLoop::DylibInjector.dylib_path_from_options(nil) }.to raise_error NoMethodError
+      end
+
+      it "when :inject_dylib is not a String" do
+        options = { :inject_dylib => true }
+        expect do
+          RunLoop::DylibInjector.dylib_path_from_options(options)
+        end.to raise_error ArgumentError, /to be a path to a dylib/
+      end
+
+      it "when dylib does not exist" do
+        options = { :inject_dylib => 'foo/bar.dylib' }
+        expect do
+          RunLoop::DylibInjector.dylib_path_from_options(options)
+        end.to raise_error RuntimeError, /Cannot load dylib/
+      end
+    end
+
+    it "returns nil if options does not contain :inject_dylib key" do
+      expect(RunLoop::DylibInjector.dylib_path_from_options({})).to be == nil
+    end
+
+    it "value of :inject_dylib key if the path exists" do
+      path = Resources.shared.sim_dylib_path
+      options = { :inject_dylib => path }
+      expect(RunLoop::DylibInjector.dylib_path_from_options(options)).to be == path
+    end
+  end
+
   context ".new" do
     let(:client) { ::HTTPClient.new }
 


### PR DESCRIPTION
### Motivation

This feature is necessary to provide backward compatibility. 

ATTN @MortenGregersen 