### PR TITLE
CoreSim: waiting is necessary after simctl install

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -596,8 +596,12 @@ Command had no output
     timeout = DEFAULT_OPTIONS[:install_app_timeout]
     simctl.install(device, app, timeout)
 
-    # Experimental: don't wait after the install
-    # device.simulator_wait_for_stable_state
+    # On Xcode 7, we must wait.  The app might not be installed otherwise.  This
+    # is particularly true for iPads where the app bundle is installed, but
+    # SpringBoard does not detect the app has been installed.
+    #
+    # On Xcode 8, more testing is needed.
+    device.simulator_wait_for_stable_state
     installed_app_bundle_dir
   end
 

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -341,6 +341,8 @@ version: #{version}
     # the app and data container exists, but Springboard does not detect them.
     #
     # 6. 1 and 2 must hold for 1.5 seconds.
+    #
+    # TODO needs update for Xcode 8 + iOS 10 simulators.
     def simulator_wait_for_stable_state
 
       # How long to wait between stability checks.
@@ -374,7 +376,9 @@ version: #{version}
       # iOS 9 simulators have an additional boot screen.
       is_gte_ios9 = version >= RunLoop::Version.new('9.0')
 
-      # iOS 9 iPad simulators need additional time to stabilize.
+      # iOS 9 iPad simulators need additional time to stabilize, especially
+      # to ensure that `simctl install` notifies SpringBoard that a new app
+      # has been installed.
       is_ipad = simulator_is_ipad?
 
       timeout = SIM_STABLE_STATE_OPTIONS[:timeout]

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -786,8 +786,7 @@ describe RunLoop::CoreSimulator do
         timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:install_app_timeout]
         expect(core_sim.simctl).to receive(:install).with(device, app, timeout).and_return(true)
 
-        # Experimental: don't wait after the install
-        expect(core_sim.device).not_to receive(:simulator_wait_for_stable_state)
+        expect(core_sim.device).to receive(:simulator_wait_for_stable_state)
 
         expect(core_sim).to receive(:installed_app_bundle_dir).and_return('/new/path')
 


### PR DESCRIPTION
### Motivation

Rolls back this 26edcc68f781745f7cbb7c2dc9b420f6ca55685f change and adds documentation about why it is necessary.

Fixes:

* Could not install app on simulator on CI [#1163](https://github.com/calabash/calabash-ios/issues/1163)
* Flickering example in Jenkins CI


ATTN: @JoeSSS