### PR TITLE
Device: ensure simulator plist paths exist

### DIFF
--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -275,79 +275,44 @@ version: #{version}
 
     # @!visibility private
     def simulator_root_dir
-      @simulator_root_dir ||= lambda {
-        return nil if physical_device?
-        File.join(CORE_SIMULATOR_DEVICE_DIR, udid)
-      }.call
+      return nil if physical_device?
+      @simulator_root_dir ||= File.join(CORE_SIMULATOR_DEVICE_DIR, udid)
     end
 
     # @!visibility private
     def simulator_accessibility_plist_path
-      @simulator_accessibility_plist_path ||= lambda {
-        return nil if physical_device?
-        File.join(simulator_root_dir, 'data/Library/Preferences/com.apple.Accessibility.plist')
-      }.call
+      return nil if physical_device?
+
+      directory = File.join(simulator_root_dir, "data", "Library", "Preferences")
+      pbuddy.ensure_plist(directory, "com.apple.Accessibility.plist")
     end
 
     # @!visibility private
     def simulator_preferences_plist_path
       return nil if physical_device?
 
-
       directory = File.join(simulator_root_dir, "data", "Library", "Preferences")
-
-      if !File.exist?(directory)
-        FileUtils.mkdir_p(directory)
-      end
-
-      plist = File.join(directory, "com.apple.Preferences.plist")
-
-      if !File.exist?(plist)
-        pbuddy.create_plist(plist)
-      end
-      plist
+      pbuddy.ensure_plist(directory, "com.apple.Preferences.plist")
     end
 
     # @!visibility private
     def simulator_log_file_path
-      @simulator_log_file_path ||= lambda {
-        return nil if physical_device?
-        File.join(CORE_SIMULATOR_LOGS_DIR, udid, 'system.log')
-      }.call
+      return nil if physical_device?
+      @simulator_log_file_path ||= File.join(CORE_SIMULATOR_LOGS_DIR, udid,
+                                             'system.log')
     end
 
     # @!visibility private
     def simulator_device_plist
-      @simulator_device_plist ||= lambda do
-        return nil if physical_device?
-        File.join(simulator_root_dir, 'device.plist')
-      end.call
+      return nil if physical_device?
+      pbuddy.ensure_plist(simulator_root_dir, "device.plist")
     end
 
     # @!visibility private
-    def simulator_global_preferences_path(timeout=10)
+    def simulator_global_preferences_path
       return nil if physical_device?
-
-      path = File.join(simulator_root_dir,
-                       "data/Library/Preferences/.GlobalPreferences.plist")
-
-      return path if File.exist?(path)
-
-      start = Time.now
-      while !File.exist?(path) && (start + timeout) < Time.now
-        sleep(1.0)
-      end
-
-      return path if File.exist?(path)
-
-      raise(RuntimeError, %Q[
-Timed out waiting for .GlobalPreferences.plist after #{Time.now - start} seconds.
-
-File does not exist at path:
-
-#{path}
-
-])
+      directory = File.join(simulator_root_dir, "data", "Library", "Preferences")
+      pbuddy.ensure_plist(directory, ".GlobalPreferences.plist")
     end
 
     # @!visibility private

--- a/lib/run_loop/plist_buddy.rb
+++ b/lib/run_loop/plist_buddy.rb
@@ -1,3 +1,4 @@
+
 module RunLoop
   # A class for reading and writing property list values.
   #
@@ -5,6 +6,8 @@ module RunLoop
   # faults, it matches Boolean to a string type with 'true/false' values which
   # is problematic for our purposes.
   class PlistBuddy
+
+    require "fileutils"
 
     # Reads key from file and returns the result.
     # @param [String] key the key to inspect (may not be nil or empty)
@@ -83,6 +86,18 @@ module RunLoop
         file.puts '</plist>'
       end
       path
+    end
+
+    # Ensures a plist exists at path by creating necessary directories and
+    # creating an empty plist if none exists.
+    def ensure_plist(directory, name)
+      FileUtils.mkdir_p(directory) if !File.exist?(directory)
+
+      plist = File.join(directory, name)
+
+      create_plist(plist) if !File.exists?(plist)
+
+      plist
     end
 
     private

--- a/lib/run_loop/simctl.rb
+++ b/lib/run_loop/simctl.rb
@@ -24,7 +24,7 @@ module RunLoop
       "Shutdown" => 1,
       "Shutting Down" => 2,
       "Booted" => 3,
-      "Plist Missing" => -1
+      "Plist Missing Key" => -1
     }.freeze
 
     # @!visibility private
@@ -125,10 +125,11 @@ module RunLoop
     # @!visibility private
     def simulator_state_as_int(device)
       plist = device.simulator_device_plist
-      if File.exist?(plist)
+
+      if pbuddy.plist_key_exists?("state", plist)
         pbuddy.plist_read("state", plist).to_i
       else
-        SIM_STATES["Plist Missing"]
+        SIM_STATES["Plist Missing Key"]
       end
     end
 

--- a/spec/lib/plist_buddy_spec.rb
+++ b/spec/lib/plist_buddy_spec.rb
@@ -16,6 +16,42 @@ describe RunLoop::PlistBuddy do
     expect(File.open(path).read).not_to be == ''
   end
 
+  context "#ensure_plist" do
+    let(:base_dir) { File.join(Resources.shared.local_tmp_dir, "PlistBuddy") }
+    let(:directory) { File.join(base_dir, "A", "B") }
+    let(:name) { "com.example.MyApp.plist" }
+    let(:plist) { File.join(directory, name) }
+
+    before do
+      FileUtils.rm_rf(base_dir)
+      FileUtils.mkdir_p(base_dir)
+    end
+
+    it "returns a path to an existing plist" do
+      FileUtils.mkdir_p(directory)
+      FileUtils.touch(plist)
+
+      expect(FileUtils).not_to receive(:mkdir_p).with(directory)
+      expect(pbuddy).not_to receive(:create_plist)
+      expect(pbuddy.ensure_plist(directory, name)).to be == plist
+    end
+
+    it "returns a path to an empty plist if one does not already exist" do
+      FileUtils.mkdir_p(directory)
+
+      expect(FileUtils).not_to receive(:mkdir_p).with(directory)
+      expect(pbuddy).to receive(:create_plist).with(plist)
+      expect(pbuddy.ensure_plist(directory, name)).to be == plist
+    end
+
+    it "returns a path to an empty plist after creating any necessary directories" do
+      expect(FileUtils).to receive(:mkdir_p).with(directory)
+      expect(pbuddy).to receive(:create_plist).with(plist)
+
+      expect(pbuddy.ensure_plist(directory, name)).to be == plist
+    end
+  end
+
   describe '#build_plist_cmd' do
     describe 'raises errors' do
       it 'if file does not exist' do


### PR DESCRIPTION
### Motivation

In Xcode 9, many (more) plist are (more) lazily created after simulators are erased.  This can break some of the tooling which either assumes the plist exist or waits for the plist to exist.  Whenever run-loop needs to reference a plist, it now ensure that plist exists by creating it.

Progress on:

* run-loop: cannot set language if AppleLanguage key does not already exist [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/19809)