### PR TITLE
Turns enter text input parameter to string for numeric keyboards

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -362,7 +362,7 @@ INSTANCE METHODS
         parameters = {
           :gesture => "enter_text",
           :options => {
-            :string => string
+            :string => string.to_s
           }
         }
         request = request("gesture", parameters)


### PR DESCRIPTION
**Motivation**

Numeric keyboards pass in a number where we expected a string input - so adding `to_s` to make the request with a string.

Addresses calabash/calabash-ios#1176