### PR TITLE
CoreSimulator can handle Xcode 9 DeviceAgent name change

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -738,6 +738,14 @@ Command had no output.
   end
 
   # @!visibility private
+  def device_agent_launched_by_xcode?(running_apps)
+    process_info = running_apps["XCTRunner"] || running_apps["DeviceAgent-Runner"]
+    return false if !process_info
+
+    process_info[:args][/CBX_LAUNCHED_BY_XCODE/]
+  end
+
+  # @!visibility private
   def running_apps_require_relaunch?
     running_apps = device.simulator_running_app_details
 
@@ -747,11 +755,9 @@ Command had no output.
     end
 
     # DeviceAgent is running, but it was launched by Xcode.
-    if running_apps["XCTRunner"]
-      if running_apps["XCTRunner"][:args][/CBX_LAUNCHED_BY_XCODE/]
-        RunLoop.log_debug("Simulator relaunch required: XCTRunner is controlled by Xcode")
-        return true
-      end
+    if device_agent_launched_by_xcode?(running_apps)
+      RunLoop.log_debug("Simulator relaunch required: XCTRunner is controlled by Xcode")
+      return true
     end
 
     # No app was passed to initializer.

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -402,6 +402,34 @@ describe RunLoop::CoreSimulator do
       end
     end
 
+    context "#device_agent_launched_by_xcode?" do
+      it "returns false if DeviceAgent is not running" do
+        expect(core_sim.send(:device_agent_launched_by_xcode?, {})).to be_falsey
+      end
+
+      it "returns false if XCTRunner process was not launched by Xcode IDE" do
+        expect(core_sim.send(:device_agent_launched_by_xcode?,
+                             {"XCTRunner" => {args: ""}})).to be_falsey
+      end
+
+      it "returns false if DeviceAgent-Runner process was not launched by Xcode IDE" do
+        expect(core_sim.send(:device_agent_launched_by_xcode?,
+                             {"DeviceAgent-Runner" => {args: ""}})).to be_falsey
+      end
+
+      it "returns false if XCTRunner process was not launched by Xcode IDE" do
+        expect(core_sim.send(:device_agent_launched_by_xcode?,
+                             {"XCTRunner" => {args: "CBX_LAUNCHED_BY_XCODE"}})
+        ).to be_truthy
+      end
+
+      it "returns false if DeviceAgent-Runner process was not launched by Xcode IDE" do
+        expect(core_sim.send(:device_agent_launched_by_xcode?,
+                             {"DeviceAgent-Runner" => {args: "CBX_LAUNCHED_BY_XCODE"}})
+        ).to be_truthy
+      end
+    end
+
     context "#running_apps_require_relaunch?" do
       let (:running_apps) { { } }
       it "returns false if there are no running apps" do


### PR DESCRIPTION
### Motivation

DeviceAgent built with Xcode 9 generates an .app bundle with an executable named `DeviceAgent-Runner`.  Previously, the name was `XCTRunner`. 