### PR TITLE
Device: use PlistBuddy#unshift_array to set Simulator language

### DIFF
--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -439,25 +439,14 @@ version: #{version}
 
       global_plist = simulator_global_preferences_path
 
-      cmd = [
-        "/usr/libexec/PlistBuddy",
-        "-c",
-        "Add :AppleLanguages:0 string '#{lang_code}'",
-        global_plist
-      ]
-
-      # RunLoop::PlistBuddy cannot add items to arrays.
-      hash = run_shell_command(cmd, {:log_cmd => true})
-
-      if hash[:exit_status] != 0
+      begin
+        pbuddy.unshift_array("AppleLanguages", "string", lang_code,
+                             global_plist)
+      rescue RuntimeError => e
         raise RuntimeError, %Q[
-Could not update the Simulator languages because this command:
+Could not update the Simulator languages.
 
-#{cmd.join(" ")}
-
-failed with this output:
-
-#{hash[:out]}
+#{e.message}
 
 ]
       end

--- a/spec/integration/core_simulator_spec.rb
+++ b/spec/integration/core_simulator_spec.rb
@@ -112,8 +112,12 @@ describe RunLoop::CoreSimulator do
   end
 
   it ".set_language" do
+    RunLoop::CoreSimulator.erase(simulator)
     actual = RunLoop::CoreSimulator.set_language(simulator, "en")
     expect(actual.first).to be == "en"
+
+    actual = RunLoop::CoreSimulator.set_language(simulator, "de")
+    expect(actual.first).to be == "de"
   end
 
   context ".app_installed?" do


### PR DESCRIPTION
### Motivation

Completes:

* run-loop: cannot set language if AppleLanguage key does not already exist [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/19809)