### PR TITLE
Instruments: ignore devices without name or version

### DIFF
--- a/lib/run_loop/instruments.rb
+++ b/lib/run_loop/instruments.rb
@@ -218,8 +218,12 @@ module RunLoop
           udid = line[DEVICE_UDID_REGEX, 0]
           if udid
             version = line[VERSION_REGEX, 0]
-            name = line.split('(').first.strip
-            RunLoop::Device.new(name, version, udid)
+            if version
+              name = line.split('(').first.strip
+              if name
+                RunLoop::Device.new(name, version, udid)
+              end
+            end
           else
             nil
           end

--- a/spec/resources/instruments_output.rb
+++ b/spec/resources/instruments_output.rb
@@ -136,6 +136,7 @@ instruments[98552:4623] WebKit Threading Violation - initial use of WebKit from 
       DEVICES_GTE_70 = %q(
 Known Devices:
 stern [4AFA48C7-5D39-54D0-9733-04301E70E235]
+(null) [548929865d9d3f151f6f371c7c311e5160987abd]
 mercury (8.4.1) [5ddbd7cc1e0894a77811b3f41c8e5caecef3e912]
 neptune (9.0) [43be3f89d9587e9468c24672777ff6211bd91124]
 Apple TV 1080p (9.0) [7F01721F-B916-4608-8DCB-4AB164D48A1A]


### PR DESCRIPTION
### Motivation

New instruments behavior!

```
# Occurs when the host machine is not trusted by the device
null () [<udid>]
```


