### PR TITLE
Xcodebuild: manage existing test-without-building processes

### DIFF
--- a/spec/lib/device_agent/ios_device_manager_spec.rb
+++ b/spec/lib/device_agent/ios_device_manager_spec.rb
@@ -155,5 +155,38 @@ describe RunLoop::DeviceAgent::IOSDeviceManager do
       end
     end
   end
+
+  context "#xcodebuild_destination_is_simulator?" do
+    let(:idm) { RunLoop::DeviceAgent::IOSDeviceManager.new(simulator) }
+
+    it "returns false if process description does not contain id=<destination>" do
+      description = "does not contain 'id=' pattern"
+      expect(idm.xcodebuild_destination_is_simulator?(description)).to be_falsey
+    end
+
+    it "returns false if process description has a physical device destination" do
+      description = "xcodebuild id=#{device.udid}"
+      expect(idm.xcodebuild_destination_is_simulator?(description)).to be_falsey
+    end
+
+    it "returns true if process description is a simulator" do
+      description = "xcodebuild id=#{simulator.udid}"
+      expect(idm.xcodebuild_destination_is_simulator?(description)).to be_truthy
+    end
+  end
+
+  context "#xcodebuild_destination_is_same?" do
+    let(:idm) { RunLoop::DeviceAgent::IOSDeviceManager.new(device) }
+
+    it "returns false if the id=<destination> is not the same" do
+      description = "xcodebuild id=#{simulator.udid}"
+      expect(idm.xcodebuild_destination_is_same?(description)).to be_falsey
+    end
+
+    it "returns true if the id=<destination> is the same" do
+      description = "xcodebuild id=#{device.udid}"
+      expect(idm.xcodebuild_destination_is_same?(description)).to be_truthy
+    end
+  end
 end
 


### PR DESCRIPTION
### Motivation

Progress on:

* xcodebuild test-without-building causes iOS Simulator to relaunch _after_ user asks for simulator to be relaunched #618

In run-loop 2.4.0, we replaced `iOSDeviceManager start_test`  with `xcodebuild test-without-building` to launch DeviceAgent.  When a simulator is the target (id=<destination>) of `xcodebuild test-without-building` and the simulator is terminated, xcodebuild will relaunch the simulator and the DeviceAgent (#618). 

This change set will also clean up existing `xcodebuild  test-without-building` processes that are stale.

