### PR TITLE
Fix check for available simulators

### DIFF
--- a/lib/run_loop/simctl.rb
+++ b/lib/run_loop/simctl.rb
@@ -596,7 +596,7 @@ while trying to list devices.
 
     # @!visibility private
     def device_available?(record)
-      record["isAvailable"] == "YES" || record["availability"] == "(available)"
+      record["isAvailable"] == true || record["isAvailable"] == "YES" || record["availability"] == "(available)"
     end
 
     # @!visibility private

--- a/spec/lib/simctl_spec.rb
+++ b/spec/lib/simctl_spec.rb
@@ -607,6 +607,16 @@ describe RunLoop::Simctl do
           "availabilityError" => ""
         }
       end
+      let(:newer_xcode_record) do
+        {
+          "state" => "Shutdown",
+          "isAvailable" => true,
+          "name" => "iPhone 8",
+          "udid" => "BF6DFF2F-BF46-4348-AEFF-F676EE61A43E",
+          "availabilityError" => ""
+        }
+      end
+
       let(:version) { "9.1" }
 
       it "#device_available?" do

--- a/spec/lib/simctl_spec.rb
+++ b/spec/lib/simctl_spec.rb
@@ -636,6 +636,13 @@ describe RunLoop::Simctl do
         expect(simctl.send(:device_available?, new_xcode_record)).to be_falsey
       end
 
+      it "#newer_device_available?" do
+        expect(simctl.send(:device_available?, newer_xcode_record)).to be_truthy
+
+        newer_xcode_record["isAvailable"] = false
+        expect(simctl.send(:device_available?, newer_xcode_record)).to be_falsey
+      end
+
       it "#device_from_record" do
         actual = simctl.send(:device_from_record, record, version)
         expect(actual).to be_a_kind_of(RunLoop::Device)


### PR DESCRIPTION
The output format of `xcrun simctl list devices --json` seems to have changed the type of  `isAvailable`. It a boolean value now instead of "YES" or "NO".

```bash
09:56 $ xcrun simctl list devices --json
{
  "devices" : {
    "com.apple.CoreSimulator.SimRuntime.watchOS-5-1" : [

    ],
    "com.apple.CoreSimulator.SimRuntime.tvOS-12-1" : [

    ],
    "com.apple.CoreSimulator.SimRuntime.iOS-12-1" : [
      {
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPhone 5s",
        "udid" : "0C944D5C-DCF5-4FD5-9AD6-34091735FDF0"
      },
      {
        "state" : "Booted",
        "isAvailable" : true,
        "name" : "iPhone 7",
        "udid" : "6D73A12B-F34E-4132-BE05-97355B98506B"
      },
      {
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPhone X",
        "udid" : "5E963272-CE3B-4161-A6EE-EC4F44AF53F5"
      },
      {
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPhone Xs",
        "udid" : "F7E53429-2B83-4213-9C15-6EC4E3FB7DC7"
      },
      {
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPad Air 2",
        "udid" : "5976B5A7-A943-4609-B6E2-C9BFE2243759"
      }
    ]
  }
}
```