### PR TITLE
DA:Client: launch AUT with args and environment

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -128,12 +128,16 @@ $ xcrun security find-identity -v -p codesigning
                                                      DEFAULTS[:device_agent_install_timeout])
         shutdown_before_launch = options.fetch(:shutdown_device_agent_before_launch,
                                                DEFAULTS[:shutdown_device_agent_before_launch])
+        aut_args = options.fetch(:args, [])
+        aut_env = options.fetch(:env, {})
 
         launcher_options = {
             code_sign_identity: code_sign_identity,
             device_agent_install_timeout: install_timeout,
             shutdown_device_agent_before_launch: shutdown_before_launch,
-            dylib_injection_details: dylib_injection_details
+            dylib_injection_details: dylib_injection_details,
+            aut_args: aut_args,
+            aut_env: aut_env
         }
 
         xcuitest = RunLoop::DeviceAgent::Client.new(bundle_id, device,
@@ -1295,7 +1299,12 @@ Please install it.
 
         begin
           client = http_client(http_options)
-          request = request("session", {:bundleID => bundle_id})
+          request = request("session",
+                            {
+                              :bundleID => bundle_id,
+                              :launchArgs => launcher_options[:aut_args],
+                              :environment => launcher_options[:aut_env]
+                            })
           response = client.post(request)
           RunLoop.log_debug("Launched #{bundle_id} on #{device}")
           RunLoop.log_debug("#{response.body}")


### PR DESCRIPTION
### Motivation

Completes:

* No longer possible to pass Environment variables to instance [#1172](https://github.com/calabash/calabash-ios/issues/1172)

### Notes

The `:args` key uses the same conventions as with UIAutomation:

```
options = {
  :args =>  ["-AppleLanguages", "(da)",
              "-AppleLocale", "da"]
}
```

To see this in action, try:

```
options = {
   :args => ["-NSShowNonLocalizedStrings", "YES"]
}
```

UIAutomation allowed environment variables to be set.  Calabash did not have an official API for this, but users were able to override the `:args` option using the `-e` flag.

This PR does not provide backward-compatible support for the `-e` flag.  Instead, it provides a separate option: `:env`.  To be backward compatible, follow the example below.

```
if uia_available?
  options = {
    :args =>  [  "-e", "USER_NAME", "clever_user",
                 "-e", "USER_PASS", "pa$$w0rd"]
  }
else
  options = {
    :env => { "USER_NAME" => "clever_user",
              "USER_PASS" => "pa$$w0rd"}
  }
end
```