### PR TITLE
Improve CoreSimulator Services process management

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -148,7 +148,8 @@ class RunLoop::CoreSimulator
       end
     end
 
-    kill_options = { :timeout => 0.5 }
+    term_options = { :timeout => 0.1 }
+    kill_options = { :timeout => 0.0 }
 
     RunLoop::ProcessWaiter.pgrep_f("launchd_sim").each do |pid|
       process_name = ps_name_fn.call(pid)
@@ -543,7 +544,7 @@ Could not launch #{app.bundle_identifier} on #{device} after trying #{tries} tim
   # Send 'TERM' then 'KILL' to allow processes to quit cleanly.
   def self.term_or_kill(process_name, send_term_first)
     term_options = { :timeout => 0.5 }
-    kill_options = { :timeout => 0.5 }
+    kill_options = { :timeout => 0.0 }
 
     RunLoop::ProcessWaiter.new(process_name).pids.each do |pid|
 


### PR DESCRIPTION
### Motivation

Progress on:

* UITest, XCUITest, Appium, App Center, and Calabash support for Xcode 9.3 [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/33617)

When testing run-loop or iOSDeviceManager, it is possible for your machine to run out of process identifiers because of orphaned CoreSimulator services.   This often happens during Xcode beta testing and it forces a machine reboot.

This is not a new problem.  In the past, we have maintained a list of CoreSimulator services that we manage.  Xcode 9.3 betas have forced us to be more aggressive about managing the processes.

```
RunLoop::CoreSimulator.terminate_core_simulator_processes
```

`RunLoop::CoreSimulator.terminate_core_simulator_processes` called automatically when launching a simulator and then launching an app on that simulator fails.  The run-loop, iOSDeviceManager, and DeviceAgent tests call this method often to stabilize test execution.

It is called by this CLI command:

```
# Particularly useful on CI systems
$ run-loop simctl manage-processes
```
