### PR TITLE
Add relaunch DeviceAgent, when error "Could not connect to the DeviceAgent" is occured.

### DIFF
--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -164,6 +164,8 @@ module RunLoop
                                                             DEFAULTS[:shutdown_device_agent_before_launch])
         terminate_aut_before_test = options.fetch(:terminate_aut_before_test,
                                                    DEFAULTS[:terminate_aut_before_test])
+        device_agent_launch_retries = options.fetch(:device_agent_launch_retries,
+                                                   DEFAULTS[:device_agent_launch_retries])
 
         aut_args = options.fetch(:args, [])
         aut_env = options.fetch(:env, {})

--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -1489,6 +1489,7 @@ If the body empty, the DeviceAgent has probably crashed.
         rescue RunLoop::HTTP::Error => _
           retries += 1
           puts "Could not connect to DeviceAgent service, relaunch and try again (this #{retries + 1} attempt)"
+          shutdown
           retry if (retries) <= options[:device_agent_launch_retries]
           raise %Q[
 

--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -1479,7 +1479,7 @@ If the body empty, the DeviceAgent has probably crashed.
         begin
           retries ||= 0
           @launcher_pid = cbx_launcher.launch(options)
-          timeout = options[:device_agent_install_timeout] * 0.3
+          timeout = options[:device_agent_install_timeout] * 0.5
           health_options = {
             :timeout => timeout,
             :interval => 0.1,

--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -1490,7 +1490,7 @@ If the body empty, the DeviceAgent has probably crashed.
           retries += 1
           puts "Could not connect to DeviceAgent service, relaunch and try again (this #{retries + 1} attempt)"
           shutdown
-          retry if (retries) <= options[:device_agent_launch_retries]
+          retry if (retries) <= 2
           raise %Q[
 
 Could not connect to the DeviceAgent service.

--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -59,7 +59,7 @@ module RunLoop
         # this value if you are timing out typing strings.
         :characters_per_second => 12,
         
-        # This value is number attempts for relaunch DeviceAgent
+        # The number of attempts for relaunch DeviceAgent
         # when health check is failed
         :device_agent_launch_retries => 2
       }
@@ -1487,8 +1487,9 @@ If the body empty, the DeviceAgent has probably crashed.
           }
           health(health_options)
         rescue RunLoop::HTTP::Error => _
-          puts "Could not connect to DeviceAgent service, relaunch and try again (this #{retries + 2} attempt)"
-          retry if (retries += 1) <= options[:device_agent_launch_retries]
+          retries += 1
+          puts "Could not connect to DeviceAgent service, relaunch and try again (this #{retries + 1} attempt)"
+          retry if (retries) <= options[:device_agent_launch_retries]
           raise %Q[
 
 Could not connect to the DeviceAgent service.

--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -180,7 +180,8 @@ module RunLoop
             terminate_aut_before_test: terminate_aut_before_test,
             dylib_injection_details: dylib_injection_details,
             aut_args: aut_args,
-            aut_env: aut_env
+            aut_env: aut_env,
+            device_agent_launch_retries: device_agent_launch_retries
         }
 
         xcuitest = RunLoop::DeviceAgent::Client.new(bundle_id, device,
@@ -1490,7 +1491,7 @@ If the body empty, the DeviceAgent has probably crashed.
           retries += 1
           puts "Could not connect to DeviceAgent service, relaunch and try again (this #{retries + 1} attempt)"
           shutdown
-          retry if (retries) <= 2
+          retry if (retries) <= options[:device_agent_launch_retries]
           raise %Q[
 
 Could not connect to the DeviceAgent service.

--- a/lib/run_loop/device_agent/client.rb
+++ b/lib/run_loop/device_agent/client.rb
@@ -61,7 +61,7 @@ module RunLoop
         
         # The number of attempts for relaunch DeviceAgent
         # when health check is failed
-        :device_agent_launch_retries => 2
+        :device_agent_launch_retries => 3
       }
 
       AUT_LAUNCHED_BY_RUN_LOOP_ARG = "LAUNCHED_BY_RUN_LOOP"
@@ -1489,7 +1489,8 @@ If the body empty, the DeviceAgent has probably crashed.
           health(health_options)
         rescue RunLoop::HTTP::Error => _
           retries += 1
-          puts "Could not connect to DeviceAgent service, relaunch and try again (this #{retries + 1} attempt)"
+          sleep(2.0)
+          RunLoop.log_debug("Could not connect to DeviceAgent service on try #{retries + 1}; will retry")
           shutdown
           retry if (retries) <= options[:device_agent_launch_retries]
           raise %Q[


### PR DESCRIPTION
Problem: sometimes, while cucumber tests execute, we can face error "Could not connect to the DeviceAgent service" (health check is failed).

Solution: try to relaunch DeviceAgent and repeat health check.