### PR TITLE
Change default device for Xcode 11.0

### DIFF
--- a/lib/run_loop/xcode.rb
+++ b/lib/run_loop/xcode.rb
@@ -341,7 +341,7 @@ $ man xcode-select
     def default_device
       xcode_version = version
       if xcode_version.major == 11
-        return "iPhone Xs"
+        return "iPhone 11"
       end
 
       if xcode_version.major == 10

--- a/spec/lib/xcode_spec.rb
+++ b/spec/lib/xcode_spec.rb
@@ -408,9 +408,9 @@ Build version 8W132p
       expect(xcode.default_device).to be == "iPhone Xs"
     end
 
-    it 'expect iPhone Xs for Xcode 11.0' do
+    it 'expect iPhone 11 for Xcode 11.0' do
       expect(xcode).to receive(:version).and_return(RunLoop::Version.new("11.0"))
-      expect(xcode.default_device).to be == "iPhone Xs"
+      expect(xcode.default_device).to be == "iPhone 11"
     end
   end
 


### PR DESCRIPTION
`iPhone Xs` simulator was removed from default simulator list in `Xcode 11 GM seed 1`. Replace it to `iPhone 11`