### PR TITLE
Add element_types method to DeviceAgent client

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -809,6 +809,13 @@ Could not dismiss SpringBoard alert by touching button with title '#{button_titl
         json
       end
 
+      def element_types
+        request = request("element-types")
+        client = http_client(http_options)
+        response = client.get(request)
+        expect_300_response(response)["types"]
+      end
+
       # TODO: animation model
       def wait_for_animations
         sleep(0.5)


### PR DESCRIPTION
Added new method for DeviceAgent client which will be used in Cucumber tests.

[VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/Krukow-M1-Team/_workitems/edit/34509)