### PR TITLE
Allow user to force simulator relaunch when running with DeviceAgent

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -807,8 +807,8 @@ $ xcrun instruments -s templates
       # Validate the architecture.
       self.expect_simulator_compatible_arch(device, app)
 
-      # Quits the simulator.
-      core_sim = RunLoop::CoreSimulator.new(device, app, :xcode => xcode)
+      RunLoop::CoreSimulator.quit_simulator
+      core_sim = RunLoop::CoreSimulator.new(device, app, xcode: xcode)
 
       # Calabash 0.x can only reset the app sandbox (true/false).
       # Calabash 2.x has advanced reset options.
@@ -816,13 +816,11 @@ $ xcrun instruments -s templates
         core_sim.reset_app_sandbox
       end
 
-      # Will quit the simulator if it is running.
       # @todo fix accessibility_enabled? so we don't have to quit the sim
       # SimControl#accessibility_enabled? is always false during Core#prepare_simulator
       # https://github.com/calabash/run_loop/issues/167
       simctl.ensure_accessibility(device)
 
-      # Will quit the simulator if it is running.
       # @todo fix software_keyboard_enabled? so we don't have to quit the sim
       # SimControl#software_keyboard_enabled? is always false during Core#prepare_simulator
       # https://github.com/calabash/run_loop/issues/168

--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -1043,7 +1043,7 @@ Command had no output.
 
   # @!visibility private
   def self.user_app_installed?(device, bundle_identifier)
-    core_sim = self.new(device, bundle_identifier, {:quit_sim_on_init => false})
+    core_sim = self.new(device, bundle_identifier)
     sim_apps_dir = core_sim.send(:device_applications_dir)
     Dir.glob("#{sim_apps_dir}/**/*.app").find do |path|
       RunLoop::App.new(path).bundle_identifier == bundle_identifier

--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -95,12 +95,19 @@ module RunLoop
         default_options = {
             :xcode => xcode
         }
+
         merged_options = default_options.merge(options)
 
         if device.simulator? && app
           RunLoop::Core.expect_simulator_compatible_arch(device, app)
 
+          if merged_options[:relaunch_simulator]
+            RunLoop.log_debug("Detected :relaunch_simulator option; will force simulator to restart")
+            RunLoop::CoreSimulator.quit_simulator
+          end
+
           core_sim = RunLoop::CoreSimulator.new(device, app, merged_options)
+
           if reset_options
             core_sim.reset_app_sandbox
           end

--- a/lib/run_loop/device_agent/ios_device_manager.rb
+++ b/lib/run_loop/device_agent/ios_device_manager.rb
@@ -94,8 +94,7 @@ but binary does not exist at that path.
         if device.simulator?
           cbxapp = RunLoop::App.new(runner.runner)
 
-          # Quits the simulator if CoreSimulator is not already in control of it.
-          sim = CoreSimulator.new(device, cbxapp, {:quit_sim_on_init => false})
+          sim = CoreSimulator.new(device, cbxapp)
           sim.install
           sim.launch_simulator
         else

--- a/spec/integration/core_simulator_spec.rb
+++ b/spec/integration/core_simulator_spec.rb
@@ -9,6 +9,7 @@ describe RunLoop::CoreSimulator do
   end
 
   before do
+    RunLoop::CoreSimulator.quit_simulator
     allow(RunLoop::Environment).to receive(:debug?).and_return true
   end
 

--- a/spec/integration/device_spec.rb
+++ b/spec/integration/device_spec.rb
@@ -1,15 +1,12 @@
 describe RunLoop::Device do
 
-  before do
-    allow(RunLoop::Environment).to receive(:debug?).and_return(true)
-  end
-
   let(:device) { Resources.shared.default_simulator }
   let(:prefs_identifier) { "com.apple.Preferences" }
   let(:aut) { RunLoop::App.new(Resources.shared.app_bundle_path) }
   let(:core_sim) { RunLoop::CoreSimulator.new(device, aut) }
 
   before do
+    allow(RunLoop::Environment).to receive(:debug?).and_return(true)
     RunLoop::CoreSimulator.quit_simulator
     RunLoop::Simctl.new.wait_for_shutdown(device, 30, 0.1)
   end

--- a/spec/integration/dylib_injector_spec.rb
+++ b/spec/integration/dylib_injector_spec.rb
@@ -10,7 +10,7 @@ if Resources.shared.core_simulator_env?
     let(:injector) { RunLoop::DylibInjector.new(app.executable_name, dylib) }
 
     before do
-      stub_env({'DEBUG' => '1'})
+      allow(RunLoop::Environment).to receive(:debug?).and_return(true)
       RunLoop::CoreSimulator.quit_simulator
     end
 

--- a/spec/integration/run_sim_spec.rb
+++ b/spec/integration/run_sim_spec.rb
@@ -1,5 +1,10 @@
 describe RunLoop do
 
+  before do
+    allow(RunLoop::Environment).to receive(:debug?).and_return(true)
+    RunLoop::CoreSimulator.quit_simulator
+  end
+
   describe 'run on simulator' do
     it "Xcode #{Resources.shared.current_xcode_version}" do
       options =

--- a/spec/integration/simctl_spec.rb
+++ b/spec/integration/simctl_spec.rb
@@ -8,6 +8,7 @@ describe RunLoop::Simctl do
 
   before do
     allow(RunLoop::Environment).to receive(:debug?).and_return(true)
+    RunLoop::CoreSimulator.quit_simulator
   end
 
   it "#shutdown" do


### PR DESCRIPTION
### Motivation

Starting in run-loop 2.3.0, the Simulator will not be relaunch automatically before the start of each test.  Many users have requested this feature.  For some users, however, this will introduce instability to their test runs. 

To provide backward compatibility, we've decided that  UIAutomation runs will continue to relaunch the simulator whenever `Calabash::Cucumber::Launcher#relaunch` is called.  DeviceAgent runs will try to keep the simulator running whenever possible.  Users can override this behavior and force the simulator to be relaunched by calling `Calabash::Cucumber::Launcher#relaunch` with the `:relaunch_simulator => true` option.

If users want similar behavior for UIAutomation runs, we can discuss adding it in run-loop 2.3.1.
