### PR TITLE
CoreSim: simulator does not steal focus when launching

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -375,6 +375,11 @@ class RunLoop::CoreSimulator
     options = { :timeout => 5, :raise_on_timeout => true }
     RunLoop::ProcessWaiter.new(sim_name, options).wait_for_any
 
+    # open -g no longer launches application in the background. We want the
+    # Simulator to open in the background because when it is opened in the
+    # foreground, it steals (key application) focus which is disruptive.
+    send_simulator_to_background
+
     if merged_options[:wait_for_stable]
       device.simulator_wait_for_stable_state
     end
@@ -597,6 +602,16 @@ Command had no output.
     hash[:launched_by_run_loop] = match[/LAUNCHED_BY_RUN_LOOP/]
 
     hash
+  end
+
+  # @!visibility private
+  def send_simulator_to_background
+    script = "tell application \"System Events\" to tell process \"#{sim_name}\" to set visible to false"
+    begin
+      system("osascript",  "-e", script)
+    rescue => _
+      RunLoop.log_debug("Could not put simulator into the background")
+    end
   end
 
   # @!visibility private


### PR DESCRIPTION
### Motivation

At some point during Xcode 8, `open -g` stopped launching the Simulator in the background.

When the Simulator is not launched in the background it steals (key application) focus which is disruptive.

This changeset uses AppleScript to force the Simulator into the background after it has been launched.  This is not the perfect behavior:

1. the simulator does steal focus for a moment
2. the simulator becomes hidden - this overrides any "Remain on top" user settings.
