### PR TITLE
CoreSimulator relaunches the simulator if app state is not acceptable

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -520,7 +520,7 @@ Could not launch #{app.bundle_identifier} on #{device} after trying #{tries} tim
   def running_simulator_details
     process_name = "MacOS/#{sim_name}"
 
-    args = ["ps", "x", "-o", "pid,command"]
+    args = ["ps", "x", "-o", "pid=,command="]
     hash = run_shell_command(args)
 
     exit_status = hash[:exit_status]
@@ -546,7 +546,7 @@ Command had no output.
 }
     end
 
-    lines = hash[:out].split("\n")
+    lines = hash[:out].split($-0)
 
     match = lines.detect do |line|
       line[/#{process_name}/]
@@ -556,7 +556,7 @@ Command had no output.
 
     hash = {}
 
-    pid = match.split(" ").first.to_i
+    pid = match.split(" ").first.strip.to_i
     hash[:pid] = pid
 
     hash[:launched_by_run_loop] = match[/LAUNCHED_BY_RUN_LOOP/]

--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -318,28 +318,23 @@ class RunLoop::CoreSimulator
     @simctl ||= RunLoop::Simctl.new
   end
 
+  # @!visibility private
+  def simulator_requires_relaunch?
+    [simulator_state_requires_relaunch?,
+     running_apps_require_relaunch?].any?
+  end
+
   # Launch the simulator indicated by device.
   def launch_simulator(options={})
     merged_options = {
       :wait_for_stable => true
     }.merge(options)
 
-    running_sim_details = running_simulator_details
-
-    # Is there a running simulator?
-    if running_sim_details[:pid]
-      # Did we launch it?
-      if running_sim_details[:launched_by_run_loop]
-        # Is running simulator the correct simulator?
-        device.update_simulator_state
-        if device.state == "Booted"
-          # Nothing to do, we already launched the simulator.
-          return
-        end
-      end
+    if !simulator_requires_relaunch?
+      RunLoop.log_debug("Simulator is running and does not require a relaunch.")
+      return
     end
 
-    # We did not launch this simulator; quit it.
     RunLoop::CoreSimulator.quit_simulator
 
     args = ['open', '-g', '-a', sim_app_path, '--args',
@@ -453,6 +448,10 @@ Could not launch #{app.bundle_identifier} on #{device} after trying #{tries} tim
     uninstall_app_with_simctl
     true
   end
+
+=begin
+  PRIVATE METHODS
+=end
 
   private
 
@@ -671,6 +670,80 @@ Command had no output.
   # Xcode support is dropped.
   def sdk_gte_8?
     device.version >= RunLoop::Version.new('8.0')
+  end
+
+  # @!visibility private
+  def simulator_state_requires_relaunch?
+    running_sim_details = running_simulator_details
+
+    # Simulator is not running.
+    if !running_sim_details[:pid]
+      RunLoop.log_debug("Simulator relaunch required: simulator is not running.")
+      return true
+    end
+
+    # Simulator is running, but run-loop did not launch it.
+    if !running_sim_details[:launched_by_run_loop]
+      RunLoop.log_debug("Simulator relaunch required: simulator was not launched by run_loop")
+      return true
+    end
+
+    # Simulator is running, run_loop launched it, but it is not Booted.
+    device.update_simulator_state
+    if device.state == "Booted"
+      RunLoop.log_debug("Simulator relaunch not required: simulator has state 'Booted'")
+      false
+    else
+      RunLoop.log_debug("Simulator relaunch required: simulator does not have state 'Booted'")
+      true
+    end
+  end
+
+  # @!visibility private
+  def running_apps_require_relaunch?
+    running_apps = device.simulator_running_app_details
+
+    if running_apps.empty?
+      RunLoop.log_debug("Simulator relaunch not required: no running apps")
+      return false
+    end
+
+    # DeviceAgent is running, but it was launched by Xcode.
+    if running_apps["XCTRunner"]
+      if running_apps["XCTRunner"][:args][/CBX_LAUNCHED_BY_XCODE/]
+        RunLoop.log_debug("Simulator relaunch required: XCTRunner is controlled by Xcode")
+        return true
+      end
+    end
+
+    # AUT is running, but it was not launched by DeviceAgent.
+    app_name = app.executable_name
+    if running_apps[app_name]
+      launch_arg = RunLoop::DeviceAgent::Client::AUT_LAUNCHED_BY_RUN_LOOP_ARG
+      if !running_apps[app_name][:args][/#{launch_arg}/]
+        RunLoop.log_debug("Simulator relaunch required: AUT is running, but not launched by run-loop")
+        return true
+      end
+    end
+
+    # This is the UITest behavior.  UITest does not inspect the simulator for
+    # system apps that are running - it only checks for running user apps.
+    #
+    # I don't think this condition is necessary, so we'll skip it for now, but
+    # capture there is a difference between UITest and run-loop.
+    #
+    # There is some other application running on the simulator.
+    # running_apps.delete("XCTRunner")
+    # running_apps.delete(app_name)
+    #
+    # if running_apps.empty?
+    #   RunLoop.log_debug("Simulator relaunch not required: only XCTRunner and AUT are running")
+    #   false
+    # else
+    #   RunLoop.log_debug("Simulator relaunch required: other applications are running")
+    #   true
+    # end
+    false
   end
 
   # The data directory for the the device.

--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -50,6 +50,8 @@ module RunLoop
         :characters_per_second => 12
       }
 
+      AUT_LAUNCHED_BY_RUN_LOOP_ARG = "LAUNCHED_BY_RUN_LOOP"
+
       # @!visibility private
       #
       # These defaults may change at any time.
@@ -121,6 +123,10 @@ module RunLoop
                                                DEFAULTS[:shutdown_device_agent_before_launch])
         aut_args = options.fetch(:args, [])
         aut_env = options.fetch(:env, {})
+
+        if !aut_args.include?(AUT_LAUNCHED_BY_RUN_LOOP_ARG)
+          aut_args << AUT_LAUNCHED_BY_RUN_LOOP_ARG
+        end
 
         launcher_options = {
             code_sign_identity: code_sign_identity,

--- a/lib/run_loop/process_waiter.rb
+++ b/lib/run_loop/process_waiter.rb
@@ -9,6 +9,22 @@ module RunLoop
 
     attr_reader :process_name
 
+    # Return a list of pids by matching `match_string` against the command
+    # and full argument list of the command.  As the name suggests, this
+    # method uses `pgrep -f`.
+    #
+    # @param match_string the string to match against
+    # @return Array[Integer] an array of pids
+    def self.pgrep_f(match_string)
+      cmd = ["pgrep", "-f", match_string]
+      hash = RunLoop::Shell.run_shell_command(cmd)
+
+      out = hash[:out]
+      return [] if out.nil? || out == ""
+
+      out.split($-0).map { |pid| pid.to_i }
+    end
+
     def initialize(process_name, options={})
       @options = DEFAULT_OPTIONS.merge(options)
       @process_name = process_name

--- a/spec/integration/core_simulator_spec.rb
+++ b/spec/integration/core_simulator_spec.rb
@@ -124,5 +124,30 @@ describe RunLoop::CoreSimulator do
       expect(actual).to be_falsey
     end
   end
-end
 
+  context "#simulator_state_requires_relaunch?" do
+    let (:sim_details) { {} }
+
+    before do
+      RunLoop::CoreSimulator.quit_simulator
+    end
+
+    it "returns true if the simulator is not running" do
+      RunLoop::CoreSimulator.quit_simulator
+      expect(core_sim.send(:simulator_state_requires_relaunch?)).to be_truthy
+    end
+
+    it "returns true if the simulator was not launched by run_loop" do
+      args = ['open', '-g', '-a', core_sim.send(:sim_app_path)]
+      pid = Process.spawn('xcrun', *args)
+      Process.detach(pid)
+
+      options = { :timeout => 5, :raise_on_timeout => true }
+      RunLoop::ProcessWaiter.new(core_sim.send(:sim_name), options).wait_for_any
+
+      core_sim.device.simulator_wait_for_stable_state
+
+      expect(core_sim.send(:simulator_state_requires_relaunch?)).to be_truthy
+    end
+  end
+end

--- a/spec/integration/device_spec.rb
+++ b/spec/integration/device_spec.rb
@@ -1,0 +1,53 @@
+describe RunLoop::Device do
+
+  before do
+    allow(RunLoop::Environment).to receive(:debug?).and_return(true)
+  end
+
+  let(:device) { Resources.shared.default_simulator }
+  let(:prefs_identifier) { "com.apple.Preferences" }
+  let(:aut) { RunLoop::App.new(Resources.shared.app_bundle_path) }
+  let(:core_sim) { RunLoop::CoreSimulator.new(device, aut) }
+
+  before do
+    RunLoop::CoreSimulator.quit_simulator
+    RunLoop::Simctl.new.wait_for_shutdown(device, 30, 0.1)
+  end
+
+  context "#simulator_running_app_details" do
+    it "detects the XCTRunner, AUT, and other apps" do
+      core_sim.install
+
+      aut_args = ["ARG0", "YES", "ARG1", "NO", "ARG_EXISTS"]
+
+      cbx_launcher = RunLoop::DeviceAgent::IOSDeviceManager.new(device)
+      client = RunLoop::DeviceAgent::Client.new(aut.bundle_identifier,
+                                                device, cbx_launcher,
+                                                {aut_args: aut_args})
+      client.launch
+
+      options = { :raise_on_timeout => true, :timeout => 5 }
+      RunLoop::ProcessWaiter.new(aut.executable_name, options).wait_for_any
+
+      if RunLoop::Environment.ci?
+        sleep(5)
+      else
+        sleep(1)
+      end
+
+      running_apps = device.simulator_running_app_details
+      expect(running_apps.count).to be >= 2
+
+      expect(running_apps["XCTRunner"]).to be_truthy
+      expect(running_apps["XCTRunner"][:args]).not_to be == ""
+      expect(running_apps[aut.executable_name]).to be_truthy
+      actual = running_apps[aut.executable_name][:args]
+      expect(actual).to be == aut_args.join(" ")
+
+      client.launch_other_app("com.apple.Preferences")
+
+      running_apps = device.simulator_running_app_details
+      expect(running_apps["Preferences"]).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

Now that simulators are not always relaunched, we need to detect states where the simulator _must_ be relaunched to ensure stability.


* If the DeviceAgent is running, but was launched by Xcode - relaunch.
* If the AUT is running, but not launched by run-loop - relaunch.  The assumption is that the AUT is attached to Xcode somehow.

