### PR TITLE
API for managing SpringBoard alerts manually

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -592,6 +592,19 @@ Could not dismiss SpringBoard alert by touching button with title '#{button_titl
         true
       end
 
+      # @!visibility private
+      def set_dismiss_springboard_alerts_automatically(true_or_false)
+        if ![true, false].include?(true_or_false)
+          raise ArgumentError, "Expected #{true_or_false} to be a boolean true or false"
+        end
+
+        parameters = { :dismiss_automatically => true_or_false }
+        request = request("set-dismiss-springboard-alerts-automatically", parameters)
+        client = http_client(http_options)
+        response = client.post(request)
+        hash = expect_300_response(response)
+        hash["is_dismissing_alerts_automatically"]
+      end
 
       # @!visibility private
       # @see #query

--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -564,8 +564,7 @@ Query must contain at least one of these keys:
         request = request("springboard-alert")
         client = http_client(http_options)
         response = client.get(request)
-        hash = expect_300_response(response)
-        hash["result"]
+        expect_300_response(response)
       end
 
       # @!visibility private

--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -837,6 +837,20 @@ Timed out after #{timeout} seconds waiting for an alert to appear.
       end
 
       # @!visibility private
+      def wait_for_springboard_alert(timeout=WAIT_DEFAULTS[:timeout])
+        options = WAIT_DEFAULTS.dup
+        options[:timeout] = timeout
+        message = %Q[
+
+Timed out after #{timeout} seconds waiting for a SpringBoard alert to appear.
+
+]
+        wait_for(message, options) do
+          springboard_alert_visible?
+        end
+      end
+
+      # @!visibility private
       def wait_for_no_alert(timeout=WAIT_DEFAULTS[:timeout])
         options = WAIT_DEFAULTS.dup
         options[:timeout] = timeout
@@ -848,6 +862,20 @@ Timed out after #{timeout} seconds waiting for an alert to disappear.
 
         wait_for(message, options) do
           !alert_visible?
+        end
+      end
+
+      # @!visibility private
+      def wait_for_no_springboard_alert(timeout=WAIT_DEFAULTS[:timeout])
+        options = WAIT_DEFAULTS.dup
+        options[:timeout] = timeout
+        message = %Q[
+
+Timed out after #{timeout} seconds waiting for a SpringBoard alert to disappear.
+
+]
+        wait_for(message, options) do
+          !springboard_alert_visible?
         end
       end
 

--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -574,6 +574,26 @@ Query must contain at least one of these keys:
       end
 
       # @!visibility private
+      def dismiss_springboard_alert(button_title)
+        parameters = { :button_title => button_title }
+        request = request("dismiss-springboard-alert", parameters)
+        client = http_client(http_options)
+        response = client.post(request)
+        hash = expect_300_response(response)
+
+        if hash["error"]
+          raise RuntimeError, %Q[
+Could not dismiss SpringBoard alert by touching button with title '#{button_title}':
+
+#{hash["error"]}
+
+]
+        end
+        true
+      end
+
+
+      # @!visibility private
       # @see #query
       def query_for_coordinate(uiquery)
         element = wait_for_view(uiquery)


### PR DESCRIPTION
### Motivation

Completes:

* Allow users to interact with SpringBoard alerts [TCFW 907](https://jira.xamarin.com/browse/TCFW-907)
* Possibility to ignore system level alert views #66

Progress on:

* Allow Users to Accept "Open In" Alerts [TCFW 1081](https://jira.xamarin.com/browse/TCFW-907)

### API


```
# Control whether or not SpringBoard alerts are dismissed automatically or manually.
set_dismiss_springboard_alerts_automatically(true_or_false)

# Detecting and inspecting SpringBoard alerts
springboard_alert_visible?
springboard_alert
wait_for_springboard_alert
wait_for_no_springboard_alert

# Dismiss topmost SpringBoard alert by touching button with title.
dismiss_springboard_alert(button_title)
```

### Test

Tested against changes in DeviceAgent:

*  Allow users to interact with SpringBoard alerts and control automatic dismissal  [#205](https://github.com/calabash/DeviceAgent.iOS/pull/205)

```
$ be cucumber -t @springboard_alerts

@meta
Feature: Meta Routes

  @springboard @springboard_alerts
  Scenario: SpringBoard alerts                                           
    Given the app has launched                                          
    Then I can tell DeviceAgent not to automatically dismiss SpringBoard alerts
    Then I can tell DeviceAgent to automatically dismiss SpringBoard alerts     

@simulator @springboard_alerts
Feature: Interacting with SpringBoard Alerts

  Background: Navigate to Alerts and Sheets page   
    Given the app has launched                     
    And I am looking at the Misc tab              
    And I am looking at the Alerts and Sheets page 

  @reset_device
  Scenario: Auto-dismiss contacts                       
    When DeviceAgent is dismissing alerts automatically 
    When I touch the Contacts row                       
    Then the Contacts Privacy alert appears        
    And the next query dismisses the alert           
    When I touch the Calendar row                       
    Then the Calendar Privacy alert appears        
    And the next gesture dismisses the alert       

  @reset_device
  Scenario: Dismiss Alerts Manually         
    When DeviceAgent is not dismissing alerts automatically
    When I touch the Reminders row                       
    Then the Reminders Privacy alert appears        
    And the next query does not dismiss the alert  
    And the next gesture does not dismiss the alert 
    But I can dismiss the SpringBoard alert by touching OK 
```