### PR TITLE
Finish up keyboard issue

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -1463,6 +1463,12 @@ If the body empty, the DeviceAgent has probably crashed.
           RunLoop.log_debug("The DeviceAgent that is running is stale; shutting down")
           shutdown
         end
+        
+        core_simulator = RunLoop::CoreSimulator.new(device, nil)
+        if core_simulator.simulator_state_requires_relaunch?
+          RunLoop.log_debug("Simulator requires relaunch; shutting down")
+          shutdown
+        end
 
         if running?
           RunLoop.log_debug("DeviceAgent is already running")

--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -1463,13 +1463,15 @@ If the body empty, the DeviceAgent has probably crashed.
           RunLoop.log_debug("The DeviceAgent that is running is stale; shutting down")
           shutdown
         end
-        
-        core_simulator = RunLoop::CoreSimulator.new(device, nil)
-        if core_simulator.simulator_state_requires_relaunch?
-          RunLoop.log_debug("Simulator requires relaunch; shutting down")
-          shutdown
-        end
 
+        if device.simulator?
+          core_simulator = RunLoop::CoreSimulator.new(device, nil)
+          if core_simulator.simulator_state_requires_relaunch?
+            RunLoop.log_debug("Simulator requires relaunch; shutting down")
+            shutdown
+          end
+        end
+        
         if running?
           RunLoop.log_debug("DeviceAgent is already running")
           return true


### PR DESCRIPTION
The keyboard not appear issue was not completely fixed:
- if user run a Calabash test that succeeds, then use hw keyboard and run the next test. The keyboard check will be never called again, as the launch will not happen due to the fact that DeviceAgent is launched and healthy. 

The fix is checking simulator health also in `launch_cbx_runner`
