### PR TITLE
Resolve issue #599 - Fix broken launch of iOS Simulator with RESET_BETWEEN_SCENARIOS enabled

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -101,7 +101,7 @@ module RunLoop
         if device.simulator? && app
           RunLoop::Core.expect_simulator_compatible_arch(device, app)
 
-          if merged_options[:relaunch_simulator]
+          if merged_options[:relaunch_simulator] || reset_options
             RunLoop.log_debug("Detected :relaunch_simulator option; will force simulator to restart")
             RunLoop::CoreSimulator.quit_simulator
           end


### PR DESCRIPTION
Resolve issue #599

Fix bug with RuntimeError: Expected 'Shutdown but found 'Booted' after waiting while running iOS Simulator with env variable RESET_BETWEEN_SCENARIOS=1

```
DEBUG: Waited for 30.074818 seconds for device to have state: 'Shutdown'.

RuntimeError: Expected 'Shutdown but found 'Booted' after waiting.
/Users/here/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/run_loop-2.3.0/lib/run_loop/core_simulator.rb:190:in `wait_for_simulator_state'
/Users/here/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/run_loop-2.3.0/lib/run_loop/core_simulator.rb:463:in `reset_app_sandbox'
/Users/here/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/run_loop-2.3.0/lib/run_loop/device_agent/client.rb:112:in `run'
/Users/here/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/run_loop-2.3.0/lib/run_loop.rb:113:in `run'
/Users/here/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/calabash-cucumber-0.20.4/lib/calabash-cucumber/launcher.rb:408:in `block in new_run_loop'
/Users/here/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/calabash-cucumber-0.20.4/lib/calabash-cucumber/launcher.rb:406:in `times'
/Users/here/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/calabash-cucumber-0.20.4/lib/calabash-cucumber/launcher.rb:406:in `new_run_loop'
/Users/here/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/calabash-cucumber-0.20.4/lib/calabash-cucumber/launcher.rb:365:in `relaunch'
/Users/here/ios_e2e/iOSCompanionApp_native/e2e-tests/features/support/01_launch.rb:26:in `Before'
```

Also resolve similar issues that was created recently (few days ago) in [calabash-ios](https://github.com/calabash/calabash-ios/) project:
calabash/calabash-ios#1269
calabash/calabash-ios#1270