### PR TITLE
DylibInjector: user can add delay before injecting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 # Force Xcode environment
 language: objective-c
 
-# Forces macOS 10.11
-osx_image: xcode7.3
+osx_image: xcode9
 
 before_script:
   - scripts/ci/travis/instruments-auth.sh
@@ -19,7 +18,6 @@ notifications:
   email:
     recipients:
       - joshuajmoody@gmail.com
-      - chris.fuentes@xamarin.com
     on_success: change
     on_failure: always
   slack:

--- a/spec/lib/dylib_injector_spec.rb
+++ b/spec/lib/dylib_injector_spec.rb
@@ -102,7 +102,8 @@ describe RunLoop::DylibInjector do
         }
 
         expect(lldb).to receive(:inject_dylib).with(3).exactly(5).times.and_return false
-        expect(lldb).to receive(:sleep).with(2).exactly(5).times.and_return true
+        # First sleep is the arbitrary delay.
+        expect(lldb).to receive(:sleep).exactly(6).times.and_return true
 
         expect do
           lldb.retriable_inject_dylib(options)
@@ -115,7 +116,8 @@ describe RunLoop::DylibInjector do
         timeout = RunLoop::DylibInjector::RETRY_OPTIONS[:timeout]
 
         expect(lldb).to receive(:inject_dylib).with(timeout).exactly(tries).times.and_return false
-        expect(lldb).to receive(:sleep).with(interval).exactly(tries).times.and_return true
+        # First sleep is the arbitrary delay.
+        expect(lldb).to receive(:sleep).exactly(tries + 1).times.and_return true
 
         expect do
           lldb.retriable_inject_dylib


### PR DESCRIPTION
### Motivation

Starting in Xcode 9, some apps are slow to launch completely.

If lldb tries to dlopen before the app is ready, the app launch will never complete - even on a retry.

Completes:

* As a run-loop user, I want to delay dylib injection because my app is slow to start [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/24761)