### PR TITLE
DeviceAgent::Client: enter text without keyboard check

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -356,6 +356,26 @@ INSTANCE METHODS
 
       # @!visibility private
       #
+      # Some clients are performing keyboard checks _before_ calling #enter_text.
+      #
+      # 1. Removes duplicate check.
+      # 2. It turns out DeviceAgent query can be very slow.
+      def enter_text_without_keyboard_check(string)
+        options = http_options
+        parameters = {
+          :gesture => "enter_text",
+          :options => {
+            :string => string
+          }
+        }
+        request = request("gesture", parameters)
+        client = http_client(options)
+        response = client.post(request)
+        expect_300_response(response)
+      end
+
+      # @!visibility private
+      #
       # @example
       #  query({id: "login", :type "Button"})
       #


### PR DESCRIPTION
### Motivation

Improve text entry by providing a way to enter text without texting for the keyboard.

The Calabash client already checks for the keyboard.  Calling the existing `#enter_text` in method adds a duplicate keyboard visible check which is expensive (time).

We've identified some problems in the DeviceAgent stack.  This a first step toward fixing problems with text entry.

Progress on:

* keyboard_enter_text times out typing long text [#1158](https://github.com/calabash/calabash-ios/issues/1158)
* Can't type in one of the field of our APP [#1155](https://github.com/calabash/calabash-ios/issues/1155)
* In my app's safari webview, keyboard_visible? command returns "false" while the device_agent.keyboard_visible? command returns "true" [#1166](https://github.com/calabash/calabash-ios/issues/1166)