### PR TITLE
PlistBuddy can run arbitrary commands and push new values onto arrays

### DIFF
--- a/lib/run_loop/plist_buddy.rb
+++ b/lib/run_loop/plist_buddy.rb
@@ -8,6 +8,9 @@ module RunLoop
   class PlistBuddy
 
     require "fileutils"
+    require "run_loop/shell"
+
+    include RunLoop::Shell
 
     # Reads key from file and returns the result.
     # @param [String] key the key to inspect (may not be nil or empty)
@@ -21,11 +24,11 @@ module RunLoop
         raise(ArgumentError, "key '#{key}' must not be nil or empty")
       end
       cmd = build_plist_cmd(:print, {:key => key}, file)
-      res = execute_plist_cmd(cmd, opts)
-      if res == "Print: Entry, \":#{key}\", Does Not Exist"
+      success, output = execute_plist_cmd(cmd, file, opts)
+      if !success
         nil
       else
-        res
+        output
       end
     end
 
@@ -67,8 +70,16 @@ module RunLoop
         cmd = build_plist_cmd(:add, cmd_args, file)
       end
 
-      res = execute_plist_cmd(cmd, merged)
-      res == ''
+      success, output = execute_plist_cmd(cmd, file, merged)
+      if !success
+        raise RuntimeError, %Q[
+Encountered an error performing operation on plist:
+
+#{plist_buddy} -c "#{cmd}" #{file}
+=> #{output}
+]
+      end
+      success
     end
 
     # Creates an new empty plist at `path`.
@@ -116,24 +127,17 @@ module RunLoop
     # @return [Boolean,String] `true` if command was successful.  If :print'ing
     #  the result, the value of the key.  If there is an error, the output of
     #  stderr.
-    def execute_plist_cmd(cmd, opts={})
-      default_opts = {:verbose => false}
+    def execute_plist_cmd(cmd, file, opts={})
+      default_opts = {:verbose => false }
       merged = default_opts.merge(opts)
 
-      puts cmd if merged[:verbose]
+      merged[:log_cmd] = merged[:verbose]
 
-      res = nil
-      # noinspection RubyUnusedLocalVariable
-      Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
-        err = stderr.read
-        std = stdout.read
-        if not err.nil? and err != ''
-          res = err.chomp
-        else
-          res = std.chomp
-        end
-      end
-      res
+      args = [plist_buddy, "-c", cmd, file]
+
+      hash = run_shell_command(args, merged)
+
+      return hash[:exit_status] == 0, hash[:out]
     end
 
     # Composes a PlistBuddy command that can be executed as a shell command.
@@ -176,13 +180,13 @@ module RunLoop
           unless key
             raise(ArgumentError, ':key is a required key for :add command')
           end
-          cmd_part = "\"Add :#{key} #{value_type} #{value}\""
+          cmd_part = "Add :#{key} #{value_type} #{value}"
         when :print
           key = args_hash[:key]
           unless key
             raise(ArgumentError, ':key is a required key for :print command')
           end
-          cmd_part = "\"Print :#{key}\""
+          cmd_part = "Print :#{key}"
         when :set
           value = args_hash[:value]
           unless value
@@ -192,13 +196,13 @@ module RunLoop
           unless key
             raise(ArgumentError, ':key is a required key for :set command')
           end
-          cmd_part = "\"Set :#{key} #{value}\""
+          cmd_part = "Set :#{key} #{value}"
         else
           cmds = [:add, :print, :set]
           raise(ArgumentError, "expected '#{type}' to be one of '#{cmds}'")
       end
 
-      "#{plist_buddy} -c #{cmd_part} \"#{file}\""
+      cmd_part
     end
   end
 end

--- a/lib/run_loop/plist_buddy.rb
+++ b/lib/run_loop/plist_buddy.rb
@@ -111,6 +111,35 @@ Encountered an error performing operation on plist:
       plist
     end
 
+    # Sends an arbitrary command (-c) to PlistBuddy.
+    #
+    # This class does not handle setting data, date, dictionary, or array
+    # or manipulating elements in existing array or dictionary types.  This
+    # method is an attempt to bridge this gap.
+    #
+    # When setting/adding bool, real, integer, string values, use #plist_set.
+    #
+    # For reading values, use #plist_read.
+    #
+    # @param [String] cmd The command passed to PlistBuddy with -c
+    # @param [String] file Path the plist file
+    # @param [Hash] opts options for controlling execution
+    # @option opts [Boolean] :verbose (false) controls log level
+    # @raise RuntimeError when running the command fails.
+    # @return Boolean, String Success and the output of running the command.
+    def run_command(cmd, file, opts={})
+      success, output = execute_plist_cmd(cmd, file, opts)
+      if !success
+        raise RuntimeError, %Q[
+Encountered an error performing operation on plist:
+
+#{plist_buddy} -c "#{cmd}" #{file}
+=> #{output}
+]
+      end
+      return success, output
+    end
+
     private
 
     # returns the path to the PlistBuddy executable

--- a/lib/run_loop/plist_buddy.rb
+++ b/lib/run_loop/plist_buddy.rb
@@ -140,6 +140,37 @@ Encountered an error performing operation on plist:
       return success, output
     end
 
+    # Add value to the head of an array type.
+    #
+    # @param [String] key The plist key
+    # @param [String] type any allowed plist type
+    # @param [Object] value the value to add
+    # @param [String] path the plist path
+    # @param [Hash] opts options for controlling execution
+    # @option opts [Boolean] :verbose (false) controls log level
+    # @raise RuntimeError when running the command fails.
+    # @raise RuntimeError if attempt to push value onto non-array container.
+    def unshift_array(key, type, value, path, opts={})
+      if !plist_key_exists?(key, path)
+        run_command("Add :#{key} array", path, opts)
+      else
+        key_type = plist_read(key, path).split(" ")[0]
+        if key_type != "Array"
+          raise RuntimeError, %Q[
+Could not push #{value} onto array:
+  Expected:  key #{key} be of type Array
+     Found:  had type #{key_type}
+
+in plist:
+
+  #{path}
+]
+        end
+      end
+
+      run_command("Add :#{key}:0 #{type} #{value}", path, opts)
+    end
+
     private
 
     # returns the path to the PlistBuddy executable

--- a/spec/lib/plist_buddy_spec.rb
+++ b/spec/lib/plist_buddy_spec.rb
@@ -16,6 +16,20 @@ describe RunLoop::PlistBuddy do
     expect(File.open(path).read).not_to be == ''
   end
 
+  context "#run_command" do
+    it "returns true and output if command is successful" do
+      success, output = pbuddy.run_command("Print :AXInspectorEnabled", path)
+
+      expect(success).to be_truthy
+      expect(output).to be == "false"
+    end
+    it "raises an error if command is not successful" do
+      expect do
+        pbuddy.run_command("Print :NoSuchKey", path)
+      end.to raise_error(RuntimeError, /Does Not Exist/)
+    end
+  end
+
   context "#ensure_plist" do
     let(:base_dir) { File.join(Resources.shared.local_tmp_dir, "PlistBuddy") }
     let(:directory) { File.join(base_dir, "A", "B") }

--- a/spec/lib/plist_buddy_spec.rb
+++ b/spec/lib/plist_buddy_spec.rb
@@ -76,14 +76,14 @@ describe RunLoop::PlistBuddy do
     describe 'composing commands' do
       it 'print' do
         cmd = pbuddy.send(:build_plist_cmd, *[:print, {:key => 'foo'}, path])
-        expect(cmd).to be == "/usr/libexec/PlistBuddy -c \"Print :foo\" \"#{path}\""
+        expect(cmd).to be == "Print :foo"
       end
 
       it 'set' do
         cmd =  pbuddy.send(:build_plist_cmd, *[:set,
                                                {:key => 'foo', :value => 'bar'},
                                                path])
-        expect(cmd).to be == "/usr/libexec/PlistBuddy -c \"Set :foo bar\" \"#{path}\""
+        expect(cmd).to be == "Set :foo bar"
       end
 
       it 'add' do
@@ -92,7 +92,7 @@ describe RunLoop::PlistBuddy do
                                                         :value => 'bar',
                                                         :type => 'bool'
                                                   }, path])
-        expect(cmd).to be == "/usr/libexec/PlistBuddy -c \"Add :foo bool bar\" \"#{path}\""
+        expect(cmd).to be == "Add :foo bool bar"
       end
 
     end

--- a/spec/lib/plist_buddy_spec.rb
+++ b/spec/lib/plist_buddy_spec.rb
@@ -30,6 +30,39 @@ describe RunLoop::PlistBuddy do
     end
   end
 
+  context "#unshift_array" do
+    it "creates an array for key and adds the value" do
+      pbuddy.unshift_array("Languages", "string", "de", path)
+
+      value = pbuddy.plist_read("Languages", path)
+      expect(value[/Array/]).to be_truthy
+
+      expect(pbuddy.plist_read("Languages:0", path)).to be == "de"
+    end
+
+    it "raises an error if key exists, but is not of type Array" do
+      pbuddy.run_command("Add :Languages dict", path)
+      pbuddy.run_command("Add :Languages:0 string en", path)
+
+      expect do
+        pbuddy.unshift_array("Languages", "string", "de", path)
+      end.to raise_error(RuntimeError, /Found:  had type Dict/)
+    end
+
+    it "pushes the value into the first position of the array" do
+      pbuddy.run_command("Add :Languages array", path)
+      pbuddy.run_command("Add :Languages:0 string en", path)
+
+      pbuddy.unshift_array("Languages", "string", "de", path)
+
+      value = pbuddy.plist_read("Languages", path)
+      expect(value[/Array/]).to be_truthy
+
+      expect(pbuddy.plist_read("Languages:0", path)).to be == "de"
+      expect(pbuddy.plist_read("Languages:1", path)).to be == "en"
+    end
+  end
+
   context "#ensure_plist" do
     let(:base_dir) { File.join(Resources.shared.local_tmp_dir, "PlistBuddy") }
     let(:directory) { File.join(base_dir, "A", "B") }

--- a/spec/resources.rb
+++ b/spec/resources.rb
@@ -276,12 +276,13 @@ class Resources
   end
 
   def plist_template
-     @plist_template ||= File.expand_path(File.join(resources_dir, 'plist-buddy/com.example.plist'))
+     @plist_template ||= File.join(resources_dir, "plist-buddy",
+                                   "com.example.plist")
   end
 
   def plist_for_testing
-    dir = Dir.mktmpdir
-    path = File.join(dir, 'com.testing.plist')
+    path = File.join(local_tmp_dir, 'com.testing.plist')
+    FileUtils.rm_f(path) if File.exist?(path)
     FileUtils.cp(plist_template, path)
     path
   end


### PR DESCRIPTION
### Motivation

Consider this command:

```
-c "Add :MyKey:0 string en"
```

If `MyKey` does not exist, then a new `Dict` container is created with one entry:

```
"0" => "en" (type String)
```

If `MyKey` exists and is an `Array`, then "en" is pushed onto the front of the list.

Because Xcode 9 (very) lazily creates various Simulator plists, run-loop has started creating empty plists if the expected ones do not exist (yet).

This can cause run-loop to add a `Dict` instead of an `Array` type container when setting the simulator language.

This pull request adds 2 methods to `PlistBuddy` to help run-loop correctly set the simulator language.

```
# Run an arbitrary (-c) command with PlistBuddy
run_command(cmd, path, options)

# Push a new value onto the front of an Array container
unshift_array(key, type, value, path, options)
```

Completes:

* run-loop: PlistBuddy needs a way to interact with Array containers [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/19939)

Progress:

* run-loop: cannot set language if AppleLanguage key does not already exist [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/19809)


