### PR TITLE
Fixed simulators availability check.

### DIFF
--- a/lib/run_loop/simctl.rb
+++ b/lib/run_loop/simctl.rb
@@ -596,7 +596,7 @@ while trying to list devices.
 
     # @!visibility private
     def device_available?(record)
-      record["availability"] == "(available)"
+      record["isAvailable"] == "YES" || record["availability"] == "(available)"
     end
 
     # @!visibility private

--- a/spec/lib/simctl_spec.rb
+++ b/spec/lib/simctl_spec.rb
@@ -598,6 +598,15 @@ describe RunLoop::Simctl do
           "udid" => "33E644E8-096B-4766-A957-4B34FB18DC48"
         }
       end
+      let(:new_xcode_record) do
+        {
+          "state" => "Shutdown",
+          "isAvailable" => "YES",
+          "name" => "iPhone 8",
+          "udid" => "BF6DFF2F-BF46-4348-AEFF-F676EE61A43E",
+          "availabilityError" => ""
+        }
+      end
       let(:version) { "9.1" }
 
       it "#device_available?" do
@@ -608,6 +617,13 @@ describe RunLoop::Simctl do
 
         record["availability"] =  " (unavailable, Mac OS X 10.11.4 is not supported)"
         expect(simctl.send(:device_available?, record)).to be_falsey
+      end
+
+      it "#new_device_available?" do
+        expect(simctl.send(:device_available?, new_xcode_record)).to be_truthy
+
+        new_xcode_record["isAvailable"] = "NO"
+        expect(simctl.send(:device_available?, new_xcode_record)).to be_falsey
       end
 
       it "#device_from_record" do


### PR DESCRIPTION
**Problem:** In new Xcode `xcrun simctl list devices --json` returns different output. With new output old run-loop availability check does not work.
**Root-cause:**
New JSON output from Xcode 10.1 beta 2 contains different parameters, e.g.:
```
{
    "state" : "Shutdown",
    "isAvailable" : "YES",
    "name" : "iPhone 8",
    "udid" : "BF6DFF2F-BF46-4348-AEFF-F676EE61A43E",
    "availabilityError" : ""
}
```
VS
Output from Xcode 10:
```
{
    "state" : "Shutdown",
    "availability" : "(available)",
    "name" : "iPhone 8",
    "udid" :  "BF6DFF2F-BF46-4348-AEFF-F676EE61A43E"
}
```
So we need to verify `isAvailable` and old `availability` parameters.

---
All tests passed locally with Xcode 10.1 beta 2.