### PR TITLE
Update equality rules for Version class

### DIFF
--- a/lib/run_loop/version.rb
+++ b/lib/run_loop/version.rb
@@ -102,7 +102,15 @@ module RunLoop
 
     # The hash method for this instance.
     def hash
-      to_s.hash
+      str = [major, minor, patch].map do |str|
+        str ? str : "0"
+      end.join(".")
+
+      if pre
+        str = "#{str}.#{pre}"
+      end
+
+      str.hash
     end
 
     # Compare this version to another for equality.

--- a/lib/run_loop/version.rb
+++ b/lib/run_loop/version.rb
@@ -169,12 +169,16 @@ module RunLoop
         return a.major.to_i > b.major.to_i ? 1 : -1
       end
 
-      if a.minor != b.minor
-        return a.minor.to_i > b.minor.to_i ? 1 : -1
+      a_minor = a.minor ? a.minor.to_i : 0
+      b_minor = b.minor ? b.minor.to_i : 0
+      if a_minor != b_minor
+        return a_minor > b_minor.to_i ? 1 : -1
       end
 
-      if a.patch != b.patch
-        return a.patch.to_i > b.patch.to_i ? 1 : -1
+      a_patch = a.patch ? a.patch.to_i : 0
+      b_patch = b.patch ? b.patch.to_i : 0
+      if a_patch != b_patch
+        return a_patch.to_i > b_patch.to_i ? 1 : -1
       end
 
       return -1 if a.pre && (!a.pre_version) && b.pre_version

--- a/spec/lib/version_spec.rb
+++ b/spec/lib/version_spec.rb
@@ -50,15 +50,21 @@ describe RunLoop::Version do
     end
 
     it '0.9' do
-      str = '0.9'
-      version = RunLoop::Version.new(str)
-      expect(str.hash).to be == version.hash
+      version = RunLoop::Version.new("0.9")
+      expect("0.9.0".hash).to be == version.hash
     end
 
     it '0' do
-      str = '0'
-      version = RunLoop::Version.new(str)
-      expect(str.hash).to be == version.hash
+      version = RunLoop::Version.new("0")
+      expect("0.0.0".hash).to be == version.hash
+    end
+
+    it "9 == 9.0 == 9.0.0" do
+      version = RunLoop::Version.new("9")
+      expect("9.0.0".hash).to be == version.hash
+
+      version = RunLoop::Version.new("9.0")
+      expect("9.0.0".hash).to be == version.hash
     end
   end
 

--- a/spec/lib/version_spec.rb
+++ b/spec/lib/version_spec.rb
@@ -142,6 +142,17 @@ describe RunLoop::Version do
       b = RunLoop::Version.new('0.9.5.pre1')
       expect(a == b).to be false
 
+      a = RunLoop::Version.new("9.0.0")
+      b = RunLoop::Version.new("9")
+      expect(b == a).to be true
+
+      a = RunLoop::Version.new("9")
+      b = RunLoop::Version.new("9.0")
+      expect(b == a).to be true
+
+      a = RunLoop::Version.new("9.0.0")
+      b = RunLoop::Version.new("9.0")
+      expect(b == a).to be true
     end
   end
 
@@ -232,15 +243,39 @@ describe RunLoop::Version do
       expect(a <= b).to be true
       a = RunLoop::Version.new('0.9.5')
       expect(a <= b).to be true
+
+      a = RunLoop::Version.new("9.0.0")
+      b = RunLoop::Version.new("9")
+      expect(b <= a).to be true
+
+      a = RunLoop::Version.new("9.0")
+      b = RunLoop::Version.new("9")
+      expect(b <= a).to be true
+
+      a = RunLoop::Version.new("9.0.0")
+      b = RunLoop::Version.new("9.0")
+      expect(b <= a).to be true
     end
   end
 
   describe '>=' do
-    it 'tests less-than or equal' do
+    it 'tests greater-than or equal' do
       a = RunLoop::Version.new('0.9.4')
       b = RunLoop::Version.new('0.9.5')
       expect(b >= a).to be true
       a = RunLoop::Version.new('0.9.5')
+      expect(b >= a).to be true
+
+      a = RunLoop::Version.new("9.0.0")
+      b = RunLoop::Version.new("9")
+      expect(b >= a).to be true
+
+      a = RunLoop::Version.new("9.0")
+      b = RunLoop::Version.new("9")
+      expect(b >= a).to be true
+
+      a = RunLoop::Version.new("9.0.0")
+      b = RunLoop::Version.new("9.0")
       expect(b >= a).to be true
     end
   end


### PR DESCRIPTION
### Motivation

Completes:

* run-loop #<Version 9.0.0>  >= Version.new("9.0") should be true [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/14915)

I wasted a lot of time last week trying sort out why an iOS Simulator filter-by-version was not working correctly.  Simulators with iOS version 9.0 were not responding to `>=` when tested against version 9.0.0.  