### PR TITLE
Fixed warning 'Using the last argument as keyword parameters is deprecated'

### DIFF
--- a/lib/run_loop/directory.rb
+++ b/lib/run_loop/directory.rb
@@ -66,7 +66,7 @@ found '#{handle_errors_by}'
         if !self.skip_file?(path, "SHA256", debug)
           begin
             file_sha = OpenSSL::Digest::SHA256.new
-            contents = File.read(path, {mode: "rb"})
+            contents = File.read(path, **{mode: "rb"})
             file_sha << contents
             cumulative << contents
             file_shas << [file_sha.hexdigest]


### PR DESCRIPTION
Fixed this deprecation because it was throwing warnings on ruby 2.7.0 environment.