### PR TITLE
JS: add VPN definition to on_alert

### DIFF
--- a/scripts/lib/on_alert.js
+++ b/scripts/lib/on_alert.js
@@ -43,7 +43,8 @@ function englishLocalizations() {
     ["OK", /Would Like to Access Your Motion & Fitness Activity/],
     ["OK", /Would Like Access to Twitter Accounts/],
     ["OK", /data available to nearby bluetooth devices/],
-    ["OK", /[Ww]ould [Ll]ike to [Ss]end [Yy]ou( Push)? Notifications/]
+    ["OK", /[Ww]ould [Ll]ike to [Ss]end [Yy]ou( Push)? Notifications/],
+    ["Allow", /Would Like to Add VPN Configurations/]
   ];
 }
 


### PR DESCRIPTION
### Motivation

Resolves:

* calabash should automatically accept new VPN configurations [#1279](https://github.com/calabash/calabash-ios/issues/1279)
