### PR TITLE
Improve Device#simulator_wait_for_stable_state for iOS <= 8 and iOS >= 10.1

### DIFF
--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -31,7 +31,7 @@ module RunLoop
       # exceeded - if the default 30 seconds has passed, the
       # simulator is probably stable enough for subsequent
       # operations.
-      :timeout => RunLoop::Environment.ci? ? 120 : 30
+      :timeout => RunLoop::Environment.ci? ? 240 : 120
     }
 
     attr_reader :name

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -596,7 +596,7 @@ failed with this output:
     def simulator_required_child_processes
       @simulator_required_child_processes ||= begin
         required = ["backboardd", "installd", "SimulatorBridge", "SpringBoard"]
-        if xcode.version_gte_8?
+        if xcode.version_gte_8? && version.major > 8
           required << "medialibraryd"
         end
 

--- a/spec/lib/device_spec.rb
+++ b/spec/lib/device_spec.rb
@@ -3,9 +3,9 @@ describe RunLoop::Device do
   describe "SIM_STABLE_STATE_OPTIONS" do
     it ":timeout" do
       if RunLoop::Environment.ci?
-        expected = 120
+        expected = 240
       else
-        expected = 30
+        expected = 120
       end
 
       actual = RunLoop::Device::SIM_STABLE_STATE_OPTIONS[:timeout]


### PR DESCRIPTION
### Motivation

While testing, I discovered two phenomena:

1.  iOS <= 8 Simulators were always waiting the full 30 seconds for the simulator to become stable and
2. iOS >= 10.1 Simulators take longer than 30 seconds to fully boot after an erase.

The first problem was fixed by filtering the list of required processes by iOS version.

The default sim stable timeouts have been changed to 240 seconds for CI and 120 seconds locally.   Testing shows that on a reasonably fast machine with encryption enabled, it takes ~70 seconds to boot an iOS 10.1 simulator.  🎱 




