### PR TITLE
Jenkins: ensure the correct CoreSimulatorService is loaded

### DIFF
--- a/scripts/ci/jenkins/run.sh
+++ b/scripts/ci/jenkins/run.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Ensure the correct CoreSimulatorService is loaded.
+
+xcrun simctl help >/dev/null 2>&1
+xcrun simctl help >/dev/null 2>&1
+xcrun simctl help >/dev/null 2>&1
+
 if [ -n "${JENKINS_HOME}" ]; then
   # Legacy
   rm -rf .ruby-version

--- a/spec/integration/core_simulator_spec.rb
+++ b/spec/integration/core_simulator_spec.rb
@@ -1,7 +1,5 @@
 describe RunLoop::CoreSimulator do
-  let(:simulator) do
-    Resources.shared.simctl.simulators.sample
-  end
+  let(:simulator) { Resources.shared.default_simulator }
 
   let(:app) { RunLoop::App.new(Resources.shared.cal_app_bundle_path) }
   let(:xcrun) { RunLoop::Xcrun.new }

--- a/spec/integration/simctl_spec.rb
+++ b/spec/integration/simctl_spec.rb
@@ -2,7 +2,7 @@
 describe RunLoop::Simctl do
 
   let(:simctl) { Resources.shared.simctl }
-  let(:device) { Resources.shared.simctl.simulators.sample }
+  let(:device) { Resources.shared.default_simulator }
   let(:app) { RunLoop::App.new(Resources.shared.cal_app_bundle_path) }
   let(:core_sim) { RunLoop::CoreSimulator.new(device, app) }
 

--- a/spec/integration/simctl_spec.rb
+++ b/spec/integration/simctl_spec.rb
@@ -2,22 +2,12 @@
 describe RunLoop::Simctl do
 
   let(:simctl) { Resources.shared.simctl }
-  let(:sim_control) { Resources.shared.sim_control }
   let(:device) { Resources.shared.simctl.simulators.sample }
   let(:app) { RunLoop::App.new(Resources.shared.cal_app_bundle_path) }
   let(:core_sim) { RunLoop::CoreSimulator.new(device, app) }
 
   before do
     allow(RunLoop::Environment).to receive(:debug?).and_return(true)
-  end
-
-  it "SimControl and Simctl return same simulators" do
-    from_sim_control = sim_control.simulators
-    from_simctl = simctl.simulators
-
-    # Devices are not object-equal with ==, so the best we can do here is
-    # check the simulator count.
-    expect(from_sim_control.count).to be == from_simctl.count
   end
 
   it "#shutdown" do


### PR DESCRIPTION
### Motivation

Jobs are being migrated from Xcode 7 to Xcode 8 on Jenkins.  As a result it is possible for an Xcode 8 job to leave the CoreSimulatorService in a bad state which will cause subsequent Xcode 7 jobs to fail.