### PR TITLE
Core: fix default simulator for Xcode 10

### DIFF
--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -325,9 +325,8 @@ Logfile: #{log_file}
       major = xcode_major + 2
       minor = xcode_minor
 
-      # Early major Xcode beta releases do not have new hardware model numbers
-      if xcode.beta? && xcode_major == 10
-        model = xcode_major - 2
+      if xcode_major == 10
+        model = "XS"
       else
         model = xcode_major - 1
       end


### PR DESCRIPTION
[Azure DevOps](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/46616)

New device models no longer support convention being called `iPhone #{xcode.major_version - 1}`