### PR TITLE
Add support for Xcode 10.3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,9 @@ jobs:
       Mojave-Xcode-10.2.1:
         IMAGE_POOL: 'macOS-10.14'
         XCODE_VERSION: '10.2.1'
+      Mojave-Xcode-10.3:
+        IMAGE_POOL: 'macOS-10.14'
+        XCODE_VERSION: '10.3'
       Mojave-Xcode-11.0:
         IMAGE_POOL: 'macOS-10.14'
         XCODE_VERSION: '11'

--- a/lib/run_loop/core.rb
+++ b/lib/run_loop/core.rb
@@ -319,25 +319,10 @@ Logfile: #{log_file}
     # @param [RunLoop::Xcode] xcode Used to detect the current xcode
     #  version.
     def self.default_simulator(xcode=RunLoop::Xcode.new)
-      version = xcode.version
-      xcode_major = version.major
-      xcode_minor = version.minor
-      major = xcode_major + 2
-      minor = xcode_minor
+      ios_version = xcode.ios_version
+      device = xcode.default_device
 
-      if xcode_major == 11
-        model = "Xs"
-      elsif xcode_major == 10
-        if minor >= 2
-          model = "Xs"
-        else
-          model = "XS"
-        end
-      else
-        model = xcode_major - 1
-      end
-
-      "iPhone #{model} (#{major}.#{minor})"
+      "#{device} (#{ios_version.major}.#{ios_version.minor})"
     end
 
     def self.create_uia_pipe(repl_path)

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -259,6 +259,10 @@ version: #{version}
       end
 
       if ios_version.major == (xcode_version.major + 2)
+        if xcode_version.major == 10 && xcode_version.minor == 3
+          return ios_version.minor == 4
+        end
+
         return ios_version.minor <= xcode_version.minor
       end
 

--- a/lib/run_loop/xcode.rb
+++ b/lib/run_loop/xcode.rb
@@ -34,6 +34,14 @@ module RunLoop
       fetch_version(:v110)
     end
 
+  # Returns a version instance for Xcode 10.3; used to check for the
+    # availability of features and paths to various items on the filesystem
+    #
+    # @return [RunLoop::Version] 10.3
+    def v103
+      fetch_version(:v103)
+    end
+
     # Returns a version instance for Xcode 10.2; used to check for the
     # availability of features and paths to various items on the filesystem
     #
@@ -127,6 +135,13 @@ module RunLoop
     # @return [Boolean] `true` if the current Xcode version is >= 11.0
     def version_gte_110?
       version >= v110
+    end
+
+    # Is the active Xcode version 10.2 or above?
+    #
+    # @return [Boolean] `true` if the current Xcode version is >= 10.2
+    def version_gte_103?
+      version >= v103
     end
 
     # Is the active Xcode version 10.2 or above?
@@ -297,6 +312,35 @@ $ man xcode-select
         end
         path
       end
+    end
+
+    def ios_version
+      xcode_version = version
+      sim_major = xcode_version.major + 2
+      sim_minor = xcode_version.minor
+      if xcode_version == v103
+        sim_minor = 4
+      end
+
+      return RunLoop::Version.new("#{sim_major}.#{sim_minor}")
+    end
+
+    def default_device
+      xcode_version = version
+      if xcode_version.major == 11
+        return "iPhone Xs"
+      end
+
+      if xcode_version.major == 10
+        if xcode_version.minor >= 2
+          return "iPhone Xs"
+        else
+          return "iPhone XS"
+        end
+      end
+
+      # Xcode < 10
+      return "iPhone #{xcode_version.major - 1}"
     end
 
     private

--- a/lib/run_loop/xcode.rb
+++ b/lib/run_loop/xcode.rb
@@ -137,9 +137,9 @@ module RunLoop
       version >= v110
     end
 
-    # Is the active Xcode version 10.2 or above?
+    # Is the active Xcode version 10.3 or above?
     #
-    # @return [Boolean] `true` if the current Xcode version is >= 10.2
+    # @return [Boolean] `true` if the current Xcode version is >= 10.3
     def version_gte_103?
       version >= v103
     end

--- a/spec/integration/simulator_compatibility_spec.rb
+++ b/spec/integration/simulator_compatibility_spec.rb
@@ -20,7 +20,7 @@ describe "Simulator/Binary Compatibility Check" do
   end
 
   it "can launch i386 app on x86_64 simulator"  do
-    ios_version = (Resources.shared.xcode.version.major + 2) * 1.0
+    ios_version = Resources.shared.xcode.ios_version
     air = simctl.simulators.find do |device|
       (device.name.include? "iPad Air") &&
         device.version >= RunLoop::Version.new(ios_version.to_s)

--- a/spec/lib/xcode_spec.rb
+++ b/spec/lib/xcode_spec.rb
@@ -99,6 +99,7 @@ Build version 8W132p
   end
 
   it '#v110' do expect(xcode.v110).to be == RunLoop::Version.new('11.0') end
+  it '#v103' do expect(xcode.v103).to be == RunLoop::Version.new('10.3') end
   it '#v102' do expect(xcode.v102).to be == RunLoop::Version.new('10.2') end
   it '#v100' do expect(xcode.v100).to be == RunLoop::Version.new('10.0') end
   it '#v94' do expect(xcode.v94).to be == RunLoop::Version.new('9.4') end
@@ -122,6 +123,20 @@ Build version 8W132p
       expect(xcode).to receive(:version).and_return xcode.v94
 
       expect(xcode.version_gte_110?).to be_falsey
+    end
+  end
+
+  describe "#version_gte_103?" do
+    it "true" do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new("10.3"))
+
+      expect(xcode.version_gte_103?).to be_truthy
+    end
+
+    it "false" do
+      expect(xcode).to receive(:version).and_return xcode.v94
+
+      expect(xcode.version_gte_103?).to be_falsey
     end
   end
 
@@ -327,6 +342,75 @@ Build version 8W132p
       expect(xcode).to receive(:developer_dir).and_return app
 
       expect(xcode.beta?).to be_falsey
+    end
+  end
+
+  describe '#ios_version' do
+    it 'expect 11.4 for Xcode 9.4.1' do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new("9.4.1"))
+      expect(xcode.ios_version).to be == RunLoop::Version.new('11.4')
+    end
+
+    it 'expect 12.0 for Xcode 10.0' do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new("10.0"))
+      expect(xcode.ios_version).to be == RunLoop::Version.new('12.0')
+    end
+
+    it 'expect 12.1 for Xcode 10.1' do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new("10.1"))
+      expect(xcode.ios_version).to be == RunLoop::Version.new('12.1')
+    end
+
+    it 'expect 12.2 for Xcode 10.2.1' do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new("10.2.1"))
+      expect(xcode.ios_version).to be == RunLoop::Version.new('12.2')
+    end
+
+    it 'expect 12.4 for Xcode 10.3' do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new("10.3"))
+      expect(xcode.ios_version).to be == RunLoop::Version.new('12.4')
+    end
+
+    it 'expect 13.0 for Xcode 11.0' do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new("11.0"))
+      expect(xcode.ios_version).to be == RunLoop::Version.new('13.0')
+    end
+  end
+
+  describe '#default_device' do
+    it 'expect iPhone 7 for Xcode 8.3.3' do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new("8.3.3"))
+      expect(xcode.default_device).to be == "iPhone 7"
+    end
+
+    it 'expect iPhone 8 for Xcode 9.4.1' do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new("9.4.1"))
+      expect(xcode.default_device).to be == "iPhone 8"
+    end
+
+    it 'expect iPhone XS for Xcode 10.0' do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new("10.0"))
+      expect(xcode.default_device).to be == "iPhone XS"
+    end
+
+    it 'expect iPhone XS for Xcode 10.1' do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new("10.1"))
+      expect(xcode.default_device).to be == "iPhone XS"
+    end
+
+    it 'expect iPhone Xs for Xcode 10.2.1' do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new("10.2.1"))
+      expect(xcode.default_device).to be == "iPhone Xs"
+    end
+
+    it 'expect iPhone Xs for Xcode 10.3' do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new("10.3"))
+      expect(xcode.default_device).to be == "iPhone Xs"
+    end
+
+    it 'expect iPhone Xs for Xcode 11.0' do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new("11.0"))
+      expect(xcode.default_device).to be == "iPhone Xs"
     end
   end
 end


### PR DESCRIPTION
**Changes:**
1) Include configuration `Mojave + Xcode 10.3` to the yml file
2) Fix `ios_version` on Xcode 10.3
Previously we used mapping `ios_version.minor = xcode_minor` but `Xcode 10.3` contains simulators for `12.4`
3) Refactoring:
- Moved logic to get default simulator to the Xcode class
- Moved logic to get ios_version to the Xcode class

The main advantage of this refactoring is that we can reuse this logic in other services.
For example, the following logic exists in `calabash-ios-server` too
```
version = xcode.version
      xcode_major = version.major
      xcode_minor = version.minor
      major = xcode_major + 2
      minor = xcode_minor
```
4) Add tests to cover new logic