### PR TITLE
Added pt-BR translations for permissions alerts

### DIFF
--- a/scripts/lib/on_alert.js
+++ b/scripts/lib/on_alert.js
@@ -158,7 +158,18 @@ function frenchLocalizations() {
 function portugueseBrazilLocalizations() {
   return [
     ["Permitir", /acesso à sua localização/],
-    ["Permitir", /[Dd]eseja [Ee]nviar [Nn]otificações/]
+    ["Permitir", /acesso à sua localização/],
+    ["OK", /Deseja Ter Acesso às Suas Fotos/],
+    ["OK", /Deseja Ter Acesso aos Seus Contatos/],
+    ["OK", /Acesso ao Seu Calendário/],
+    ["OK", /Deseja Ter Acesso aos Seus Lembretes/],
+    ["OK", /Would Like to Access Your Motion Activity/],
+    ["OK", /Deseja Ter Acesso à Câmera/],
+    ["OK", /Deseja Ter Acesso às Suas Atividades de Movimento e Preparo Físico/],
+    ["OK", /Deseja Ter Acesso às Contas do Twitter/],
+    ["OK", /data available to nearby bluetooth devices/],
+    ["Permitir", /[Dd]eseja [Ee]nviar [Nn]otificações/],
+    ["OK", /[Dd]eseja [Ee]nviar-lhe [Nn]otificações/]  
   ];
 }
 

--- a/scripts/lib/on_alert.js
+++ b/scripts/lib/on_alert.js
@@ -176,7 +176,7 @@ function localizations() {
   return [].concat(
      danishLocalizations(),
      dutchLocalizations(),
-     englishLocalizations(),n
+     englishLocalizations(),
      germanLocalizations(),
      russianLocalizations(),
      spanishLocalizations(),

--- a/scripts/lib/on_alert.js
+++ b/scripts/lib/on_alert.js
@@ -168,7 +168,6 @@ function portugueseBrazilLocalizations() {
     ["OK", /Deseja Ter Acesso às Suas Atividades de Movimento e Preparo Físico/],
     ["OK", /Deseja Ter Acesso às Contas do Twitter/],
     ["OK", /data available to nearby bluetooth devices/],
-    ["Permitir", /[Dd]eseja [Ee]nviar [Nn]otificações/],
     ["OK", /[Dd]eseja [Ee]nviar-lhe [Nn]otificações/]  
   ];
 }

--- a/scripts/lib/on_alert.js
+++ b/scripts/lib/on_alert.js
@@ -155,6 +155,13 @@ function frenchLocalizations() {
   ];
 }
 
+function portugueseBrazilLocalizations() {
+  return [
+    ["Permitir", /acesso à sua localização/],
+    ["Permitir", /[Dd]eseja [Ee]nviar [Nn]otificações/]
+  ];
+}
+
 function localizations() {
   return [].concat(
      danishLocalizations(),
@@ -163,7 +170,8 @@ function localizations() {
      germanLocalizations(),
      russianLocalizations(),
      spanishLocalizations(),
-     frenchLocalizations()
+     frenchLocalizations(),
+     portugueseBrazilLocalizations() 
   );
 }
 
@@ -173,7 +181,7 @@ function isPrivacyAlert(alert) {
 
   var title = findAlertTitle(alert);
 
-  // Comment this out when capturing new regexes. See the comment below.
+    // Comment this out when capturing new regexes. See the comment below.
   Log.output({"alert":title});
 
   // When debugging or trying to capture the regexes for a new
@@ -207,8 +215,8 @@ function isPrivacyAlert(alert) {
   // $ APP_LANG="nl" APP_LOCALE="nl" be cucumber -t @supported -p macmini
 
   // This is very slow, so only do this if you are trying to capture regexes.
-  //var buttonNames = findAlertButtonNames(alert);
-  //Log.output({"alert":{"title":title, "buttons":buttonNames, "capture":"YES"}});
+  var buttonNames = findAlertButtonNames(alert);
+  Log.output({"alert":{"title":title, "buttons":buttonNames, "capture":"YES"}});
 
   var answer;
   var expression;

--- a/scripts/lib/on_alert.js
+++ b/scripts/lib/on_alert.js
@@ -176,7 +176,7 @@ function localizations() {
   return [].concat(
      danishLocalizations(),
      dutchLocalizations(),
-     englishLocalizations(),
+     englishLocalizations(),n
      germanLocalizations(),
      russianLocalizations(),
      spanishLocalizations(),
@@ -192,7 +192,7 @@ function isPrivacyAlert(alert) {
   var title = findAlertTitle(alert);
 
   // Comment this out when capturing new regexes. See the comment below.
-  // Log.output({"alert":title});
+  Log.output({"alert":title});
 
   // When debugging or trying to capture the regexes for a new
   // localization, uncomment the logging below.

--- a/scripts/lib/on_alert.js
+++ b/scripts/lib/on_alert.js
@@ -181,8 +181,8 @@ function isPrivacyAlert(alert) {
 
   var title = findAlertTitle(alert);
 
-    // Comment this out when capturing new regexes. See the comment below.
-  Log.output({"alert":title});
+  // Comment this out when capturing new regexes. See the comment below.
+  // Log.output({"alert":title});
 
   // When debugging or trying to capture the regexes for a new
   // localization, uncomment the logging below.
@@ -215,8 +215,8 @@ function isPrivacyAlert(alert) {
   // $ APP_LANG="nl" APP_LOCALE="nl" be cucumber -t @supported -p macmini
 
   // This is very slow, so only do this if you are trying to capture regexes.
-  var buttonNames = findAlertButtonNames(alert);
-  Log.output({"alert":{"title":title, "buttons":buttonNames, "capture":"YES"}});
+  // var buttonNames = findAlertButtonNames(alert);
+  // Log.output({"alert":{"title":title, "buttons":buttonNames, "capture":"YES"}});
 
   var answer;
   var expression;


### PR DESCRIPTION
Added translations for the Permissions Alerts messages, because Calabash was not able to automatically dismiss Portuguese alerts.
I used Permissions.app to get this messages. I could not run Permissions.app in a Device, so all messages came from an iPhone 6 simulator, running iOS 9.3. Ruby 2.3.1p112 and calabash-ios 0.20.3.
Then I used Permissions.app to check if this solved the problem and the scenarios passed.
For newer versions of iOS SDK, I opened the Issue [#1226](https://github.com/calabash/calabash-ios/issues/1226) in the calabash-ios repository, so DeviceAgent can also be updated.

This is my first pull request for run_loop. Please forgive me if something is not OK. Anything that should change, please let me know and I will fix it in no time.