### PR TITLE
Fix table row reordering test

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -33,7 +33,7 @@ module RunLoop
       DEFAULTS = {
         :port => 27753,
         :simulator_ip => "127.0.0.1",
-        :http_timeout => (RunLoop::Environment.ci? || RunLoop::Environment.xtc?) ? 120 : 20,
+        :http_timeout => (RunLoop::Environment.ci? || RunLoop::Environment.xtc?) ? 120 : 60,
         :route_version => "1.0",
 
         # Ignored in the XTC.


### PR DESCRIPTION
The problem with the "pan" test can be resolved by increasing the default timeout  value for all requests. An attempt to pass a timeout as a parameter to the query method did not fix the problem. Therefore, the standard timeout for all requests was changed. The set value (60) is used as the default value for receive_timeout in HTTPClient ([link](https://github.com/nahi/httpclient/blob/ddd141b30848a8c4df2dfa84602f80b5b8a5f362/lib/httpclient/session.rb#L136)).
No regression was found after these changes.