### PR TITLE
Add special method for CoreSimulator directory

### DIFF
--- a/lib/run_loop/core_simulator.rb
+++ b/lib/run_loop/core_simulator.rb
@@ -1163,23 +1163,18 @@ Command had no output.
 
   # @!visibility private
   def self.system_applications_dir(xcode=RunLoop::Xcode.new)
-    base_dir = xcode.developer_dir
-
-    if xcode.version_gte_110?
-      apps_dir = File.join("Platforms", "iPhoneOS.platform", "Library",
-                           "Developer", "CoreSimulator", "Profiles", "Runtimes",
-                           "iOS.simruntime", "Contents", "Resources",
-                           "RuntimeRoot", "Applications")
-    elsif xcode.version_gte_90?
-      apps_dir = File.join("Platforms", "iPhoneOS.platform", "Developer",
-                           "Library", "CoreSimulator", "Profiles", "Runtimes",
-                           "iOS.simruntime", "Contents", "Resources",
-                           "RuntimeRoot", "Applications")
+    if xcode.version_gte_90?
+      apps_dir = File.join(xcode.core_simulator_dir,
+                          "Profiles", "Runtimes", "iOS.simruntime",
+                          "Contents", "Resources", "RuntimeRoot",
+                          "Applications")
     else
-      apps_dir = File.join("Platforms", "iPhoneSimulator.platform", "Developer",
-                           "SDKs", "iPhoneSimulator.sdk", "Applications")
+      apps_dir = File.join(xcode.developer_dir,
+                          "Platforms", "iPhoneSimulator.platform",
+                          "Developer", "SDKs", "iPhoneSimulator.sdk",
+                          "Applications")
     end
-    File.expand_path(File.join(base_dir, apps_dir))
+    File.expand_path(apps_dir)
   end
 
   # @!visibility private

--- a/lib/run_loop/device.rb
+++ b/lib/run_loop/device.rb
@@ -780,15 +780,12 @@ https://github.com/calabash/calabash-ios/wiki/Testing-on-Physical-Devices
 
     # @!visibility private
     def simulator_running_system_app_pids
-      base_dir = xcode.developer_dir
-      if xcode.version_gte_110?
-        sim_apps_dir = "Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/Applications"
-      elsif xcode.version_gte_90?
-        sim_apps_dir = "Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/Applications"
+      if xcode.version_gte_90?
+        sim_apps_dir = File.join(xcode.core_simulator_dir, "Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/Applications")
       else
-        sim_apps_dir = "Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/Applications"
+        sim_apps_dir = File.join(xcode.developer_dir, "Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/Applications")
       end
-      path = File.expand_path(File.join(base_dir, sim_apps_dir))
+      path = File.expand_path(sim_apps_dir)
       RunLoop::ProcessWaiter.pgrep_f(path)
     end
   end

--- a/lib/run_loop/l10n.rb
+++ b/lib/run_loop/l10n.rb
@@ -17,9 +17,8 @@ module RunLoop
       key_name_lookup_table(lookup_table_dir)[key_code]
     end
 
-    UIKIT_AXBUNDLE_PATH_CORE_SIM = 'Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/AccessibilityBundles/UIKit.axbundle/'
-    UIKIT_AXBUNDLE_PATH_CORE_SIM_XCODE_9 = "Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/AccessibilityBundles/UIKit.axbundle"
-    UIKIT_AXBUNDLE_PATH_CORE_SIM_XCODE_11 = "Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/AccessibilityBundles/UIKit.axbundle"
+    UIKIT_AXBUNDLE_PATH_CORE_SIM = 'Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/AccessibilityBundles/UIKit.axbundle'
+    UIKIT_AXBUNDLE_PATH_CORE_SIM_XCODE_9 = "Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/AccessibilityBundles/UIKit.axbundle"
 
     LANG_CODE_TO_LANG_NAME_MAP = {
           'en' => 'English',
@@ -72,10 +71,8 @@ module RunLoop
     end
 
     def uikit_bundle_l10n_path
-      if xcode.version_gte_110?
-        File.join(xcode.developer_dir, UIKIT_AXBUNDLE_PATH_CORE_SIM_XCODE_11)
-      elsif xcode.version_gte_90?
-        File.join(xcode.developer_dir, UIKIT_AXBUNDLE_PATH_CORE_SIM_XCODE_9)
+      if xcode.version_gte_90?
+        File.join(xcode.core_simulator_dir, UIKIT_AXBUNDLE_PATH_CORE_SIM_XCODE_9)
       else
         File.join(xcode.developer_dir, UIKIT_AXBUNDLE_PATH_CORE_SIM)
       end

--- a/lib/run_loop/xcode.rb
+++ b/lib/run_loop/xcode.rb
@@ -314,6 +314,19 @@ $ man xcode-select
       end
     end
 
+    def core_simulator_dir
+      if version_gte_110?
+        core_simulator_dir = File.join(developer_dir,
+                                      'Platforms', 'iPhoneOS.platform', 'Library',
+                                      'Developer', 'CoreSimulator')
+      else
+        core_simulator_dir = File.join(developer_dir,
+                                      'Platforms', 'iPhoneOS.platform', 'Developer',
+                                      'Library', 'CoreSimulator')
+      end
+      File.expand_path(core_simulator_dir)
+    end
+
     def ios_version
       xcode_version = version
       sim_major = xcode_version.major + 2

--- a/spec/lib/core_simulator_spec.rb
+++ b/spec/lib/core_simulator_spec.rb
@@ -1281,5 +1281,43 @@ describe RunLoop::CoreSimulator do
         expect(core_sim.send(:sim_app_path)).to be == expected
       end
     end
+
+    describe '#system_applications_dir' do
+      it 'expect correct path for Xcode 8.3.3' do
+        xcode = RunLoop::Xcode.new
+        expect(xcode).to receive(:version).and_return(RunLoop::Version.new('8.3.3'))
+        expect(xcode).to receive(:developer_dir).and_return('/Xcode')
+        expected = '/Xcode/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/Applications'
+        actual = RunLoop::CoreSimulator.system_applications_dir(xcode)
+        expect(actual).to be == expected
+      end
+
+      it 'expect correct path for Xcode 9.4.1' do
+        xcode = RunLoop::Xcode.new
+        expect(xcode).to receive(:version).twice.and_return(RunLoop::Version.new('9.4.1'))
+        expect(xcode).to receive(:developer_dir).and_return('/Xcode')
+        expected = '/Xcode/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/Applications'
+        actual = RunLoop::CoreSimulator.system_applications_dir(xcode)
+        expect(actual).to be == expected
+      end
+
+      it 'expect correct path for Xcode 10.2.1' do
+        xcode = RunLoop::Xcode.new
+        expect(xcode).to receive(:version).twice.and_return(RunLoop::Version.new('10.2.1'))
+        expect(xcode).to receive(:developer_dir).and_return('/Xcode')
+        expected = '/Xcode/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/Applications'
+        actual = RunLoop::CoreSimulator.system_applications_dir(xcode)
+        expect(actual).to be == expected
+      end
+
+      it 'expect correct path for Xcode 11.0' do
+        xcode = RunLoop::Xcode.new
+        expect(xcode).to receive(:version).twice.and_return(RunLoop::Version.new('11.0'))
+        expect(xcode).to receive(:developer_dir).and_return('/Xcode')
+        expected = '/Xcode/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/Applications'
+        actual = RunLoop::CoreSimulator.system_applications_dir(xcode)
+        expect(actual).to be == expected
+      end
+    end
   end
 end

--- a/spec/lib/l10n_spec.rb
+++ b/spec/lib/l10n_spec.rb
@@ -7,40 +7,29 @@ describe RunLoop::L10N do
     allow(l10n).to receive(:xcode).and_return(xcode)
   end
   describe '#uikit_bundle_l10n_path' do
-    it "returns a valid path for Xcode >= 11" do
-      expect(xcode).to receive(:developer_dir).and_return("/some/xcode/path")
-      stub_env("DEVELOPER_DIR", "/some/xcode/path")
+    it 'returns a valid path for Xcode >= 11' do
+      expect(xcode).to receive(:version).twice.and_return(RunLoop::Version.new('11.0'))
+      expect(xcode).to receive(:developer_dir).and_return('/Xcode')
 
-      expect(xcode).to receive(:version_gte_110?).and_return(true)
-
-      axbundle_path = RunLoop::L10N.const_get("UIKIT_AXBUNDLE_PATH_CORE_SIM_XCODE_11")
-      expected = File.join("/some/xcode/path", axbundle_path)
+      expected = '/Xcode/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/AccessibilityBundles/UIKit.axbundle'
 
       expect(l10n.send(:uikit_bundle_l10n_path)).to be == expected
     end
 
-    it "returns a valid path for 9 <= Xcode < 11 " do
-      expect(xcode).to receive(:developer_dir).and_return("/some/xcode/path")
-      stub_env("DEVELOPER_DIR", "/some/xcode/path")
+    it 'returns a valid path for 9 <= Xcode < 11' do
+      expect(xcode).to receive(:version).twice.and_return(RunLoop::Version.new('10.2.1'))
+      expect(xcode).to receive(:developer_dir).and_return('/Xcode')
 
-      expect(xcode).to receive(:version_gte_110?).and_return(false)
-      expect(xcode).to receive(:version_gte_90?).and_return(true)
-
-      axbundle_path = RunLoop::L10N.const_get("UIKIT_AXBUNDLE_PATH_CORE_SIM_XCODE_9")
-      expected = File.join("/some/xcode/path", axbundle_path)
+      expected = '/Xcode/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/AccessibilityBundles/UIKit.axbundle'
 
       expect(l10n.send(:uikit_bundle_l10n_path)).to be == expected
     end
 
-    it "returns a valid path for Xcode < 9" do
-      expect(xcode).to receive(:developer_dir).and_return("/some/xcode/path")
-      stub_env("DEVELOPER_DIR", "/some/xcode/path")
+    it 'returns a valid path for Xcode < 9' do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new('8.3.3'))
+      expect(xcode).to receive(:developer_dir).and_return('/Xcode')
 
-      expect(xcode).to receive(:version_gte_110?).and_return(false)
-      expect(xcode).to receive(:version_gte_90?).and_return(false)
-
-      axbundle_path = RunLoop::L10N.const_get("UIKIT_AXBUNDLE_PATH_CORE_SIM")
-      expected = File.join("/some/xcode/path", axbundle_path)
+      expected = '/Xcode/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/AccessibilityBundles/UIKit.axbundle'
 
       expect(l10n.send(:uikit_bundle_l10n_path)).to be == expected
     end

--- a/spec/lib/xcode_spec.rb
+++ b/spec/lib/xcode_spec.rb
@@ -413,4 +413,27 @@ Build version 8W132p
       expect(xcode.default_device).to be == "iPhone Xs"
     end
   end
+
+  describe '#core_simulator_dir' do
+    it 'expect correct path for Xcode 9.4.1' do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new('9.4.1'))
+      expect(xcode).to receive(:developer_dir).and_return('/Xcode')
+      expected = '/Xcode/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator'
+      expect(xcode.core_simulator_dir).to be == expected
+    end
+
+    it 'expect correct path for Xcode 10.3' do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new('10.3'))
+      expect(xcode).to receive(:developer_dir).and_return('/Xcode')
+      expected = '/Xcode/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator'
+      expect(xcode.core_simulator_dir).to be == expected
+    end
+
+    it 'expect correct path for Xcode 11.0' do
+      expect(xcode).to receive(:version).and_return(RunLoop::Version.new('11.0'))
+      expect(xcode).to receive(:developer_dir).and_return('/Xcode')
+      expected = '/Xcode/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator'
+      expect(xcode.core_simulator_dir).to be == expected
+    end
+  end
 end


### PR DESCRIPTION
Small improvement for run-loop that will be very helpful for springboard-alert tool since it depends on CoreSimulator path.

1) Add method `core_simulator_dir` to Xcode class
2) Fix all places where the path is hardcoded
3) Fix existing tests
4) Add new tests