### PR TITLE
Migrate ~/.run-loop/xcuittest to ~/.run-loop/DeviceAgent to ensure xctestrun run exists

### DIFF
--- a/lib/run_loop/device_agent/ios_device_manager.rb
+++ b/lib/run_loop/device_agent/ios_device_manager.rb
@@ -142,7 +142,7 @@ Could not install #{runner.runner}.  iOSDeviceManager says:
         args = ["xcodebuild", "test-without-building",
                 "-xctestrun", path_to_xctestrun(device),
                 "-destination", "id=#{device.udid}",
-                "-derivedDataPath", derived_data_directory]
+                "-derivedDataPath", Xcodebuild.derived_data_directory]
 
         log_file = IOSDeviceManager.log_file
         FileUtils.rm_rf(log_file)
@@ -213,12 +213,6 @@ iOSDeviceManager says:
           end
           path
         end
-      end
-
-      def derived_data_directory
-        path = File.join(RunLoop::DotDir.directory, "xcuitest", "DerivedData")
-        FileUtils.mkdir_p(path) if !File.exist?(path)
-        path
       end
     end
   end

--- a/lib/run_loop/device_agent/ios_device_manager.rb
+++ b/lib/run_loop/device_agent/ios_device_manager.rb
@@ -75,10 +75,23 @@ but binary does not exist at that path.
       #
       # ~/.calabash/iOSDeviceManager/logs/current.log
       #
-      # There is still occasional output to ~/.run-loop.
+      # Starting in run-loop 2.4.0, iOSDeviceManager start_test was replaced
+      # by xcodebuild test-without-building.   This change causes a name
+      # conflict: there is already an xcodebuild launcher with a log file
+      # ~/.run-loop/DeviceAgent/xcodebuild.log.
+      #
+      # The original xcodebuild launcher requires access to the DeviceAgent
+      # Xcode project which is not yet available to the public.
+      #
+      # Using `current.log` seems to make sense because the file is recreated
+      # for every call to `#launch`.
       def self.log_file
-        path = File.join(LauncherStrategy.dot_dir, "ios-device-manager.log")
+        path = File.join(LauncherStrategy.dot_dir, "current.log")
         FileUtils.touch(path) if !File.exist?(path)
+        legacy_path = File.join(LauncherStrategy.dot_dir, "ios-device-manager.log")
+        if File.exist?(legacy_path)
+          FileUtils.rm_rf(legacy_path)
+        end
         path
       end
 

--- a/lib/run_loop/device_agent/launcher_strategy.rb
+++ b/lib/run_loop/device_agent/launcher_strategy.rb
@@ -46,12 +46,17 @@ DeviceAgent is only available for iOS >= 9.0
 
       # @!visibility private
       def self.dot_dir
-        path = File.join(RunLoop::DotDir.directory, "xcuitest")
+        path = File.join(RunLoop::DotDir.directory, "DeviceAgent")
+        legacy_path = File.join(RunLoop::DotDir.directory, "xcuitest")
 
-        if !File.exist?(path)
-          FileUtils.mkdir_p(path)
+        if File.directory?(legacy_path)
+          FileUtils.cp_r(legacy_path, path)
+          FileUtils.rm_rf(legacy_path)
+        else
+          if !File.exist?(path)
+            FileUtils.mkdir_p(path)
+          end
         end
-
         path
       end
     end

--- a/lib/run_loop/device_agent/xcodebuild.rb
+++ b/lib/run_loop/device_agent/xcodebuild.rb
@@ -15,6 +15,13 @@ module RunLoop
       end
 
       # @!visibility private
+      def self.derived_data_directory
+        path = File.join(Xcodebuild.dot_dir, "DerivedData")
+        FileUtils.mkdir_p(path) if !File.exist?(path)
+        path
+      end
+
+      # @!visibility private
       def to_s
         "#<Xcodebuild #{workspace}>"
       end
@@ -75,7 +82,7 @@ Use the CBXWS environment variable to override the default.
         args = [
           "xcrun",
           "xcodebuild",
-          "-derivedDataPath", derived_data_directory,
+          "-derivedDataPath", Xcodebuild.derived_data_directory,
           "-scheme", "AppStub",
           "-workspace", workspace,
           "-config", "Debug",
@@ -108,12 +115,6 @@ Use the CBXWS environment variable to override the default.
         this_dir = File.expand_path(File.dirname(__FILE__))
         relative = File.expand_path(File.join(this_dir, "..", "..", "..", ".."))
         File.join(relative, "DeviceAgent.iOS/DeviceAgent.xcworkspace")
-      end
-
-      def derived_data_directory
-        path = File.join(Xcodebuild.dot_dir, "DerivedData")
-        FileUtils.mkdir_p(path) if !File.exist?(path)
-        path
       end
     end
   end

--- a/spec/lib/device_agent/ios_device_manager_spec.rb
+++ b/spec/lib/device_agent/ios_device_manager_spec.rb
@@ -80,6 +80,80 @@ describe RunLoop::DeviceAgent::IOSDeviceManager do
         expect(File.exist?(legacy_path)).to be_falsey
       end
     end
+
+    context "xctestrun path" do
+      let(:runner_bundle) { File.expand_path("path/to/DeviceAgent-Runner.app") }
+      let(:xctest_bundle) { File.join(runner_bundle, "PlugIns", "DeviceAgent.xctest") }
+      let(:runner) { RunLoop::DeviceAgent::Runner.new(device) }
+
+      before do
+        allow(runner).to receive(:runner).and_return(runner_bundle)
+        allow(runner).to receive(:tester).and_return(xctest_bundle)
+        allow_any_instance_of(RunLoop::DeviceAgent::IOSDeviceManager).to(
+          receive(:runner).and_return(runner)
+        )
+      end
+      context "#path_to_xctestrun_template" do
+        it "raises an argument error if device is a physical device" do
+          expect do
+            RunLoop::DeviceAgent::IOSDeviceManager.new(device).path_to_xctestrun_template
+          end.to raise_error(ArgumentError, /Physical devices do not require an xctestrun template/)
+        end
+
+        it "raises an error if simulator template does not exist" do
+          expect do
+            RunLoop::DeviceAgent::IOSDeviceManager.new(simulator).path_to_xctestrun_template
+          end.to raise_error(RuntimeError, /Could not find an xctestrun template at path/)
+        end
+
+        it "returns a path to xctestrun file template for simulators" do
+          expected = File.join(xctest_bundle, "DeviceAgent-simulator-template.xctestrun")
+          expect(File).to receive(:exist?).with(expected).and_return(true)
+
+          actual = RunLoop::DeviceAgent::IOSDeviceManager.new(simulator).path_to_xctestrun_template
+          expect(actual).to be == expected
+        end
+      end
+
+      context "#path_to_xctestrun" do
+        it "returns a path to xctestrun file for a physical device" do
+          expected = File.join(xctest_bundle, "DeviceAgent-device.xctestrun")
+          expect(File).to receive(:exist?).with(expected).and_return(true)
+
+          actual = RunLoop::DeviceAgent::IOSDeviceManager.new(device).path_to_xctestrun
+          expect(actual).to be == expected
+        end
+
+        it "raises an error if xctestrun file for physical device does not exist" do
+          expect do
+            RunLoop::DeviceAgent::IOSDeviceManager.new(device).path_to_xctestrun
+          end.to raise_error(RuntimeError, /Could not find an xctestrun file at path/)
+        end
+
+        it "returns ~/.run-loop/DeviceAgent/DeviceAgent-simulator.xctestrun with TEST_HOST_PATH substituted" do
+          template = File.join("tmp", "DeviceAgent-Runner.app", "DeviceAgent-simulator-template.xctestrun")
+          FileUtils.mkdir_p(File.dirname(template))
+          File.open(template, "w:UTF-8") do |file|
+            file.puts("TEST_HOST_PATH")
+          end
+
+          idm = RunLoop::DeviceAgent::IOSDeviceManager.new(simulator)
+          expect(idm).to receive(:path_to_xctestrun_template).and_return(template)
+
+          expected = File.join(RunLoop::DeviceAgent::IOSDeviceManager.dot_dir, "DeviceAgent-simulator.xctestrun")
+          actual = idm.path_to_xctestrun
+          expect(actual).to be == expected
+
+          contents = File.read(actual).force_encoding("UTF-8")
+          expect(contents[/TEST_HOST_PATH/]).to be_falsey
+          expect(contents[/#{runner_bundle}/]).to be_truthy
+
+          # template is untouched
+          contents = File.read(template).force_encoding("UTF-8")
+          expect(contents[/TEST_HOST_PATH/]).to be_truthy
+        end
+      end
+    end
   end
 end
 

--- a/spec/lib/device_agent/ios_device_manager_spec.rb
+++ b/spec/lib/device_agent/ios_device_manager_spec.rb
@@ -48,31 +48,36 @@ describe RunLoop::DeviceAgent::IOSDeviceManager do
   end
 
   describe "file system" do
-    let(:dot_dir) { File.expand_path(File.join("tmp", ".run-loop-xcuitest")) }
-    let(:xcuitest_dir) { File.join(dot_dir, "xcuitest") }
+    let(:dot_dir) { File.expand_path(File.join("tmp", ".run-loop", "DeviceAgent")) }
 
     before do
       FileUtils.mkdir_p(dot_dir)
-      allow(RunLoop::DeviceAgent::LauncherStrategy).to receive(:dot_dir).and_return(xcuitest_dir)
+      allow(RunLoop::DeviceAgent::LauncherStrategy).to receive(:dot_dir).and_return(dot_dir)
     end
 
     describe ".log_file" do
-      before do
-        FileUtils.mkdir_p(xcuitest_dir)
-      end
+      let(:path) { File.join(dot_dir, "current.log") }
 
-      let(:path) { File.join(xcuitest_dir, "ios-device-manager.log") }
-
-      it "creates a file" do
+      it "returns ~/.run-loop/DeviceAgent/current.log after creating it" do
         FileUtils.rm_rf(path)
 
         expect(RunLoop::DeviceAgent::IOSDeviceManager.log_file).to be == path
         expect(File.exist?(path)).to be_truthy
       end
 
-      it "returns existing file path" do
+      it "returns ~/.run-loop/DeviceAgent/current.log if it exists" do
         FileUtils.touch(path)
         expect(RunLoop::DeviceAgent::IOSDeviceManager.log_file).to be == path
+      end
+
+      it "returns ~/.run-loop/DeviceAgent/current.log after deleting legacy ios-device-manager.log" do
+        legacy_path = File.join(dot_dir, "ios-device-manager.log")
+        FileUtils.rm_rf(path)
+        FileUtils.touch(legacy_path)
+
+        expect(RunLoop::DeviceAgent::IOSDeviceManager.log_file).to be == path
+        expect(File.exist?(path)).to be_truthy
+        expect(File.exist?(legacy_path)).to be_falsey
       end
     end
   end

--- a/spec/lib/device_agent/launcher_strategy_spec.rb
+++ b/spec/lib/device_agent/launcher_strategy_spec.rb
@@ -38,9 +38,10 @@ describe RunLoop::DeviceAgent::LauncherStrategy do
     end
   end
 
-  describe "file system" do
+  context ".dot_dir" do
     let(:dot_dir) { File.expand_path(File.join("tmp", ".run-loop-xcuitest")) }
     let(:xcuitest_dir) { File.join(dot_dir, "xcuitest") }
+    let(:device_agent_dir) { File.join(dot_dir, "DeviceAgent") }
 
     before do
       FileUtils.mkdir_p(dot_dir)
@@ -48,19 +49,36 @@ describe RunLoop::DeviceAgent::LauncherStrategy do
     end
 
     describe ".dot_dir" do
-      it "creates a directory" do
+      it "returns a path to .run-loop/DeviceAgent directory after creating it" do
         FileUtils.rm_rf(dot_dir)
 
         actual = RunLoop::DeviceAgent::Xcodebuild.send(:dot_dir)
-        expect(actual).to be == xcuitest_dir
+        expect(actual).to be == device_agent_dir
         expect(File.directory?(actual)).to be_truthy
       end
 
-      it "returns a path" do
-        FileUtils.mkdir_p(xcuitest_dir)
+      it "returns a path to existing .run-loop/DeviceAgent directory" do
+        FileUtils.mkdir_p(device_agent_dir)
 
         actual = RunLoop::DeviceAgent::Xcodebuild.send(:dot_dir)
-        expect(actual).to be == xcuitest_dir
+        expect(actual).to be == device_agent_dir
+      end
+
+      it "returns a path to .run-loop/DeviceAgent directory after migrating legacy xcuitest directory" do
+        FileUtils.rm_rf(dot_dir)
+        FileUtils.mkdir_p(xcuitest_dir)
+        FileUtils.mkdir_p(File.join(xcuitest_dir, "a"))
+        FileUtils.mkdir_p(File.join(xcuitest_dir, "b"))
+        FileUtils.touch(File.join(xcuitest_dir, "file.txt"))
+
+        actual = RunLoop::DeviceAgent::Xcodebuild.send(:dot_dir)
+        expect(actual).to be == device_agent_dir
+        expect(File.directory?(actual)).to be_truthy
+        expect(File.directory?(xcuitest_dir)).to be_falsey
+
+        expect(File.directory?(File.join(device_agent_dir, "a"))).to be_truthy
+        expect(File.directory?(File.join(device_agent_dir, "b"))).to be_truthy
+        expect(File.exist?(File.join(device_agent_dir, "file.txt"))).to be_truthy
       end
     end
   end

--- a/spec/lib/device_agent/xcodebuild_spec.rb
+++ b/spec/lib/device_agent/xcodebuild_spec.rb
@@ -43,7 +43,7 @@ describe RunLoop::DeviceAgent::Xcodebuild do
 
   describe "file system" do
     let(:dot_dir) { File.expand_path(File.join("tmp", ".run-loop-xcuitest")) }
-    let(:xcuitest_dir) { File.join(dot_dir, "xcuitest") }
+    let(:device_agent_dir) { File.join(dot_dir, "DeviceAgent") }
 
     before do
       FileUtils.mkdir_p(dot_dir)
@@ -52,10 +52,10 @@ describe RunLoop::DeviceAgent::Xcodebuild do
 
     describe ".log_file" do
       before do
-        FileUtils.mkdir_p(xcuitest_dir)
+        FileUtils.mkdir_p(device_agent_dir)
       end
 
-      let(:path) { File.join(xcuitest_dir, "xcodebuild.log") }
+      let(:path) { File.join(device_agent_dir, "xcodebuild.log") }
 
       it "creates a file" do
         FileUtils.rm_rf(path)
@@ -72,10 +72,10 @@ describe RunLoop::DeviceAgent::Xcodebuild do
 
     context "#derived_data_directory" do
       before do
-        FileUtils.mkdir_p(xcuitest_dir)
+        FileUtils.mkdir_p(device_agent_dir)
       end
 
-      let(:path) { File.join(xcuitest_dir, "DerivedData") }
+      let(:path) { File.join(device_agent_dir, "DerivedData") }
 
       it "returns a path to existing DerivedData directory" do
         FileUtils.mkdir_p(path)

--- a/spec/lib/device_agent/xcodebuild_spec.rb
+++ b/spec/lib/device_agent/xcodebuild_spec.rb
@@ -70,7 +70,7 @@ describe RunLoop::DeviceAgent::Xcodebuild do
       end
     end
 
-    context "#derived_data_directory" do
+    context ".derived_data_directory" do
       before do
         FileUtils.mkdir_p(device_agent_dir)
       end
@@ -80,13 +80,13 @@ describe RunLoop::DeviceAgent::Xcodebuild do
       it "returns a path to existing DerivedData directory" do
         FileUtils.mkdir_p(path)
 
-        expect(xcodebuild.derived_data_directory).to be == path
+        expect(RunLoop::DeviceAgent::Xcodebuild.derived_data_directory).to be == path
       end
 
       it "creates a DerivedData directory if it does not exist and returns path" do
         FileUtils.rm_rf(path)
 
-        expect(xcodebuild.derived_data_directory).to be == path
+        expect(RunLoop::DeviceAgent::Xcodebuild.derived_data_directory).to be == path
         expect(File.exist?(path)).to be_truthy
       end
     end


### PR DESCRIPTION
### Motivation

Users are reporting that on the first run, the ~/.run-loop/DeviceAgent directory does not exist.

Progress on:

* run-loop 2.4.1 [3102](https://msmobilecenter.visualstudio.com/Test/_workitems/edit/3102)

The log file for iOSDeviceManager + xcodebuild test-without-building is:

* ~/.run-loop/DeviceAgent/current.log

ATTN @JoeSSS