### PR TITLE
Gem: force HTTPClient 2.7.1 or higher

### DIFF
--- a/run_loop.gemspec
+++ b/run_loop.gemspec
@@ -51,7 +51,7 @@ tools like instruments and simctl.}
   s.add_dependency('CFPropertyList','~> 2.2')
   s.add_dependency('thor', '>= 0.18.1', '< 1.0')
   s.add_dependency('command_runner_ng', '>= 0.0.2')
-  s.add_dependency("httpclient", "~> 2.6")
+  s.add_dependency("httpclient", ">= 2.7.1", "< 3.0")
   s.add_dependency("i18n", ">= 0.7.0", "< 1.0")
 
   s.add_development_dependency("rspec_junit_formatter", "~> 0.2")


### PR DESCRIPTION
### Motivation

* Update HTTP Client to 2.7.1 or better [JIRA](https://jira.xamarin.com/browse/TCFW-85)