### PR TITLE
CoreSim: quit simulator if before resetting app sandbox

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -460,6 +460,7 @@ Could not launch #{app.bundle_identifier} on #{device} after trying #{tries} tim
   def reset_app_sandbox
     return true if !app_is_installed?
 
+    RunLoop::CoreSimulator.quit_simulator
     RunLoop::CoreSimulator.wait_for_simulator_state(device, "Shutdown")
 
     reset_app_sandbox_internal


### PR DESCRIPTION
### Motivation

Resolves:

* [iOS Simulator] RuntimeError: Expected 'Shutdown but found 'Booted' after waiting #599
* Error - Expected 'Shutdown but found 'Booted' after waiting [#1270](https://github.com/calabash/calabash-ios/issues/1270)

Supersedes:

* Resolve issue #599 - Fix broken launch of iOS Simulator with RESET_BETWEEN_SCENARIOS enabled #600