### PR TITLE
Prepare for Xcode 8.3 support

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -320,7 +320,9 @@ Logfile: #{log_file}
     #  version.
     def self.default_simulator(xcode=RunLoop::Xcode.new)
 
-      if xcode.version_gte_82?
+      if xcode.version_gte_83?
+        "iPhone 7 (10.3)"
+      elsif xcode.version_gte_82?
         "iPhone 7 (10.2)"
       elsif xcode.version_gte_81?
         "iPhone 7 (10.1)"

--- a/lib/run_loop/xcode.rb
+++ b/lib/run_loop/xcode.rb
@@ -24,6 +24,14 @@ module RunLoop
       to_s
     end
 
+    # Returns a version instance for Xcode 8.3 ; used to check for the
+    # availability of features and paths to various items on the filesystem
+    #
+    # @return [RunLoop::Version] 8.3
+    def v83
+      fetch_version(:v83)
+    end
+
     # Returns a version instance for Xcode 8.2 ; used to check for the
     # availability of features and paths to various items on the filesystem
     #
@@ -134,6 +142,13 @@ module RunLoop
     # @return [RunLoop::Version] 5.0
     def v50
       fetch_version(:v50)
+    end
+
+    # Is the active Xcode version 8.3 or above?
+    #
+    # @return [Boolean] `true` if the current Xcode version is >= 8.3
+    def version_gte_83?
+      version >= v83
     end
 
     # Is the active Xcode version 8.2 or above?

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -268,6 +268,12 @@ describe RunLoop::Core do
       expect(xcode).to receive(:version).at_least(:once).and_return xcode.v82
       expect(RunLoop::Core.default_simulator(xcode)).to be == expected
     end
+
+    it 'Xcode >= 8.3' do
+      expected = 'iPhone 7 (10.3)'
+      expect(xcode).to receive(:version).at_least(:once).and_return xcode.v83
+      expect(RunLoop::Core.default_simulator(xcode)).to be == expected
+    end
   end
 
   describe '.above_or_eql_version?' do

--- a/spec/lib/xcode_spec.rb
+++ b/spec/lib/xcode_spec.rb
@@ -56,6 +56,7 @@ describe RunLoop::Xcode do
     expect(xcode.send(:fetch_version, key)).to be == version
   end
 
+  it '#v83' do expect(xcode.v83).to be == RunLoop::Version.new('8.3') end
   it '#v82' do expect(xcode.v82).to be == RunLoop::Version.new('8.2') end
   it '#v81' do expect(xcode.v81).to be == RunLoop::Version.new('8.1') end
   it '#v80' do expect(xcode.v80).to be == RunLoop::Version.new('8.0') end
@@ -70,6 +71,20 @@ describe RunLoop::Xcode do
   it '#v60' do expect(xcode.v60).to be == RunLoop::Version.new('6.0') end
   it '#v51' do expect(xcode.v51).to be == RunLoop::Version.new('5.1') end
   it '#v50' do expect(xcode.v50).to be == RunLoop::Version.new('5.0') end
+
+  describe "#version_gte_83?" do
+    it "true" do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new("8.3"))
+
+      expect(xcode.version_gte_83?).to be_truthy
+    end
+
+    it "false" do
+      expect(xcode).to receive(:version).and_return xcode.v82
+
+      expect(xcode.version_gte_83?).to be_falsey
+    end
+  end
 
   describe "#version_gte_82?" do
     it "true" do


### PR DESCRIPTION
### Motivation

Xcode 8.3 beta 3 is out.

The DeviceAgent stack is not ready for Xcode 8.3.

