### PR TITLE
Do not bind run_loop to any versions of json

### DIFF
--- a/run_loop.gemspec
+++ b/run_loop.gemspec
@@ -47,7 +47,7 @@ tools like instruments and simctl.}
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency('json', '~> 1.8')
+  s.add_dependency('json')
   s.add_dependency('awesome_print', '~> 1.2')
   s.add_dependency('CFPropertyList','~> 2.2')
   s.add_dependency('thor', '>= 0.18.1', '< 1.0')


### PR DESCRIPTION
The version is quite outdated, in this way users are able to decide which version they want to use

Fixes #583