### PR TITLE
Fix retry with dylib injection and DeviceAgent

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -1231,10 +1231,10 @@ Please install it.
         end
 
         retries = 5
-        client = http_client(http_options)
-        request = request("session", {:bundleID => bundle_id})
 
         begin
+          client = http_client(http_options)
+          request = request("session", {:bundleID => bundle_id})
           response = client.post(request)
           RunLoop.log_debug("Launched #{bundle_id} on #{device}")
           RunLoop.log_debug("#{response.body}")


### PR DESCRIPTION
Move the instantiation of the client and request inside begin/rescue block

as discussed with @jmoody on gitter.im