### PR TITLE
Core: default sim for Xcode 8 is iPhone 7 iOS 10

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -316,14 +316,12 @@ Logfile: #{log_file}
     # Returns the a default simulator to target.  This default needs to be one
     # that installed by default in the current Xcode version.
     #
-    # For historical reasons, the most recent non-64b SDK should be used.
-    #
     # @param [RunLoop::Xcode] xcode Used to detect the current xcode
     #  version.
     def self.default_simulator(xcode=RunLoop::Xcode.new)
 
       if xcode.version_gte_8?
-        "iPhone 6s (10.0)"
+        "iPhone 7 (10.0)"
       elsif xcode.version_gte_73?
         "iPhone 6s (9.3)"
       elsif xcode.version_gte_72?

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -252,7 +252,7 @@ describe RunLoop::Core do
     end
 
     it 'Xcode >= 8.0' do
-      expected = 'iPhone 6s (10.0)'
+      expected = 'iPhone 7 (10.0)'
       expect(xcode).to receive(:version).at_least(:once).and_return xcode.v80
       expect(RunLoop::Core.default_simulator(xcode)).to be == expected
     end


### PR DESCRIPTION
### Motivation

Xcode 8 GM ships with iPhone 7 iOS 10 simulator.