### PR TITLE
Decouple simulator wait for stable state and CoreSim install and uninstall

### DIFF
--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -323,6 +323,7 @@ version: #{version}
 
     # @!visibility private
     def simulator_wait_for_stable_state
+      data_path = File.join(simulator_root_dir, 'data')
       required = simulator_required_child_processes
 
       timeout = SIM_STABLE_STATE_OPTIONS[:timeout]
@@ -330,8 +331,22 @@ version: #{version}
       poll_until = now + timeout
 
       RunLoop.log_debug("Waiting for simulator to stabilize with timeout: #{timeout} seconds")
+      footprint = RunLoop::Directory.size(data_path, :mb)
+
+      if version.major >= 9 && footprint < 18
+        first_launch = true
+      elsif version.major == 8
+        if version.minor >= 3 && footprint < 19
+          first_launch = true
+        else
+          first_launch = footprint < 11
+        end
+      else
+        first_launch = true
+      end
 
       while !required.empty? && Time.now < poll_until do
+        sleep(0.5)
         required = required.map do |process_name|
           if simulator_process_running?(process_name)
             nil
@@ -339,29 +354,15 @@ version: #{version}
             process_name
           end
         end.compact
-        sleep(0.5)
       end
 
-      is_stable = false
       if required.empty?
         elapsed = Time.now - now
         RunLoop.log_debug("All required simulator processes have started after #{elapsed}")
-        current_dir_sha = simulator_data_directory_sha
-        while Time.now < poll_until do
-          latest_dir_sha = simulator_data_directory_sha
-          is_stable = current_dir_sha == latest_dir_sha
-          if is_stable
-            RunLoop.log_debug("Simulator data directory has stabilized")
-            break
-          else
-            sleep(1.0)
-          end
+        if first_launch
+          sleep(RunLoop::Environment.ci? ? 10 : 5)
         end
-      end
-
-      if is_stable
-        elapsed = Time.now - now
-        RunLoop.log_debug("Waited a total of #{elapsed} seconds for simulator to stabilize")
+        RunLoop.log_debug("Waited for #{elapsed} seconds for simulator to stabilize")
       else
         RunLoop.log_debug("Timed out after #{timeout} seconds waiting for simulator to stabilize")
       end

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -322,8 +322,14 @@ version: #{version}
     end
 
     # @!visibility private
-    def simulator_wait_for_stable_state
+    # In megabytes
+    def simulator_size_on_disk
       data_path = File.join(simulator_root_dir, 'data')
+      RunLoop::Directory.size(data_path, :mb)
+    end
+
+    # @!visibility private
+    def simulator_wait_for_stable_state
       required = simulator_required_child_processes
 
       timeout = SIM_STABLE_STATE_OPTIONS[:timeout]
@@ -331,7 +337,7 @@ version: #{version}
       poll_until = now + timeout
 
       RunLoop.log_debug("Waiting for simulator to stabilize with timeout: #{timeout} seconds")
-      footprint = RunLoop::Directory.size(data_path, :mb)
+      footprint = simulator_size_on_disk
 
       if version.major >= 9 && footprint < 18
         first_launch = true

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -273,12 +273,7 @@ describe RunLoop::CoreSimulator do
 
       it 'launches the simulator and installs the app with simctl' do
         expect(core_sim).to receive(:app_is_installed?).and_return true
-        expect(core_sim).to receive(:launch_simulator).and_return true
-
-        timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:uninstall_app_timeout]
-        expect(core_sim.simctl).to receive(:uninstall).with(device, app, timeout).and_return(true)
-        expect(core_sim.device).to receive(:simulator_wait_for_stable_state).and_return true
-
+        expect(core_sim).to receive(:uninstall_app_with_simctl).and_return true
         expect(core_sim.uninstall_app_and_sandbox).to be_truthy
       end
     end
@@ -773,18 +768,6 @@ describe RunLoop::CoreSimulator do
 
         expect(core_sim.install).to be == '/new/path'
       end
-
-      it '#install_app_with_simctl' do
-        expect(core_sim).to receive(:launch_simulator).and_return true
-        timeout = RunLoop::CoreSimulator::DEFAULT_OPTIONS[:install_app_timeout]
-        expect(core_sim.simctl).to receive(:install).with(device, app, timeout).and_return(true)
-
-        expect(core_sim.device).to receive(:simulator_wait_for_stable_state)
-
-        expect(core_sim).to receive(:installed_app_bundle_dir).and_return('/new/path')
-
-        expect(core_sim.send(:install_app_with_simctl)).to be == '/new/path'
-      end
     end
 
     it "#launch_app_with_simctl" do
@@ -1046,18 +1029,11 @@ describe RunLoop::CoreSimulator do
       end
 
       it 'installs the new app' do
-        path = '/some/path'
         expect(core_sim).to receive(:installed_app_bundle_dir).and_return '/some/path'
         expect(core_sim.app).to receive(:sha1).and_return :a
         expect(core_sim).to receive(:installed_app_sha1).and_return :b
-
-        allow(FileUtils).to receive(:rm_rf).with(path).and_return true
-
-        args = ['ditto', app.path, '/some/CalSmoke-cal.app']
-        options = {:log_cmd => true}
-        expect(core_sim.xcrun).to receive(:run_command_in_context).with(args, options).and_return({})
-
-        expect(core_sim).to receive(:clear_device_launch_csstore).and_return true
+        expect(core_sim).to receive(:uninstall_app_with_simctl).and_return true
+        expect(core_sim).to receive(:install_app_with_simctl).and_return true
 
         expect(core_sim.send(:ensure_app_same)).to be_truthy
       end


### PR DESCRIPTION
### Motivation

The simulator wait for stable state no longer waits for the the SHA and the simulator log to stabilize.  Instead, it waits for `launchd_sim` to start critical simulator processes.  This means that CoreSimulator `install` and `uninstall` should not call `Device#simulator_wait_for_stable_state` because, by definition, the simulator must be stable before install/uninstall are called.

* A first launch check to `Device#simulator_wait_for_stable_state`.
* CoreSimulator install and uninstall wait for the _size_ of the simulator directory to match an expectation before proceeding.

