### PR TITLE
Simulator process is determined incorrectly during simulator relaunch

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -635,7 +635,7 @@ Could not launch #{app.bundle_identifier} on #{device} after trying #{tries} tim
   #
   # @return [Hash] details about the running simulator.
   def running_simulator_details
-    process_name = "MacOS/#{sim_name}"
+    process_name = sim_app_path
 
     args = ["ps", "x", "-o", "pid=,command="]
     hash = run_shell_command(args)

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -397,7 +397,7 @@ describe RunLoop::CoreSimulator do
 97656 /bin/ps x -o pid,command
 7656 /MacOS/SillySim
 }
-          expect(core_sim).to receive(:sim_name).and_return("SillySim")
+          expect(core_sim).to receive(:sim_app_path).and_return("/MacOS/SillySim")
           expect(core_sim).to receive(:run_shell_command).and_return(hash)
 
           details = core_sim.send(:running_simulator_details)
@@ -414,7 +414,7 @@ describe RunLoop::CoreSimulator do
 97656 /bin/ps x -o pid,command
 7656 /MacOS/SillySim -CurrentDeviceUDID 258C3EC3-EA59-49CB-A9FB-16186B039601 LAUNCHED_BY_RUN_LOOP
 }
-          expect(core_sim).to receive(:sim_name).and_return("SillySim")
+          expect(core_sim).to receive(:sim_app_path).and_return("/MacOS/SillySim")
           expect(core_sim).to receive(:run_shell_command).and_return(hash)
 
           details = core_sim.send(:running_simulator_details)

--- a/spec/lib/shell_spec.rb
+++ b/spec/lib/shell_spec.rb
@@ -41,7 +41,7 @@ describe RunLoop::Shell do
       expect do
         object.run_shell_command(["sleep", 5])
       end.to raise_error ArgumentError,
-      /Expected arg '5' to be a String, but found 'Fixnum'/
+      /Expected arg '5' to be a String, but found/
     end
 
     it "re-raises error if UTF8 encoding fails" do

--- a/spec/lib/xcrun_spec.rb
+++ b/spec/lib/xcrun_spec.rb
@@ -33,7 +33,7 @@ describe RunLoop::Xcrun do
       expect do
         xcrun.run_command_in_context(['sleep', 5])
       end.to raise_error ArgumentError,
-      /Expected arg '5' to be a String, but found 'Fixnum'/
+      /Expected arg '5' to be a String, but found/
     end
 
     it "re-raises error if UTF8 encoding fails" do


### PR DESCRIPTION
**Issue:**
Test fails in `run_loop/spec/integration/core_simulator_spec.rb`
`RunLoop::CoreSimulator#launch_simulator does not relaunch if the simulator is already running`

Test fails with error message:
`DEBUG: Simulator relaunch required: simulator was not launched by run_loop`

**Root cause:**
`running_simulator_details` function searches the first process with substring `MacOS/#{sim_name}`.
On Mojave there are two processes that matches this substr:
```
6055 /Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/XPCServices/SimulatorTrampoline.xpc/Contents/MacOS/SimulatorTrampoline
6105 /Xcode/10.2/Xcode.app/Contents/Developer/Applications/Simulator.app/Contents/MacOS/Simulator -CurrentDeviceUDID 6DE7902E-CAD6-4949-9037-C1A0319991FF -ConnectHardwareKeyboard 0 -DeviceBootTimeout 120 -DetatchOnAppQuit 0 -DetachOnWindowClose 0 LAUNCHED_BY_RUN_LOOP
```

**Fix:**
We need to use more specific searching pattern for Simulator process.
Since macOS command `ps x -o pid=,command=` returns the full path to the simulator we can use the full path as searching pattern.