### PR TITLE
Increase DeviceAgent timeouts

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -29,6 +29,7 @@ module RunLoop
       # For example:
       #
       # RunLoop::DeviceAgent::Client::DEFAULTS[:http_timeout] = 60
+      # RunLoop::DeviceAgent::Client::DEFAULTS[:device_agent_install_timeout] = 120
       DEFAULTS = {
         :port => 27753,
         :simulator_ip => "127.0.0.1",
@@ -37,7 +38,7 @@ module RunLoop
 
         # Ignored in the XTC.
         # This key is subject to removal or changes
-        :device_agent_install_timeout => RunLoop::Environment.ci? ? 120 : 60,
+        :device_agent_install_timeout => RunLoop::Environment.ci? ? 120 : 90,
         # This value must always be false on the XTC.
         # This is should only be used by gem maintainers or very advanced users.
         :shutdown_device_agent_before_launch => false

--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -33,7 +33,7 @@ module RunLoop
       DEFAULTS = {
         :port => 27753,
         :simulator_ip => "127.0.0.1",
-        :http_timeout => (RunLoop::Environment.ci? || RunLoop::Environment.xtc?) ? 120 : 10,
+        :http_timeout => (RunLoop::Environment.ci? || RunLoop::Environment.xtc?) ? 120 : 20,
         :route_version => "1.0",
 
         # Ignored in the XTC.


### PR DESCRIPTION
### Motivation

Users are complaining that DeviceAgent installs are timing out.

I added a documentation example of how to increase the install timeout:

```
# Add this to your features/support/env.rb
RunLoop::DeviceAgent::Client::DEFAULTS[:device_agent_install_timeout] = 120
```

and bumped the default timeout to 90 seconds.

We've noticed that DeviceAgent queries can take a very long time execute.

I bumped the default HTTP timeout to 20 seconds.