### PR TITLE
Xcode#version returns 0.0.0 on XTC on RuntimeErrors

### DIFF
--- a/spec/integration/xcode_spec.rb
+++ b/spec/integration/xcode_spec.rb
@@ -2,22 +2,6 @@ describe RunLoop::Xcode do
 
   let(:xcode) { RunLoop::Xcode.new }
 
-  it '#version' do
-    stdout = %q(
-Xcode 7.0.1
-Build version 7A192o
-)
-    yielded = [StringIO.new(stdout), StringIO.new(''), nil]
-    expect(xcode).to receive(:execute_command).with(['-version']).and_yield(*yielded)
-
-    expected = RunLoop::Version.new('7.0.1')
-    expect(xcode.version).to be == expected
-    expect(xcode.instance_variable_get(:@xcode_version)).to be == expected
-
-    #Testing memoization
-    expect(xcode.version).to be == expected
-  end
-
   it '#xcode_select_path' do
     path = xcode.send(:xcode_select_path)
     expect(Dir.exist?(path)).to be_truthy

--- a/spec/lib/run_loop_spec.rb
+++ b/spec/lib/run_loop_spec.rb
@@ -49,7 +49,7 @@ describe RunLoop do
     context "not XTC" do
 
       before do
-        expect(RunLoop::Environment).to receive(:xtc?).and_return(false)
+        expect(RunLoop::Environment).to receive(:xtc?).at_least(:once).and_return(false)
       end
 
       context "Xcode >= 8" do
@@ -101,7 +101,7 @@ describe RunLoop do
     context "not XTC" do
 
       before do
-        expect(RunLoop::Environment).to receive(:xtc?).and_return(false)
+        expect(RunLoop::Environment).to receive(:xtc?).at_least(:once).and_return(false)
       end
 
       context ":automator defined" do


### PR DESCRIPTION
### Motivation

Xcode#to_s is raising errors on Test Cloud.

Progress on:

* https://github.com/xamarin/test-cloud-frontend/issues/2628

