### PR TITLE
Update maximum version of 'i18n' dependecy

### DIFF
--- a/run_loop.gemspec
+++ b/run_loop.gemspec
@@ -52,7 +52,7 @@ tools like instruments and simctl.}
   s.add_dependency('thor', '>= 0.20.0', '< 1.0')
   s.add_dependency('command_runner_ng', '>= 0.1.4', '< 1.0')
   s.add_dependency("httpclient", ">= 2.7.1", "< 3.0")
-  s.add_dependency("i18n", ">= 0.7.0", "< 1.0")
+  s.add_dependency("i18n", ">= 0.7.0", "< 1.9")
 
   s.add_development_dependency("rspec_junit_formatter", "~> 0.3")
   s.add_development_dependency("luffa", "~> 2.0")


### PR DESCRIPTION
Hello,
I was trying to use on a local project the functionality of `i18n` gem:
`I18n.config.interpolation_patterns`
But it seemed to not exist :(

I tracked it down to the enforcing of the version `< 1.0` from the `run_loop` gem

I checked the usage of such dependency in this project and it seemed to me that the usage is very basic and a higher version of `i18n` could be used

Hence the PR :),

Maybe I am wrong and/or maybe it could be updated even further maybe `<2.0` ?