### PR TITLE
Ipa: create instance from extension-less zip archives

### DIFF
--- a/lib/run_loop/ipa.rb
+++ b/lib/run_loop/ipa.rb
@@ -2,6 +2,20 @@ module RunLoop
   # A model of the an .ipa - a application binary for iOS devices.
   class Ipa
 
+    require "run_loop/shell"
+
+    # Return true if the path_to_ipa to a zip archive
+    def self.is_zip_archive?(path_to_ipa)
+      hash = RunLoop::Shell.run_shell_command(["file", path_to_ipa],
+                                              {log_cmd: true})
+      hash[:out][/Zip archive data/]
+    end
+
+    # Return true if the path_to_ipa is probably an .ipa
+    def self.is_ipa?(path_to_ipa)
+      path_to_ipa.end_with?('.ipa') || RunLoop::Ipa.is_zip_archive?(path_to_ipa)
+    end
+
     # The path to this .ipa.
     # @!attribute [r] path
     # @return [String] A path to this .ipa.
@@ -13,12 +27,12 @@ module RunLoop
     # @raise [RuntimeError] If the file does not exist.
     # @raise [RuntimeError] If the file does not end in .ipa.
     def initialize(path_to_ipa)
-      unless File.exist? path_to_ipa
+      if !File.exist? path_to_ipa
         raise "Expected an ipa at '#{path_to_ipa}'"
       end
 
-      unless path_to_ipa.end_with?('.ipa')
-        raise "Expected '#{path_to_ipa}' to be an .ipa"
+      if !RunLoop::Ipa.is_ipa?(path_to_ipa)
+        raise "Expected '#{path_to_ipa}' have extension .ipa or be a zip archive"
       end
       @path = path_to_ipa
     end

--- a/spec/lib/ipa_spec.rb
+++ b/spec/lib/ipa_spec.rb
@@ -1,26 +1,42 @@
 describe RunLoop::Ipa do
 
   let(:ipa_path) { Resources.shared.cal_ipa_path  }
-
   let(:ipa) { RunLoop::Ipa.new(ipa_path) }
 
-  describe '.new' do
-    describe 'raises an exception' do
-      it 'when the path does not exist' do
-        expect {
-          RunLoop::Ipa.new('/path/does/not/exist')
-        }.to raise_error(RuntimeError)
-      end
+  context ".is_zip_archive?" do
+    it "returns true when the file at path is zip archive" do
+      hash = {out: "Zip archive data"}
+      expect(RunLoop::Shell).to receive(:run_shell_command).and_return(hash)
 
-      it 'when the path does not end in .ipa' do
-        expect(File).to receive(:exist?).with('/path/foo.app').and_return(true)
-        expect {
-          RunLoop::Ipa.new('/path/foo.app')
-        }.to raise_error(RuntimeError)
-      end
+      expect(RunLoop::Ipa.is_zip_archive?("path/to/app")).to be_truthy
     end
 
-    it 'sets the path' do
+    it "returns false when the file at path is not a zip archive" do
+      hash = {out: "Regular file"}
+      expect(RunLoop::Shell).to receive(:run_shell_command).and_return(hash)
+
+      expect(RunLoop::Ipa.is_zip_archive?("path/to/app")).to be_falsey
+    end
+  end
+
+  context ".new" do
+    it "raises an error when the path does not exist" do
+      expect do
+        RunLoop::Ipa.new('/path/does/not/exist')
+      end.to raise_error(RuntimeError)
+    end
+
+    it "raise an error when the file at path is not an ipa" do
+      path = "path/foo.app"
+      expect(RunLoop::Ipa).to receive(:is_ipa?).with(path).and_return(false)
+      expect(File).to receive(:exist?).with(path).and_return(true)
+
+      expect do
+        RunLoop::Ipa.new(path)
+      end.to raise_error(RuntimeError)
+    end
+
+    it "sets the path" do
       expect(ipa.path).to be == ipa_path
     end
   end


### PR DESCRIPTION
### Motivation

When we grab test run assets from App Center, the `.ipa` is usually named `app`.

The previous implementation of `RunLoop::Ipa` did not allow instances to be created from paths that did not end with a `.ipa` extension.

Allowing `Ipa` instances to be created from extension-less zip files will help automate the process of debugging App Center test runs.