### PR TITLE
Fix keyboard on iOS 13

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -443,6 +443,7 @@ class RunLoop::CoreSimulator
     RunLoop::CoreSimulator.quit_simulator
     RunLoop::CoreSimulator.ensure_hardware_keyboard_connected(pbuddy)
     sim_keyboard.ensure_soft_keyboard_will_show
+    sim_keyboard.ensure_keyboard_tutorial_disabled
 
     args = ['open', '-g', '-a', sim_app_path, '--args',
             '-CurrentDeviceUDID', device.udid,

--- a/lib/run_loop/sim_keyboard_settings.rb
+++ b/lib/run_loop/sim_keyboard_settings.rb
@@ -28,6 +28,10 @@ module RunLoop
       pbuddy.plist_set('AutomaticMinimizationEnabled', 'bool', false, plist)
     end
 
+    def ensure_keyboard_tutorial_disabled
+      pbuddy.plist_set('DidShowContinuousPathIntroduction', 'bool', true, plist)
+    end
+
     # Enable/disable keyboard autocorrection
     #
     # @param [Boolean] condition, option passed by the user in launch arguments


### PR DESCRIPTION
When you open keyboard for the first time, it shows tutorial for Swipe keyboard using.
We should disable this tutorial to fix keyboard tests