### PR TITLE
Shell#run_shell_command responds to :environment option

### DIFF
--- a/lib/run_loop/shell.rb
+++ b/lib/run_loop/shell.rb
@@ -65,8 +65,12 @@ IO.popen requires all arguments to be Strings.
       hash = {}
       shell_start_time = Time.now
 
+      environment = options.fetch(:environment, {})
+
       begin
-        command_output = CommandRunner.run(args, timeout: timeout)
+        command_output = CommandRunner.run(args,
+                                           timeout: timeout,
+                                           environment: environment)
 
         out = ensure_command_output_utf8(command_output[:out], cmd)
         process_status = command_output[:status]

--- a/spec/lib/shell_spec.rb
+++ b/spec/lib/shell_spec.rb
@@ -104,6 +104,18 @@ describe RunLoop::Shell do
         expect(hash[:seconds_elapsed]).to be_truthy
       end
     end
+
+    it "responds to :environment option" do
+      hash = object.run_shell_command(["grep", "responds to :environment",
+                                       __FILE__])
+      expect(hash[:out][/responds to :environment/]).to be_truthy
+
+      environment = {"GREP_OPTIONS" => "-v"}
+      hash = object.run_shell_command(["grep", "responds to :environment",
+                                       __FILE__],
+                                      {environment: environment})
+      expect(hash[:out][/responds to :environment/]).to be_falsey
+    end
   end
 
   context "#timeout_exceeded?" do


### PR DESCRIPTION
### Motivation

This improves our ability to test against side-by-side Xcode installations.

```
environment = {"DEVELOPER_DIR" => "/Xcode/8.3.3/Xcode.app/Contents/Developer"}
RunLoop::Shell.run_shell_command(["xcrun", "-f", "xcodebuild"], {environment: environment})
```