### PR TITLE
CLI: add simctl erase and launch commands

### DIFF
--- a/lib/run_loop/cli/simctl.rb
+++ b/lib/run_loop/cli/simctl.rb
@@ -1,10 +1,12 @@
-require 'thor'
-require 'run_loop'
-require 'run_loop/cli/errors'
 
 module RunLoop
   module CLI
+
+    require 'thor'
     class Simctl < Thor
+
+      require 'run_loop'
+      require 'run_loop/cli/errors'
 
       attr_reader :simctl
 
@@ -184,6 +186,60 @@ module RunLoop
             end
           end
           core_sim.install
+        end
+      end
+
+      desc "erase <simulator>", "Erases the simulator"
+
+      method_option 'debug',
+                    :desc => 'Enable debug logging.',
+                    :aliases => '-v',
+                    :required => false,
+                    :default => false,
+                    :type => :boolean
+
+      def erase(simulator=nil)
+
+        debug = options[:debug]
+
+        RunLoop::Environment.with_debugging(debug) do
+          if !simulator
+            identifier = RunLoop::Core.default_simulator(xcode)
+          else
+            identifier = simulator
+          end
+
+          options = {simctl: simctl, xcode: xcode}
+          device = RunLoop::Device.device_with_identifier(identifier, options)
+
+          RunLoop::CoreSimulator.erase(device, options)
+        end
+      end
+
+      desc "launch <simulator>", "Launches the simulator"
+
+      method_option 'debug',
+                    :desc => 'Enable debug logging.',
+                    :aliases => '-v',
+                    :required => false,
+                    :default => false,
+                    :type => :boolean
+
+      def launch(simulator=nil)
+        debug = options[:debug]
+
+        RunLoop::Environment.with_debugging(debug) do
+          if !simulator
+            identifier = RunLoop::Core.default_simulator(xcode)
+          else
+            identifier = simulator
+          end
+
+          options = {simctl: simctl, xcode: xcode}
+          device = RunLoop::Device.device_with_identifier(identifier, options)
+
+          core_sim = RunLoop::CoreSimulator.new(device, nil)
+          core_sim.launch_simulator
         end
       end
 


### PR DESCRIPTION
### Motivation

We recently upgraded our Jenkins machine to Sierra and Xcode 8.3.3 (from El Cap and Xcode 7.3.1).  Since then, our simulator experience has been terrible.  Specifically, `xcodebuild` cannot seem to connect to simulators when running XCTest bundles. 

We know that running:

```
$ run-loop simctl doctor
```

can correct the problem, so we started running that nightly.

However, if there is a lot of activity on Jenkins the XCTest start to fail.

This PR adds two commands that allow us to erase and launch specific simulators.

```
$ run-loop simctl erase # the default simulator
$ run-loop simctl erase <UDID>
$ run-loop simctl erase "iPhone 7 (10.3)" # Instruments simulator name format

# Same options as above.
$ run-loop simctl launch
```

Progress on:

* Simulators on Jenkins CI machine are failing to launch XCTest [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/13506)