### PR TITLE
DeviceAgent::Client: skip ensure software keyboard check

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -112,7 +112,6 @@ module RunLoop
             core_sim.reset_app_sandbox
           end
 
-          simctl.ensure_software_keyboard(device)
           core_sim.install
         end
 


### PR DESCRIPTION
### Motivation

This check quits the simulator and defeats the purpose of **CoreSim: quit simulator only when necessary** #580

Thanks @JoeSSS for reporting and diagnosing.