### PR TITLE
patch Device#compatible_with_xcode_version?

### DIFF
--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -260,12 +260,11 @@ version: #{version}
 
       if ios_version.major == (xcode_version.major + 2)
         if xcode_version.major == 10 && xcode_version.minor == 3
-          return ios_version.minor == 4
+          return ios_version.minor <= 4
+        else
+          return ios_version.minor <= xcode_version.minor
         end
-
-        return ios_version.minor <= xcode_version.minor
       end
-
       false
     end
 

--- a/spec/lib/device_spec.rb
+++ b/spec/lib/device_spec.rb
@@ -213,7 +213,6 @@ describe RunLoop::Device do
 
       xcode_version = RunLoop::Version.new("12.0")
       expect(device.compatible_with_xcode_version?(xcode_version)).to be_truthy
-
     end
 
     it "returns false if simulator iOS version is too low for Xcode version" do
@@ -246,6 +245,14 @@ describe RunLoop::Device do
       expect(device.compatible_with_xcode_version?(xcode_version)).to be_falsey
 
       xcode_version = RunLoop::Version.new("9.1")
+      expect(device.compatible_with_xcode_version?(xcode_version)).to be_falsey
+    end
+
+    it "returns false if iOS beta version is too high for the Xcode version" do
+      device_version = RunLoop::Version.new("13.0")
+      expect(device).to receive(:version).at_least(:once).and_return(device_version)
+
+      xcode_version = RunLoop::Version.new("10.3")
       expect(device.compatible_with_xcode_version?(xcode_version)).to be_falsey
     end
 


### PR DESCRIPTION
### Motivation

While testing Xcode 11 b6, I noticed two problems.  I had 2 device connected - iOS 12.1.2 and iOS 13.0 beta 7.

When targeting Xcode 10.3, `Device#compatible_with_xcode_version?` returned the iOS 13.0 beta 7 device as compatible and iOS 12.1.2 was not compatible.

The reverse is true - Xcode 10.3 can target 12.1.2 devices and cannot target iOS 13 devices.

