### PR TITLE
Fixed regex for new device ids.

### DIFF
--- a/lib/run_loop/regex.rb
+++ b/lib/run_loop/regex.rb
@@ -10,7 +10,7 @@ module RunLoop
     XCODE_511_SIMULATOR_REGEX = /(\d)\.(\d)\.?(\d)?(-64)?/.freeze
 
     # @!visibility private
-    DEVICE_UDID_REGEX = /[a-f0-9]{40}/.freeze
+    DEVICE_UDID_REGEX = /[a-f0-9]{40}|([A-F0-9]{8}-[A-F0-9]{16})/.freeze
 
     # @!visibility private
     VERSION_REGEX = /(\d+\.\d+(\.\d+)?)/.freeze


### PR DESCRIPTION
- Changed regex to include new devices
This fix needed to enable iOSDeviceAgent tests locally.
```
Akvelon 8 (12.1) [c25eb5ffd7f1468b1adbafb684b34339ac67c950] - old device id format
Akvelon XS Max (12.0.1) [00008020-00196D9E3650003A] - new device id format
Apple TV (12.1) [DF19D6B2-C13A-4194-BF5E-0DBEA88A53DB] (Simulator) - simulator id format
```