### PR TITLE
Dir#digest: change how cumulative digest is computed

### DIFF
--- a/spec/integration/directory_spec.rb
+++ b/spec/integration/directory_spec.rb
@@ -1,0 +1,38 @@
+
+describe RunLoop::Directory do
+  let(:app_path) { Resources.shared.app_bundle_path }
+
+  context ".directory_digest" do
+    let(:tmpdir) { File.join(Resources.shared.local_tmp_dir, "digest") }
+
+    before do
+      FileUtils.rm_rf(tmpdir)
+      FileUtils.mkdir_p(tmpdir)
+    end
+
+    it "returns the same digest after ditto" do
+      original_digest = RunLoop::Directory.directory_digest(app_path)
+
+      copy_path = File.join(tmpdir, "App-copy.app")
+      RunLoop::Shell.run_shell_command(["ditto", app_path, copy_path])
+      copy_digest = RunLoop::Directory.directory_digest(copy_path)
+
+      expect(original_digest).to be == copy_digest
+    end
+
+    it "returns the same digest after 'xcrun install'" do
+      app = RunLoop::App.new(app_path)
+      original_digest = RunLoop::Directory.directory_digest(app_path)
+
+      device = Resources.shared.default_simulator
+      core_sim = RunLoop::CoreSimulator.new(device, app)
+      core_sim.uninstall_app_and_sandbox
+      core_sim.install
+
+      installed_path = core_sim.send(:installed_app_bundle_dir)
+      installed_digest = RunLoop::Directory.directory_digest(installed_path)
+
+      expect(original_digest).to be == installed_digest
+    end
+  end
+end

--- a/spec/lib/directory_spec.rb
+++ b/spec/lib/directory_spec.rb
@@ -81,7 +81,7 @@ describe RunLoop::Directory do
         options = { :handle_errors_by => :logging }
 
         error = RuntimeError.new("My runtime error")
-        expect(File).to receive(:read).with(path).and_raise error
+        expect(File).to receive(:read).with(path, {mode: "rb"}).and_raise error
 
         out = Kernel.capture_stdout do
           RunLoop::Directory.directory_digest(tmp_dir, options)
@@ -99,7 +99,7 @@ describe RunLoop::Directory do
         options = { :handle_errors_by => :ignoring }
 
         error = RuntimeError.new("My runtime error")
-        expect(File).to receive(:read).with(path).and_raise error
+        expect(File).to receive(:read).with(path, {mode: "rb"}).and_raise error
 
         out = Kernel.capture_stdout do
           RunLoop::Directory.directory_digest(tmp_dir, options)
@@ -112,7 +112,7 @@ describe RunLoop::Directory do
         options = { :handle_errors_by => :raising }
 
         error = RuntimeError.new("My runtime error")
-        expect(File).to receive(:read).with(path).and_raise error
+        expect(File).to receive(:read).with(path, {mode: "rb"}).and_raise error
 
         expect do
           RunLoop::Directory.directory_digest(tmp_dir, options)
@@ -121,7 +121,7 @@ describe RunLoop::Directory do
 
       it "the default behavior is to raise" do
         error = RuntimeError.new("My runtime error")
-        expect(File).to receive(:read).with(path).and_raise error
+        expect(File).to receive(:read).with(path, {mode: "rb"}).and_raise error
 
         expect do
           RunLoop::Directory.directory_digest(tmp_dir)


### PR DESCRIPTION
### Motivation

While creating deploy/ios clear-app-data tests for Calabash, I noticed that my .app was being re-installed between test runs.  This should not happen because the local .app was the same as the .app that was (already) installed on the simulator.  This was causing the clear-app-data tests to fail because the re-install was wiping the app data.

This implementation returns the expected result:  the local .app and the installed .app have the same digest after `xcrun simctl install <app>`.