### PR TITLE
Updated XCUIElementType documentation

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -506,7 +506,7 @@ INSTANCE METHODS
       # ]
       # ```
       #
-      # @see http://masilotti.com/xctest-documentation/Constants/XCUIElementType.html
+      # @see https://developer.apple.com/documentation/xctest/xcuielementtype
       # @param [Hash] uiquery A hash describing the query.
       # @return [Array<Hash>] An array of elements matching the `uiquery`.
       def query(uiquery)


### PR DESCRIPTION
As with the main `calabash-ios` repo:

The previous URL is 404ing now as the owner got a cease and desist from Apple. Apple now have official documentation on XCTest.
