### PR TITLE
HTTP: client retries on unreachable host

### DIFF
--- a/lib/run_loop/http/retriable_client.rb
+++ b/lib/run_loop/http/retriable_client.rb
@@ -26,6 +26,8 @@ module RunLoop
           Errno::ECONNABORTED,
           # The foreign function call call timed out
           #Errno::ETIMEDOUT
+
+          Errno::EHOSTUNREACH
         ]
 
       # @!visibility private


### PR DESCRIPTION
### Motivation

iOS 11 devices are sometimes in this state.

Completes:

* run-loop: DeviceAgent HTTP clients needs to retry on Errno::EHOSTUNREACH [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/22073)