### PR TITLE
Xcode: add support for 9.1

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -320,7 +320,9 @@ Logfile: #{log_file}
     #  version.
     def self.default_simulator(xcode=RunLoop::Xcode.new)
 
-      if xcode.version_gte_90?
+      if xcode.version_gte_91?
+        "iPhone 7 (11.1)"
+      elsif xcode.version_gte_90?
         "iPhone 7 (11.0)"
       elsif xcode.version_gte_83?
         "iPhone 7 (10.3)"

--- a/lib/run_loop/xcode.rb
+++ b/lib/run_loop/xcode.rb
@@ -26,6 +26,14 @@ module RunLoop
       to_s
     end
 
+    # Returns a version instance for Xcode 9.1; used to check for the
+    # availability of features and paths to various items on the filesystem
+    #
+    # @return [RunLoop::Version] 9.1
+    def v91
+      fetch_version(:v91)
+    end
+
     # Returns a version instance for Xcode 9.0; used to check for the
     # availability of features and paths to various items on the filesystem
     #
@@ -152,6 +160,13 @@ module RunLoop
     # @return [RunLoop::Version] 5.0
     def v50
       fetch_version(:v50)
+    end
+
+    # Is the active Xcode version 9.1 or above?
+    #
+    # @return [Boolean] `true` if the current Xcode version is >= 9.1
+    def version_gte_91?
+      version >= v91
     end
 
     # Is the active Xcode version 9.0 or above?

--- a/spec/lib/core_spec.rb
+++ b/spec/lib/core_spec.rb
@@ -280,6 +280,12 @@ describe RunLoop::Core do
       expect(xcode).to receive(:version).at_least(:once).and_return xcode.v90
       expect(RunLoop::Core.default_simulator(xcode)).to be == expected
     end
+
+    it 'Xcode >= 9.1' do
+      expected = 'iPhone 7 (11.1)'
+      expect(xcode).to receive(:version).at_least(:once).and_return xcode.v91
+      expect(RunLoop::Core.default_simulator(xcode)).to be == expected
+    end
   end
 
   describe '.above_or_eql_version?' do

--- a/spec/lib/xcode_spec.rb
+++ b/spec/lib/xcode_spec.rb
@@ -94,6 +94,7 @@ Build version 8W132p
     expect(xcode.send(:fetch_version, key)).to be == version
   end
 
+  it '#v91' do expect(xcode.v91).to be == RunLoop::Version.new('9.1') end
   it '#v90' do expect(xcode.v90).to be == RunLoop::Version.new('9.0') end
   it '#v83' do expect(xcode.v83).to be == RunLoop::Version.new('8.3') end
   it '#v82' do expect(xcode.v82).to be == RunLoop::Version.new('8.2') end
@@ -110,6 +111,20 @@ Build version 8W132p
   it '#v60' do expect(xcode.v60).to be == RunLoop::Version.new('6.0') end
   it '#v51' do expect(xcode.v51).to be == RunLoop::Version.new('5.1') end
   it '#v50' do expect(xcode.v50).to be == RunLoop::Version.new('5.0') end
+
+  describe "#version_gte_91?" do
+    it "true" do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new("9.1"))
+
+      expect(xcode.version_gte_91?).to be_truthy
+    end
+
+    it "false" do
+      expect(xcode).to receive(:version).and_return xcode.v90
+
+      expect(xcode.version_gte_91?).to be_falsey
+    end
+  end
 
   describe "#version_gte_90?" do
     it "true" do


### PR DESCRIPTION
### Motivation

Completes:

* As a tester I want to use run-loop with Xcode 9.1 [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/24757)