### PR TITLE
Add passing the port from the env variables

### DIFF
--- a/lib/run_loop/device_agent/ios_device_manager.rb
+++ b/lib/run_loop/device_agent/ios_device_manager.rb
@@ -237,6 +237,7 @@ Could not find an xctestrun file at path:
           path = File.join(IOSDeviceManager.dot_dir, "DeviceAgent-simulator.xctestrun")
           contents = File.read(template).force_encoding("UTF-8")
           substituted = contents.gsub("TEST_HOST_PATH", runner.runner)
+          substituted = substituted.gsub("CBX_SERVER_PORT", runner.port)
           File.open(path, "w:UTF-8") do |file|
             file.write(substituted)
           end

--- a/lib/run_loop/device_agent/runner.rb
+++ b/lib/run_loop/device_agent/runner.rb
@@ -114,6 +114,16 @@ but runner does not exist at that path.
         end
       end
 
+      def port
+        @port ||= begin
+          if device.physical_device?
+            27753
+          else
+            RunLoop::Environment.port
+          end
+        end
+      end  
+
       # @!visibility private
       def tester
         @tester ||= File.join(runner, "PlugIns", "DeviceAgent.xctest")

--- a/lib/run_loop/environment.rb
+++ b/lib/run_loop/environment.rb
@@ -57,6 +57,15 @@ module RunLoop
       end
     end
 
+    def self.port
+      value = ENV["CBX_SERVER_PORT"]
+      if value.nil? || value == ""
+        27753
+      else
+        value
+      end
+    end
+
     # Should the app data be reset between Scenarios?
     def self.reset_between_scenarios?
       ENV["RESET_BETWEEN_SCENARIOS"] == "1"


### PR DESCRIPTION
This is to support the changes to the DeviceAgent repo for using a custom port for running the tests https://github.com/calabash/DeviceAgent.iOS/pull/373/commits/07c0142271c183e038fe7f277f826adc249a1af7 
