### PR TITLE
Update list of managed simulator processes

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -517,16 +517,20 @@ Could not launch #{app.bundle_identifier} on #{device} after trying #{tries} tim
       # macOS is looking more like iOS.  Process names like 'mobileassetd' are
       # found in both operating systems.
 
-      killed = false
+      args = ["ps", "-o", "uid=", pid.to_s]
+      uid = RunLoop::Shell.run_shell_command(args)[:out].strip
+      if uid != "0"
+        killed = false
 
-      if send_term_first
-        term = RunLoop::ProcessTerminator.new(pid, 'TERM', process_name, term_options)
-        killed = term.kill_process
-      end
+        if send_term_first
+          term = RunLoop::ProcessTerminator.new(pid, 'TERM', process_name, term_options)
+          killed = term.kill_process
+        end
 
-      if !killed
-        term = RunLoop::ProcessTerminator.new(pid, 'KILL', process_name, kill_options)
-        term.kill_process
+        if !killed
+          term = RunLoop::ProcessTerminator.new(pid, 'KILL', process_name, kill_options)
+          term.kill_process
+        end
       end
     end
   end

--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -114,7 +114,11 @@ class RunLoop::CoreSimulator
               # appear to influence the behavior of DeviceAgent.
               ["MobileSMSSpotlightImporter", false],
               ["UserEventAgent", false],
-              ["mobileassetd", false]
+              ["mobileassetd", false],
+              ["pkd", false],
+              ["KeychainSyncingOverIDSProxy", false],
+              ["CloudKeychainProxy", false],
+              ["aslmanager", false]
         ]
 
   # @!visibility private


### PR DESCRIPTION
### Motivation

Looking at our CI machine, I found hundreds of orphaned processes related to CoreSimulator.

The expectation is that terminating these processes will improve simulator stability.

"Hope is a straight road to disappointment." 🎱 
