### PR TITLE
Improve simulator "wait for stable" heuristic

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -424,6 +424,9 @@ class RunLoop::CoreSimulator
             '-CurrentDeviceUDID', device.udid,
             "-ConnectHardwareKeyboard", "0",
             "-DeviceBootTimeout", "120",
+            # Yes, this is the argument even though it is not spelled correctly
+            "-DetatchOnAppQuit", "0",
+            "-DetachOnWindowClose", "0",
             "LAUNCHED_BY_RUN_LOOP"]
 
     RunLoop.log_debug("Launching #{device} with:")

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -392,6 +392,7 @@ version: #{version}
         RunLoop.log_debug("Waited for #{elapsed} seconds for simulator to stabilize")
       else
         RunLoop.log_debug("Timed out after #{timeout} seconds waiting for simulator to stabilize")
+        RunLoop.log_debug("These simulator processes did not start: #{required.join(",")}")
       end
     end
 
@@ -613,11 +614,17 @@ Could not update the Simulator languages.
 
     # @!visibility private
     def simulator_required_child_processes
+      # required: ["SimulatorBridge", "medialibraryd"]
       @simulator_required_child_processes ||= begin
-        required = ["backboardd", "installd", "SimulatorBridge", "SpringBoard"]
+        if xcode.version_gte_83? && version.major > 10
+          required = ["backboardd", "installd", "SpringBoard", "suggestd"]
+        else
+          required = ["backboardd", "installd", "SimulatorBridge", "SpringBoard"]
+        end
+
         if xcode.version_gte_90?
           required << "filecoordinationd"
-        elsif xcode.version_gte_8? && version.major > 8
+        elsif xcode.version_gte_8? && (version.major > 8 && version.major < 11)
           required << "medialibraryd"
         end
 


### PR DESCRIPTION
### Motivation

We are migrating to Jenkins 2.0.  We have seen that jobs that use iOS Simulators are not stable.

In Jenkins 1.0, I ran a nightly job that "doctored" the iOS Simulators - erased all simulators and booted them so they would be ready for testing.  

I ran that job this morning and discovered a couple of interesting things:

1. Xcode 8.3.3 can launch iOS 11.0 and 11.1 simulators
2. Xcode 9.2 can launch iOS 8.2 simulators

In the case of Xcode 8.3.3, I discovered that the simulator-stable heuristic was not working for iOS > 10 - we were waiting for 240 seconds for the simulator to stabilize.

This pull request updates the heuristic for iOS > 10 on Xcode 8.3.3 so we will not wait for 240 seconds.

Since Xcode 9.2 appears to launch the same simulators as Xcode 8.3.3 + iOS 11.2 simulators, we can update the "doctor" job to run against Xcode 9.2 only.

