### PR TITLE
Directory: rescue errors during skip check and File.size

### DIFF
--- a/lib/run_loop/directory.rb
+++ b/lib/run_loop/directory.rb
@@ -73,11 +73,11 @@ found '#{handle_errors_by}'
 
          #{e}
 
-       while trying to find the SHA of this file:
+while trying to find the SHA of this file:
 
          #{file}
 
-       This is not a fatal error; it can be ignored.
+This is not a fatal error; it can be ignored.
 }
               RunLoop.log_debug(message)
             when :raising
@@ -135,32 +135,37 @@ found '#{handle_errors_by}'
 
     def self.skip_file?(file, task, debug)
       skip = false
-      if File.directory?(file)
-        # Skip directories
-        skip = true
-      elsif !Pathname.new(file).exist?
-        # Skip broken symlinks
-        skip = true
-      elsif !File.exist?(file)
-        # Skip files that don't exist
-        skip = true
-      else
-        case File.ftype(file)
-          when 'fifo'
-            RunLoop.log_warn("#{task} IS SKIPPING FIFO #{file}") if debug
-            skip = true
-          when 'socket'
-            RunLoop.log_warn("#{task} IS SKIPPING SOCKET #{file}") if debug
-            skip = true
-          when 'characterSpecial'
-            RunLoop.log_warn("#{task} IS SKIPPING CHAR SPECIAL #{file}") if debug
-            skip = true
-          when 'blockSpecial'
-            skip = true
-            RunLoop.log_warn("#{task} SKIPPING BLOCK SPECIAL #{file}") if debug
-          else
-
+      begin
+        if File.directory?(file)
+          # Skip directories
+          skip = true
+        elsif !Pathname.new(file).exist?
+          # Skip broken symlinks
+          skip = true
+        elsif !File.exist?(file)
+          # Skip files that don't exist
+          skip = true
+        else
+          case File.ftype(file)
+            when 'fifo'
+              RunLoop.log_warn("#{task} IS SKIPPING FIFO #{file}") if debug
+              skip = true
+            when 'socket'
+              RunLoop.log_warn("#{task} IS SKIPPING SOCKET #{file}") if debug
+              skip = true
+            when 'characterSpecial'
+              RunLoop.log_warn("#{task} IS SKIPPING CHAR SPECIAL #{file}") if debug
+              skip = true
+            when 'blockSpecial'
+              skip = true
+              RunLoop.log_warn("#{task} SKIPPING BLOCK SPECIAL #{file}") if debug
+            else
+          end
         end
+      rescue => e
+        skip = true
+        RunLoop.log_debug("Directory.skip_file? rescued an ignorable error.")
+        RunLoop.log_debug("#{e.class}: #{e.message}")
       end
       skip
     end
@@ -170,7 +175,12 @@ found '#{handle_errors_by}'
       size = 0
       entries.each do |file|
         unless self.skip_file?(file, "SIZE", debug)
-          size = size + File.size(file)
+          begin
+            size = size + File.size(file)
+          rescue => e
+            RunLoop.log_debug("Directory.iterate_for_size? rescued an ignorable error.")
+            RunLoop.log_debug("#{e.class}: #{e.message}")
+          end
         end
       end
       size


### PR DESCRIPTION
### Motivation

Occasionally `File.size` or the `Directory.skip_file?` check raises `Errno::ENOENT` errors.  We can safely ignore this error and other errors.

Replaces #597