### PR TITLE
Device: adjust required processes for Xcode 9

### DIFF
--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -614,7 +614,9 @@ failed with this output:
     def simulator_required_child_processes
       @simulator_required_child_processes ||= begin
         required = ["backboardd", "installd", "SimulatorBridge", "SpringBoard"]
-        if xcode.version_gte_8? && version.major > 8
+        if xcode.version_gte_90?
+          required << "filecoordinationd"
+        elsif xcode.version_gte_8? && version.major > 8
           required << "medialibraryd"
         end
 


### PR DESCRIPTION
### Motivation

The simulator stable algorithm was hanging on Xcode 9 simulators.

Completes:

* run-loop's simulator-stable algorithm should work with Xcode 9.0 [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/10974)