### PR TITLE
Stabilize Simulator examples on Jenkins

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -1280,13 +1280,18 @@ Please install it.
 
         retries = 5
 
+        # Launch arguments and environment arguments cannot be nil
+        # The public interface Client.run has a guard against this, but
+        # internal callers to do not.
+        aut_args = launcher_options.fetch(:aut_args, [])
+        aut_env = launcher_options.fetch(:aut_env, {})
         begin
           client = http_client(http_options)
           request = request("session",
                             {
                               :bundleID => bundle_id,
-                              :launchArgs => launcher_options[:aut_args],
-                              :environment => launcher_options[:aut_env]
+                              :launchArgs => aut_args,
+                              :environment => aut_env
                             })
           response = client.post(request)
           RunLoop.log_debug("Launched #{bundle_id} on #{device}")

--- a/spec/integration/simctl_spec.rb
+++ b/spec/integration/simctl_spec.rb
@@ -15,7 +15,7 @@ describe RunLoop::Simctl do
   end
 
   it "#wait_for_shutdown" do
-    expect(simctl.wait_for_shutdown(device, 1.0, 0)).to be_truthy
+    expect(simctl.wait_for_shutdown(device, 10.0, 0)).to be_truthy
   end
 
   it "handles the app life cycle" do


### PR DESCRIPTION
### Motivation

There are at least 2 flickering examples:

* rspec ./spec/integration/device_agent/client_spec.rb:44 # RunLoop::DeviceAgent::Client#launch ios_device_manager
* rspec ./spec/integration/simctl_spec.rb:17 # RunLoop::Simctl #wait_for_shutdown