### PR TITLE
Respond to DeviceAgent iOS 11 changes to POST /rotate_home_button_to

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -695,14 +695,13 @@ Could not dismiss SpringBoard alert by touching button with title '#{button_titl
       def rotate_home_button_to(position, sleep_for=1.0)
         orientation = normalize_orientation_position(position)
         parameters = {
-          :orientation => orientation
+          :orientation => orientation,
+          :seconds_to_sleep_after => sleep_for
         }
         request = request("rotate_home_button_to", parameters)
         client = http_client(http_options)
         response = client.post(request)
-        json = expect_300_response(response)
-        sleep(sleep_for)
-        json
+        expect_300_response(response)
       end
 
       # @!visibility private

--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -705,6 +705,14 @@ Could not dismiss SpringBoard alert by touching button with title '#{button_titl
       end
 
       # @!visibility private
+      def orientations
+        request = request("orientations")
+        client = http_client(http_options)
+        response = client.get(request)
+        expect_300_response(response)
+      end
+
+      # @!visibility private
       def pan_between_coordinates(start_point, end_point, options={})
         default_options = {
           :num_fingers => 1,


### PR DESCRIPTION
### Motivation

Progress on:

* iOS 11: orientation is being reported incorrectly [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/15051)

DeviceAgent now sleeps after the rotation change and then responds with the new orientation.

In previous versions of iOS, the `XCUIDevice` instance returned the _new_ orientation immediately.  In iOS 11, the new orientation is not available until _after_ the orientation animations have completed.

`POST /rotate_home_button_to` responds to `:seconds_to_sleep_after` parameter to control how long to wait for the orientation update.