### PR TITLE
App: fix TrueType font extension to avoid otool failures

### DIFF
--- a/lib/run_loop/app.rb
+++ b/lib/run_loop/app.rb
@@ -369,7 +369,7 @@ Bundle must:
     def font?(file)
       extension = File.extname(file)
 
-      extension == ".tff" || extension == ".otf"
+      extension == ".ttf" || extension == ".otf"
     end
   end
 end

--- a/spec/lib/app_spec.rb
+++ b/spec/lib/app_spec.rb
@@ -483,7 +483,7 @@ describe RunLoop::App do
 
   describe "#font?" do
     it "returns trues" do
-      expect(app.send(:font?, "path/to/my.tff")).to be_truthy
+      expect(app.send(:font?, "path/to/my.ttf")).to be_truthy
       expect(app.send(:font?, "path/to/my.otf")).to be_truthy
     end
 


### PR DESCRIPTION
### Motivation

Fixes:

* Issues with TTF files - The file was not recognized as a valid object file [#1227](https://github.com/calabash/calabash-ios/issues/1227)

Thanks @raffabhaktin for reporting.