### PR TITLE
CODE_SIGN_IDENTITY is not longer required

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -107,23 +107,6 @@ module RunLoop
           code_sign_identity = RunLoop::Environment::code_sign_identity
         end
 
-        if device.physical_device? && cbx_launcher.name == :ios_device_manager
-          if !code_sign_identity
-            raise RuntimeError, %Q[
-Targeting a physical devices requires a code signing identity.
-
-Rerun your test with:
-
-$ CODE_SIGN_IDENTITY="iPhone Developer: Your Name (ABCDEF1234)" cucumber
-
-To see the valid code signing identities on your device run:
-
-$ xcrun security find-identity -v -p codesigning
-
-]
-          end
-        end
-
         install_timeout = options.fetch(:device_agent_install_timeout,
                                                      DEFAULTS[:device_agent_install_timeout])
         shutdown_before_launch = options.fetch(:shutdown_device_agent_before_launch,

--- a/lib/run_loop/device_agent/ios_device_manager.rb
+++ b/lib/run_loop/device_agent/ios_device_manager.rb
@@ -101,24 +101,21 @@ Expected :device_agent_install_timeout key in options:
 ]
           end
 
-          if !code_sign_identity
-            raise ArgumentError, %Q[
-Targeting a physical devices requires a code signing identity.
-
-Rerun your test with:
-
-$ CODE_SIGN_IDENTITY="iPhone Developer: Your Name (ABCDEF1234)" cucumber
-
-]
-          end
-
           options = {:log_cmd => true, :timeout => install_timeout}
-          args = [
-            cmd, "install",
-            "--device-id", device.udid,
-            "--app-bundle", runner.runner,
-            "--codesign-identity", code_sign_identity
-          ]
+          if code_sign_identity
+            args = [
+              cmd, "install",
+              "--device-id", device.udid,
+              "--app-bundle", runner.runner,
+              "--codesign-identity", code_sign_identity
+            ]
+          else
+            args = [
+              cmd, "install",
+              "--device-id", device.udid,
+              "--app-bundle", runner.runner
+            ]
+          end
 
           start = Time.now
           hash = run_shell_command(args, options)


### PR DESCRIPTION
### Motivation

iOSDeviceManager can find a CODE_SIGN_IDENTITY so there is no need to set this variable.

Setting CODE_SIGN_IDENTITY is still supported - if set, iOSDeviceManager will attempt to sign with the provided identity.