### PR TITLE
Fix "conversion of Integer into String" error

### DIFF
--- a/lib/run_loop/device_agent/ios_device_manager.rb
+++ b/lib/run_loop/device_agent/ios_device_manager.rb
@@ -237,7 +237,7 @@ Could not find an xctestrun file at path:
           path = File.join(IOSDeviceManager.dot_dir, "DeviceAgent-simulator.xctestrun")
           contents = File.read(template).force_encoding("UTF-8")
           substituted = contents.gsub("TEST_HOST_PATH", runner.runner)
-          substituted = substituted.gsub("CBX_SERVER_PORT", runner.port)
+          substituted = substituted.gsub("CBX_SERVER_PORT", "#{runner.port}")
           File.open(path, "w:UTF-8") do |file|
             file.write(substituted)
           end


### PR DESCRIPTION
There were a little mistake in the `ios_device_manager.rb` file, which caused a test failure with `no implicit conversion of Integer into String` error.
This PR should fix this error.