### PR TITLE
Simctl: can switch back to Xcode 8 after Xcode 9 is active

### DIFF
--- a/lib/run_loop/simctl.rb
+++ b/lib/run_loop/simctl.rb
@@ -39,9 +39,9 @@ module RunLoop
 
     # @!visibility private
     def self.ensure_valid_core_simulator_service
-      max_tries = 3
+      max_tries = 4
       valid = false
-      3.times do |try|
+      4.times do |try|
         valid = self.valid_core_simulator_service?
         break if valid
         RunLoop.log_debug("Invalid CoreSimulator service for active Xcode: try #{try + 1} of #{max_tries}")
@@ -54,11 +54,12 @@ module RunLoop
       require "run_loop/shell"
       args = ["xcrun", "simctl", "help"]
 
+      options = {timeout: 5 }
       begin
-        hash = Shell.run_shell_command(args)
+        hash = Shell.run_shell_command(args, options)
         hash[:exit_status] == 0 &&
           !hash[:out][/Failed to locate a valid instance of CoreSimulatorService/]
-      rescue RunLoop::Shell::Error => _
+      rescue RunLoop::Shell::TimeoutError, RunLoop::Shell::Error => _
         false
       end
     end

--- a/spec/lib/simctl_spec.rb
+++ b/spec/lib/simctl_spec.rb
@@ -25,12 +25,15 @@ describe RunLoop::Simctl do
 
   context ".valid_core_simulator_service?" do
     let(:args) { ["xcrun", "simctl", "help"] }
+    let(:options) { {timeout: 5 } }
     let(:hash) { { } }
 
     it "returns true if simctl help exits with 0 and a valid CoreSimulatorService is located" do
       hash[:exit_status] = 0
       hash[:out] = "Apple!!!"
-      expect(RunLoop::Shell).to receive(:run_shell_command).with(args).and_return(hash)
+      expect(RunLoop::Shell).to(
+        receive(:run_shell_command).with(args, options).and_return(hash)
+      )
 
       actual = RunLoop::Simctl.valid_core_simulator_service?
       expect(actual).to be == true
@@ -38,7 +41,9 @@ describe RunLoop::Simctl do
 
     it "returns false if simctl help fails" do
       hash[:exit_status] = 1
-      expect(RunLoop::Shell).to receive(:run_shell_command).with(args).and_return(hash)
+      expect(RunLoop::Shell).to(
+        receive(:run_shell_command).with(args, options).and_return(hash)
+      )
 
       actual = RunLoop::Simctl.valid_core_simulator_service?
       expect(actual).to be == false
@@ -48,14 +53,27 @@ describe RunLoop::Simctl do
       hash[:exit_status] = 0
       hash[:out] = "Failed to locate a valid instance of CoreSimulatorService"
 
-      expect(RunLoop::Shell).to receive(:run_shell_command).with(args).and_return(hash)
+      expect(RunLoop::Shell).to(
+        receive(:run_shell_command).with(args, options).and_return(hash)
+      )
 
       actual = RunLoop::Simctl.valid_core_simulator_service?
       expect(actual).to be == false
     end
 
-    it "returns false if simctl help raises a shell error" do
-      expect(RunLoop::Shell).to receive(:run_shell_command).with(args).times.and_raise RunLoop::Shell::Error
+    it "returns false if simctl help raises a Shell error" do
+      expect(RunLoop::Shell).to(
+        receive(:run_shell_command).with(args, options).times.and_raise(RunLoop::Shell::Error)
+      )
+
+      actual = RunLoop::Simctl.valid_core_simulator_service?
+      expect(actual).to be == false
+    end
+
+    it "returns false if simctl help raises a Timeout error" do
+      expect(RunLoop::Shell).to(
+        receive(:run_shell_command).with(args, options).times.and_raise(RunLoop::Shell::TimeoutError)
+      )
 
       actual = RunLoop::Simctl.valid_core_simulator_service?
       expect(actual).to be == false
@@ -71,18 +89,18 @@ describe RunLoop::Simctl do
       expect(actual).to be == true
     end
 
-    it "returns true after 3 tries" do
+    it "returns true after 4 tries" do
       expect(RunLoop::Simctl).to(
-        receive(:valid_core_simulator_service?).and_return(false, false, true)
+        receive(:valid_core_simulator_service?).and_return(false, false, false, true)
       )
 
       actual = RunLoop::Simctl.ensure_valid_core_simulator_service
       expect(actual).to be == true
     end
 
-    it "returns false after 3 tries" do
+    it "returns false after 4 tries" do
       expect(RunLoop::Simctl).to(
-        receive(:valid_core_simulator_service?).and_return(false, false, false)
+        receive(:valid_core_simulator_service?).and_return(false, false, false, false)
       )
 
       actual = RunLoop::Simctl.ensure_valid_core_simulator_service


### PR DESCRIPTION
### Motivation

`xcrun simctl help` was timing out when ensuring a valid CoreSimulator service after switching from Xcode 9 to Xcode 8.0.  This was causing unit and integration tests to fail.

Completes:

* run-loop: ensure valid CoreSim service can fail when switching from Xcode 8.0 to Xcode 9.0 [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/19609)