### PR TITLE
Fix unstable simulators count test

### DIFF
--- a/spec/integration/detect_simulators_spec.rb
+++ b/spec/integration/detect_simulators_spec.rb
@@ -1,7 +1,7 @@
 describe "Detect iOS Simulators" do
   it "Instruments and Simctl agree on the simulator count" do
-    simcontrol = Resources.shared.simctl.simulators.count
-    instruments = Resources.shared.instruments.simulators.count
+    simcontrol = RunLoop::Simctl.new.simulators.count
+    instruments = RunLoop::Instruments.new.simulators.count
     expect(instruments).to be == simcontrol
   end
 end


### PR DESCRIPTION
We have found problem with `Instruments and Simctl agree on the simulator count` test, this test randomly fails, but always pass when we run single test.

It fails because xcode `instruments` simulators count is cached and not equal xcode `simctl` simulators count.

As fix we have initialized new instances of classes `Instruments` and `Simctl` to avoid caching.

Note: this issue randomly reproduces on all xcode versions. 